### PR TITLE
feat(terminology): clinical term normalization layer (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6627,6 +6627,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminology"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["packages/core-model", "packages/parser", "packages/pipeline", "packages/ocr", "packages/dicom", "packages/share", "apps/cli", "apps/desktop/src-tauri", "apps/mobile/src-tauri"]
+members = ["packages/core-model", "packages/parser", "packages/terminology", "packages/pipeline", "packages/ocr", "packages/dicom", "packages/share", "apps/cli", "apps/desktop/src-tauri", "apps/mobile/src-tauri"]
 
 [workspace.dependencies]
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md
+++ b/docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md
@@ -1,0 +1,140 @@
+# Terminology Normalization Layer — Design (Issue #18)
+
+> **一句话:** 一个明确、可不断扩展、**不运行但不出错**的临床术语归一化映射层。把中文/英文/缩写/OCR 拆字的 raw 术语,映射到内部规范键 + 规范中文名 + 国际编码(LOINC/RxNorm/ATC/OMOP)+ canonical 单位 + 显式换算。
+
+关联:[docs/015_Trends_and_Timelines.md](../../015_Trends_and_Timelines.md) §3(本 spec 是其「归一化词典/抽取」子集的独立落地)。Issue: https://github.com/Chesterguan/medme/issues/18
+
+---
+
+## 1. 范围
+
+**做:** 可复用的映射层 —— 一份版本化静态词典(JSON)+ 一个查表函数 `normalize()` + 测试。
+
+**不做(明确边界):**
+- 不碰 event log / DB schema / observations 表 / pipeline 接入 / UI(那些是 015 后续)。
+- 不写运行时换算/校验代码(此层没有「值」)。**但换算方法必须在数据里写死写对**,任何人照着 `units[]` 就能算,零歧义。
+- `source_document_id / source_location` 不进词典 —— 每次命中由调用方(pipeline)附加。
+
+**为什么现在做:** 标准(编码 + canonical 单位 + 换算)是概念身份,必须第一天立对;词典是 shipped 资源,日后 keyed 数据都跟它走,晚立就得迁移。词汇 mapping 对医生/科研价值大(可比、可互操作),对普通用户价值小 —— 接入流程延后。
+
+**覆盖(V1):** docs/015 §3.5 全清单 —— ~25 化验项 + 4 类生命体征 + ~30 常见慢病药。
+
+## 2. 架构
+
+新建 crate `packages/terminology`(parser 管抽取,terminology 是可复用词典,边界干净)。
+
+```
+packages/terminology/
+  src/lib.rs        // normalize() + 类型 + alias 索引(OnceLock) + 测试
+  dictionary.json   // 版本化静态词典(include_str! 编进二进制)
+```
+
+代码极简,丰富度全在**数据**里 —— 标准数据齐全,代码不膨胀。
+
+## 3. 词典条目 schema
+
+统一条目,`category` 区分 `lab | vital | drug`。
+
+### lab / vital 条目
+```jsonc
+{
+  "key": "creatinine",
+  "canonical_name": "肌酐",
+  "category": "lab",                                  // lab | vital
+  "system": "serum/plasma",                           // LOINC specimen,防 血肌酐/尿肌酐 collapse
+  "codes": { "loinc": "14682-9", "omop_concept_id": 3020564 },
+  "canonical_unit": "umol/L",                          // UCUM 记法
+  "units": [                                           // 显式换算,见 §4
+    { "unit": "umol/L", "slope": 1.0,   "intercept": 0 },
+    { "unit": "mg/dL",  "slope": 88.42, "intercept": 0 }
+  ],
+  "aliases": ["肌酐","血肌酐","血清肌酐","Cr","CREA","CRE","Creatinine","SCr"],
+  "ocr_confusions": ["肌研","肌肝"]                     // 命中→降置信,标可疑
+}
+```
+
+### drug 条目
+```jsonc
+{
+  "key": "metformin",
+  "canonical_name": "二甲双胍",
+  "category": "drug",
+  "ingredient": "Metformin",
+  "codes": { "rxnorm": "6809", "atc": "A10BA02", "omop_concept_id": null },
+  "aliases": ["二甲双胍","盐酸二甲双胍","格华止","美迪康","Metformin","二甲双胍缓释片","甲福明"],
+  "ocr_confusions": []
+}
+```
+药无 `canonical_unit / units / system`(剂量换算是 015 抽取层的事)。
+
+## 4. 换算:显式、不歧义、可扩展
+
+**统一形式**(数据里写死,任何消费者照此计算):
+```
+canonical_value = slope × source_value + intercept
+```
+- 线性(绝大多数):`intercept = 0`。例:肌酐 mg/dL → `slope=88.42, intercept=0`。
+- 仿射:HbA1c IFCC mmol/mol → NGSP % → `slope=0.09148, intercept=2.152`。
+- canonical 单位本身:`slope=1, intercept=0`。
+
+每个 analyte 把**所有可接受源单位**各列一行 `(unit, slope, intercept)`。加单位 = 加一行。
+
+> 关键正确性:只留 `factor` 会把 HbA1c 等仿射换算算错 —— 所以统一用 slope/intercept。
+
+## 5. 编码来源:OMOP vocab(correct-by-construction,不手猜)
+
+本地 OMOP testbed:`postgresql://postgres@localhost:5435/mimiciv_omop`,`SET search_path=omop_cdm`(原生 PG15,无密码,含全 OMOP vocab)。
+
+每个 analyte/drug 从 vocab 查:
+- OMOP standard `concept_id`(`standard_concept='S'`)。
+- **与 canonical 单位一致的** LOINC/RxNorm/ATC 码。
+  - 反例警示:LOINC `2160-0` 是 Creatinine **[Mass/volume]**(→mg/dL);µmol/L(molar)对应 `14682-9`(concept 3020564)。canonical 选 µmol/L 就必须配 molar 码,否则编码/单位打架。
+- UCUM canonical 单位(UCUM 是 OMOP/FHIR 标准单位词表)。
+
+查询范式:
+```sql
+SET search_path=omop_cdm;
+SELECT concept_id, concept_name, concept_code, standard_concept
+FROM concept WHERE vocabulary_id='LOINC' AND concept_code = :code;
+```
+
+## 6. API
+
+```rust
+pub struct Match {
+    pub key: String,               // 内部规范键
+    pub canonical_name: String,    // 规范中文名
+    pub category: Category,        // Lab | Vital | Drug
+    pub codes: Codes,              // loinc / rxnorm / atc / omop_concept_id (各 Option)
+    pub ingredient: Option<String>,// 仅 drug
+    pub matched_alias: String,     // 命中的原别名(可溯源)
+    pub confidence: f32,           // 别名精确命中 1.0;ocr_confusions 命中 0.5
+}
+
+/// 单个候选术语 → 规范映射。无命中返回 None。不做全文扫描(那是抽取层)。
+pub fn normalize(raw_term: &str) -> Option<Match>;
+```
+
+**匹配前归一化**(建索引与查询都过同一函数):小写化 + 全角→半角 + 去内部空白(命中 OCR 拆字「肌 酐」)。加载时用 `OnceLock` 建 `normalized_alias → entry` 索引;`ocr_confusions` 建独立低置信索引。
+
+**信息不丢的四条红线:**
+1. mapping 永远**附加**,绝不替换 raw_term —— 调用方保留原文 + span。
+2. `system` 字段保留标本,serum ≠ urine 不 collapse。
+3. LOINC 选与 canonical 单位一致的 property/scale(§5)。
+4. `codes` 是多码 map,不把多概念塞进一个字段。
+
+## 7. 测试(与代码同 crate)
+
+- 别名精确命中:「谷丙转氨酶 / ALT / GPT / SGPT」→ 同一 `alt`;「肌酐 / 血肌酐 / Cr / SCr」→ `creatinine`。
+- 归一化:全角「ＡＬＴ」、大小写「crea」、OCR 拆字「肌 酐」均命中。
+- `ocr_confusions`(「肌研」)→ 命中但 confidence=0.5。
+- 未命中 → `None`。
+- 换算正确性:肌酐 mg/dL slope=88.42;HbA1c mmol/mol 仿射 slope/intercept 存在且 ≠ 简单 factor。
+- 词典完整性:§3.5 每个清单项都在词典里(防漏);每条 lab/vital 都有 `canonical_unit` 且 `units[]` 含 canonical 自身行(slope=1)。
+- 编码一致性:每条 lab 的 loinc 非空 → canonical_unit 与该 LOINC 的 property 不矛盾(molar↔µmol/mmol,mass↔mg/g)。
+
+## 8. 交付
+
+- 实现由 sonnet/opus subagent 完成;编码/单位在实现时连 OMOP testbed 查全查对。
+- 别名整理是主体工作量:§3.5 每项手工整理(中文全称/简称 + 英文 + 缩写 + OCR 拆字)。
+- 门禁:`cargo fmt` + `clippy` + `test` 全绿(CI 同款)后再交。

--- a/packages/terminology/Cargo.toml
+++ b/packages/terminology/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "terminology"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/packages/terminology/dictionary.json
+++ b/packages/terminology/dictionary.json
@@ -1,0 +1,611 @@
+{
+  "version": "2026-07-10",
+  "note": "Clinical terminology normalization dictionary for MedMe (docs/015 §3.5). Codes pulled from the local OMOP vocab (LOINC / RxNorm / ATC + OMOP standard concept_id). Conversions are affine: canonical_value = slope * source_value + intercept. LOINC property/scale is chosen to agree with canonical_unit (molar LOINC for SI molar canonicals). See docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md.",
+  "entries": [
+    {
+      "key": "creatinine",
+      "canonical_name": "肌酐",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14682-9", "omop_concept_id": 3020564 },
+      "canonical_unit": "umol/L",
+      "units": [
+        { "unit": "umol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 88.42, "intercept": 0.0 }
+      ],
+      "aliases": ["肌酐", "血肌酐", "血清肌酐", "Cr", "CREA", "CRE", "SCr", "Creatinine"],
+      "ocr_confusions": ["肌研", "肌肝", "肌酥"]
+    },
+    {
+      "key": "egfr",
+      "canonical_name": "估算肾小球滤过率",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "33914-3", "omop_concept_id": 3030354 },
+      "canonical_unit": "mL/min/1.73m2",
+      "units": [
+        { "unit": "mL/min/1.73m2", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["估算肾小球滤过率", "肾小球滤过率", "肾小球滤过率估算值", "eGFR", "GFR"],
+      "ocr_confusions": [],
+      "note": "LOINC 33914-3 is the MDRD-formula eGFR; its OMOP concept (3030354) is non-standard (blank standard_concept) — OMOP has no clean standard eGFR measurement concept, so this is the best available and a deliberate deviation from the standard_concept='S' rule."
+    },
+    {
+      "key": "urea",
+      "canonical_name": "尿素",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "22664-7", "omop_concept_id": 3020779 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.357, "intercept": 0.0 }
+      ],
+      "aliases": ["尿素", "尿素氮", "血尿素", "血尿素氮", "Urea", "BUN"],
+      "ocr_confusions": ["尿紊"],
+      "note": "Canonical is molar urea (mmol/L, LOINC 22664-7). The mg/dL row assumes the source is BUN (urea nitrogen, as N): factor 0.357 = 10/28.014. This is correct for US labs reporting BUN in mg/dL (the near-universal mg/dL convention). Do NOT apply it to a value reporting urea mass in mg/dL (MW 60.06 → ×0.1665)."
+    },
+    {
+      "key": "uric_acid",
+      "canonical_name": "尿酸",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14933-6", "omop_concept_id": 3026493 },
+      "canonical_unit": "umol/L",
+      "units": [
+        { "unit": "umol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 59.48, "intercept": 0.0 }
+      ],
+      "aliases": ["尿酸", "血尿酸", "血清尿酸", "UA", "Uric acid", "Urate"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "glucose",
+      "canonical_name": "血糖",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14749-6", "omop_concept_id": 3013826 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.0555, "intercept": 0.0 }
+      ],
+      "aliases": ["空腹血糖", "血糖", "葡萄糖", "血浆葡萄糖", "GLU", "FPG", "FBG", "Glucose"],
+      "ocr_confusions": [],
+      "note": "Generic serum/plasma glucose (LOINC 14749-6, Moles/volume). Fasting-specific aliases (空腹血糖/FPG/FBG) also map here in V1 — the fasting-vs-random distinction is not preserved. If that distinction is needed later, split to fasting LOINC 14771-0 (concept 3018251)."
+    },
+    {
+      "key": "hba1c",
+      "canonical_name": "糖化血红蛋白",
+      "category": "lab",
+      "system": "blood",
+      "codes": { "loinc": "4548-4", "omop_concept_id": 3004410 },
+      "canonical_unit": "%",
+      "units": [
+        { "unit": "%", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mmol/mol", "slope": 0.09148, "intercept": 2.152 }
+      ],
+      "aliases": ["糖化血红蛋白", "糖化血红蛋白A1c", "糖化", "HbA1c", "A1c", "GHb"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "cholesterol",
+      "canonical_name": "总胆固醇",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14647-2", "omop_concept_id": 3019900 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.02586, "intercept": 0.0 }
+      ],
+      "aliases": ["总胆固醇", "胆固醇", "血清总胆固醇", "TC", "CHOL", "TCHO", "Cholesterol"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "ldl",
+      "canonical_name": "低密度脂蛋白胆固醇",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "22748-8", "omop_concept_id": 3001308 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.02586, "intercept": 0.0 }
+      ],
+      "aliases": ["低密度脂蛋白胆固醇", "低密度脂蛋白", "低密度", "LDL", "LDL-C", "LDLC"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "hdl",
+      "canonical_name": "高密度脂蛋白胆固醇",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14646-4", "omop_concept_id": 3023602 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.02586, "intercept": 0.0 }
+      ],
+      "aliases": ["高密度脂蛋白胆固醇", "高密度脂蛋白", "高密度", "HDL", "HDL-C", "HDLC"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "triglycerides",
+      "canonical_name": "甘油三酯",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14927-8", "omop_concept_id": 3025839 },
+      "canonical_unit": "mmol/L",
+      "units": [
+        { "unit": "mmol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 0.01129, "intercept": 0.0 }
+      ],
+      "aliases": ["甘油三酯", "三酰甘油", "甘油三脂", "TG", "TRIG", "Triglyceride", "Triglycerides"],
+      "ocr_confusions": ["甘油三醋"]
+    },
+    {
+      "key": "alt",
+      "canonical_name": "谷丙转氨酶",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "1742-6", "omop_concept_id": 3006923 },
+      "canonical_unit": "U/L",
+      "units": [
+        { "unit": "U/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "IU/L", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["谷丙转氨酶", "丙氨酸氨基转移酶", "丙氨酸转氨酶", "谷丙转胺酶", "ALT", "GPT", "SGPT"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "ast",
+      "canonical_name": "谷草转氨酶",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "1920-8", "omop_concept_id": 3013721 },
+      "canonical_unit": "U/L",
+      "units": [
+        { "unit": "U/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "IU/L", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["谷草转氨酶", "天门冬氨酸氨基转移酶", "天冬氨酸氨基转移酶", "门冬氨酸氨基转移酶", "AST", "GOT", "SGOT"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "tbil",
+      "canonical_name": "总胆红素",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "14631-6", "omop_concept_id": 3006140 },
+      "canonical_unit": "umol/L",
+      "units": [
+        { "unit": "umol/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "mg/dL", "slope": 17.1, "intercept": 0.0 }
+      ],
+      "aliases": ["总胆红素", "血清总胆红素", "TBIL", "T-BIL", "STB", "Bilirubin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "albumin",
+      "canonical_name": "白蛋白",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "1751-7", "omop_concept_id": 3024561 },
+      "canonical_unit": "g/L",
+      "units": [
+        { "unit": "g/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "g/dL", "slope": 10.0, "intercept": 0.0 }
+      ],
+      "aliases": ["白蛋白", "血清白蛋白", "清蛋白", "ALB", "Albumin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "wbc",
+      "canonical_name": "白细胞",
+      "category": "lab",
+      "system": "blood",
+      "codes": { "loinc": "6690-2", "omop_concept_id": 3000905 },
+      "canonical_unit": "10*9/L",
+      "units": [
+        { "unit": "10*9/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "10*3/uL", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["白细胞", "白细胞计数", "白血球", "WBC", "Leukocytes"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "hgb",
+      "canonical_name": "血红蛋白",
+      "category": "lab",
+      "system": "blood",
+      "codes": { "loinc": "718-7", "omop_concept_id": 3000963 },
+      "canonical_unit": "g/L",
+      "units": [
+        { "unit": "g/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "g/dL", "slope": 10.0, "intercept": 0.0 }
+      ],
+      "aliases": ["血红蛋白", "血色素", "血红素", "HGB", "Hb", "Hemoglobin", "Haemoglobin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "plt",
+      "canonical_name": "血小板",
+      "category": "lab",
+      "system": "blood",
+      "codes": { "loinc": "777-3", "omop_concept_id": 3024929 },
+      "canonical_unit": "10*9/L",
+      "units": [
+        { "unit": "10*9/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "10*3/uL", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["血小板", "血小板计数", "PLT", "Platelets", "Platelet"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "neut_pct",
+      "canonical_name": "中性粒细胞百分比",
+      "category": "lab",
+      "system": "blood",
+      "codes": { "loinc": "770-8", "omop_concept_id": 3008342 },
+      "canonical_unit": "%",
+      "units": [
+        { "unit": "%", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["中性粒细胞百分比", "中性粒细胞比率", "中性粒细胞比例", "中性粒百分比", "NEUT%", "N%", "NE%"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "tsh",
+      "canonical_name": "促甲状腺激素",
+      "category": "lab",
+      "system": "serum/plasma",
+      "codes": { "loinc": "3016-3", "omop_concept_id": 3009201 },
+      "canonical_unit": "mIU/L",
+      "units": [
+        { "unit": "mIU/L", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "uIU/mL", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["促甲状腺激素", "促甲状腺素", "甲状腺刺激素", "TSH", "Thyrotropin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "bp_systolic",
+      "canonical_name": "收缩压",
+      "category": "vital",
+      "system": "arterial",
+      "codes": { "loinc": "8480-6", "omop_concept_id": 3004249 },
+      "canonical_unit": "mmHg",
+      "units": [
+        { "unit": "mmHg", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["收缩压", "高压", "SBP", "Systolic", "Systolic blood pressure"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "bp_diastolic",
+      "canonical_name": "舒张压",
+      "category": "vital",
+      "system": "arterial",
+      "codes": { "loinc": "8462-4", "omop_concept_id": 3012888 },
+      "canonical_unit": "mmHg",
+      "units": [
+        { "unit": "mmHg", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["舒张压", "低压", "DBP", "Diastolic", "Diastolic blood pressure"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "heart_rate",
+      "canonical_name": "心率",
+      "category": "vital",
+      "system": "cardiovascular",
+      "codes": { "loinc": "8867-4", "omop_concept_id": 3027018 },
+      "canonical_unit": "/min",
+      "units": [
+        { "unit": "/min", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["心率", "心跳", "脉搏", "HR", "Heart rate", "Pulse"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "body_weight",
+      "canonical_name": "体重",
+      "category": "vital",
+      "system": "whole body",
+      "codes": { "loinc": "29463-7", "omop_concept_id": 3025315 },
+      "canonical_unit": "kg",
+      "units": [
+        { "unit": "kg", "slope": 1.0, "intercept": 0.0 },
+        { "unit": "g", "slope": 0.001, "intercept": 0.0 },
+        { "unit": "[lb_av]", "slope": 0.45359237, "intercept": 0.0 }
+      ],
+      "aliases": ["体重", "BW", "Body weight", "Weight"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "bmi",
+      "canonical_name": "体质指数",
+      "category": "vital",
+      "system": "whole body",
+      "codes": { "loinc": "39156-5", "omop_concept_id": 3038553 },
+      "canonical_unit": "kg/m2",
+      "units": [
+        { "unit": "kg/m2", "slope": 1.0, "intercept": 0.0 }
+      ],
+      "aliases": ["体质指数", "体重指数", "身体质量指数", "BMI", "Body mass index"],
+      "ocr_confusions": []
+    },
+
+    {
+      "key": "metformin",
+      "canonical_name": "二甲双胍",
+      "category": "drug",
+      "ingredient": "Metformin",
+      "codes": { "rxnorm": "6809", "atc": "A10BA02", "omop_concept_id": 1503297 },
+      "aliases": ["二甲双胍", "盐酸二甲双胍", "二甲双胍缓释片", "盐酸二甲双胍缓释片", "格华止", "美迪康", "甲福明", "Metformin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "glimepiride",
+      "canonical_name": "格列美脲",
+      "category": "drug",
+      "ingredient": "Glimepiride",
+      "codes": { "rxnorm": "25789", "atc": "A10BB12", "omop_concept_id": 1597756 },
+      "aliases": ["格列美脲", "亚莫利", "圣平", "迪北", "Glimepiride", "Amaryl"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "gliclazide",
+      "canonical_name": "格列齐特",
+      "category": "drug",
+      "ingredient": "Gliclazide",
+      "codes": { "rxnorm": "4816", "atc": "A10BB09", "omop_concept_id": 19059796 },
+      "aliases": ["格列齐特", "格列齐特缓释片", "达美康", "甲磺吡脲", "Gliclazide"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "acarbose",
+      "canonical_name": "阿卡波糖",
+      "category": "drug",
+      "ingredient": "Acarbose",
+      "codes": { "rxnorm": "16681", "atc": "A10BF01", "omop_concept_id": 1529331 },
+      "aliases": ["阿卡波糖", "拜糖平", "卡博平", "Acarbose"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "empagliflozin",
+      "canonical_name": "恩格列净",
+      "category": "drug",
+      "ingredient": "Empagliflozin",
+      "codes": { "rxnorm": "1545653", "atc": "A10BK03", "omop_concept_id": 45774751 },
+      "aliases": ["恩格列净", "欧唐静", "Empagliflozin", "Jardiance"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "dapagliflozin",
+      "canonical_name": "达格列净",
+      "category": "drug",
+      "ingredient": "Dapagliflozin",
+      "codes": { "rxnorm": "1488564", "atc": "A10BK01", "omop_concept_id": 44785829 },
+      "aliases": ["达格列净", "安达唐", "Dapagliflozin", "Farxiga", "Forxiga"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "sitagliptin",
+      "canonical_name": "西格列汀",
+      "category": "drug",
+      "ingredient": "Sitagliptin",
+      "codes": { "rxnorm": "593411", "atc": "A10BH01", "omop_concept_id": 1580747 },
+      "aliases": ["西格列汀", "磷酸西格列汀", "捷诺维", "Sitagliptin", "Januvia"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "semaglutide",
+      "canonical_name": "司美格鲁肽",
+      "category": "drug",
+      "ingredient": "Semaglutide",
+      "codes": { "rxnorm": "1991302", "atc": "A10BJ06", "omop_concept_id": 793143 },
+      "aliases": ["司美格鲁肽", "诺和泰", "诺和忻", "Semaglutide", "Ozempic", "Wegovy", "Rybelsus"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "insulin_glargine",
+      "canonical_name": "甘精胰岛素",
+      "category": "drug",
+      "ingredient": "Insulin glargine",
+      "codes": { "rxnorm": "274783", "atc": "A10AE04", "omop_concept_id": 1502905 },
+      "aliases": ["甘精胰岛素", "来得时", "长秀霖", "Insulin glargine", "Lantus", "Glargine"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "insulin_aspart",
+      "canonical_name": "门冬胰岛素",
+      "category": "drug",
+      "ingredient": "Insulin aspart",
+      "codes": { "rxnorm": "51428", "atc": "A10AB05", "omop_concept_id": 1567198 },
+      "aliases": ["门冬胰岛素", "诺和锐", "Insulin aspart", "NovoRapid", "NovoLog", "Aspart"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "valsartan",
+      "canonical_name": "缬沙坦",
+      "category": "drug",
+      "ingredient": "Valsartan",
+      "codes": { "rxnorm": "69749", "atc": "C09CA03", "omop_concept_id": 1308842 },
+      "aliases": ["缬沙坦", "代文", "缬克", "Valsartan"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "losartan",
+      "canonical_name": "氯沙坦",
+      "category": "drug",
+      "ingredient": "Losartan",
+      "codes": { "rxnorm": "52175", "atc": "C09CA01", "omop_concept_id": 1367500 },
+      "aliases": ["氯沙坦", "氯沙坦钾", "科素亚", "Losartan"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "irbesartan",
+      "canonical_name": "厄贝沙坦",
+      "category": "drug",
+      "ingredient": "Irbesartan",
+      "codes": { "rxnorm": "83818", "atc": "C09CA04", "omop_concept_id": 1347384 },
+      "aliases": ["厄贝沙坦", "伊贝沙坦", "安博维", "Irbesartan"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "amlodipine",
+      "canonical_name": "氨氯地平",
+      "category": "drug",
+      "ingredient": "Amlodipine",
+      "codes": { "rxnorm": "17767", "atc": "C08CA01", "omop_concept_id": 1332418 },
+      "aliases": ["氨氯地平", "苯磺酸氨氯地平", "氨氯地平片", "络活喜", "压氏达", "安内真", "Amlodipine"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "nifedipine",
+      "canonical_name": "硝苯地平",
+      "category": "drug",
+      "ingredient": "Nifedipine",
+      "codes": { "rxnorm": "7417", "atc": "C08CA05", "omop_concept_id": 1318853 },
+      "aliases": ["硝苯地平", "硝苯地平控释片", "硝苯吡啶", "拜新同", "心痛定", "Nifedipine"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "metoprolol",
+      "canonical_name": "美托洛尔",
+      "category": "drug",
+      "ingredient": "Metoprolol",
+      "codes": { "rxnorm": "6918", "atc": "C07AB02", "omop_concept_id": 1307046 },
+      "aliases": ["美托洛尔", "酒石酸美托洛尔", "琥珀酸美托洛尔", "倍他乐克", "美多心安", "Metoprolol"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "hydrochlorothiazide",
+      "canonical_name": "氢氯噻嗪",
+      "category": "drug",
+      "ingredient": "Hydrochlorothiazide",
+      "codes": { "rxnorm": "5487", "atc": "C03AA03", "omop_concept_id": 974166 },
+      "aliases": ["氢氯噻嗪", "双氢克尿噻", "双氢氯噻嗪", "HCTZ", "Hydrochlorothiazide"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "perindopril",
+      "canonical_name": "培哚普利",
+      "category": "drug",
+      "ingredient": "Perindopril",
+      "codes": { "rxnorm": "54552", "atc": "C09AA04", "omop_concept_id": 1373225 },
+      "aliases": ["培哚普利", "培哚普利叔丁胺", "培哚普利氨丁三醇", "雅施达", "Perindopril"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "atorvastatin",
+      "canonical_name": "阿托伐他汀",
+      "category": "drug",
+      "ingredient": "Atorvastatin",
+      "codes": { "rxnorm": "83367", "atc": "C10AA05", "omop_concept_id": 1545958 },
+      "aliases": ["阿托伐他汀", "阿托伐他汀钙", "立普妥", "阿乐", "尤佳", "Atorvastatin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "rosuvastatin",
+      "canonical_name": "瑞舒伐他汀",
+      "category": "drug",
+      "ingredient": "Rosuvastatin",
+      "codes": { "rxnorm": "301542", "atc": "C10AA07", "omop_concept_id": 1510813 },
+      "aliases": ["瑞舒伐他汀", "瑞舒伐他汀钙", "可定", "托妥", "Rosuvastatin", "Crestor"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "simvastatin",
+      "canonical_name": "辛伐他汀",
+      "category": "drug",
+      "ingredient": "Simvastatin",
+      "codes": { "rxnorm": "36567", "atc": "C10AA01", "omop_concept_id": 1539403 },
+      "aliases": ["辛伐他汀", "舒降之", "京必舒新", "Simvastatin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "ezetimibe",
+      "canonical_name": "依折麦布",
+      "category": "drug",
+      "ingredient": "Ezetimibe",
+      "codes": { "rxnorm": "341248", "atc": "C10AX09", "omop_concept_id": 1526475 },
+      "aliases": ["依折麦布", "益适纯", "Ezetimibe", "Zetia"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "aspirin",
+      "canonical_name": "阿司匹林",
+      "category": "drug",
+      "ingredient": "Aspirin",
+      "codes": { "rxnorm": "1191", "atc": "B01AC06", "omop_concept_id": 1112807 },
+      "aliases": ["阿司匹林", "乙酰水杨酸", "阿斯匹林", "拜阿司匹林", "阿司匹林肠溶片", "Aspirin", "ASA"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "clopidogrel",
+      "canonical_name": "氯吡格雷",
+      "category": "drug",
+      "ingredient": "Clopidogrel",
+      "codes": { "rxnorm": "32968", "atc": "B01AC04", "omop_concept_id": 1322184 },
+      "aliases": ["氯吡格雷", "硫酸氢氯吡格雷", "波立维", "泰嘉", "Clopidogrel", "Plavix"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "warfarin",
+      "canonical_name": "华法林",
+      "category": "drug",
+      "ingredient": "Warfarin",
+      "codes": { "rxnorm": "11289", "atc": "B01AA03", "omop_concept_id": 1310149 },
+      "aliases": ["华法林", "华法林钠", "华法令", "苄丙酮香豆素钠", "Warfarin"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "rivaroxaban",
+      "canonical_name": "利伐沙班",
+      "category": "drug",
+      "ingredient": "Rivaroxaban",
+      "codes": { "rxnorm": "1114195", "atc": "B01AF01", "omop_concept_id": 40241331 },
+      "aliases": ["利伐沙班", "拜瑞妥", "Rivaroxaban", "Xarelto"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "allopurinol",
+      "canonical_name": "别嘌醇",
+      "category": "drug",
+      "ingredient": "Allopurinol",
+      "codes": { "rxnorm": "519", "atc": "M04AA01", "omop_concept_id": 1167322 },
+      "aliases": ["别嘌醇", "别嘌呤醇", "别嘌呤", "Allopurinol"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "febuxostat",
+      "canonical_name": "非布司他",
+      "category": "drug",
+      "ingredient": "Febuxostat",
+      "codes": { "rxnorm": "73689", "atc": "M04AA03", "omop_concept_id": 19017742 },
+      "aliases": ["非布司他", "非布索坦", "优立通", "Febuxostat", "Uloric"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "levothyroxine",
+      "canonical_name": "左甲状腺素",
+      "category": "drug",
+      "ingredient": "Levothyroxine",
+      "codes": { "rxnorm": "10582", "atc": "H03AA01", "omop_concept_id": 1501700 },
+      "aliases": ["左甲状腺素", "左甲状腺素钠", "优甲乐", "加衡", "雷替斯", "Levothyroxine", "L-T4"],
+      "ocr_confusions": []
+    },
+    {
+      "key": "pantoprazole",
+      "canonical_name": "泮托拉唑",
+      "category": "drug",
+      "ingredient": "Pantoprazole",
+      "codes": { "rxnorm": "40790", "atc": "A02BC02", "omop_concept_id": 948078 },
+      "aliases": ["泮托拉唑", "泮托拉唑钠", "潘妥拉唑", "泰美尼克", "韦迪", "Pantoprazole"],
+      "ocr_confusions": []
+    }
+  ]
+}

--- a/packages/terminology/src/lib.rs
+++ b/packages/terminology/src/lib.rs
@@ -1,0 +1,517 @@
+//! Clinical terminology normalization layer.
+//!
+//! A static, versioned dictionary (`dictionary.json`, compiled in via
+//! `include_str!`) plus a single lookup function [`normalize`]. It maps a raw
+//! Chinese/English/abbreviation/OCR-split term to an internal canonical key +
+//! canonical Chinese name + international codes (LOINC / RxNorm / ATC + OMOP
+//! standard concept_id) + canonical unit + explicit unit conversions.
+//!
+//! This layer has no runtime "value": it does not perform conversions itself.
+//! Instead each accepted source unit carries an affine conversion written into
+//! the data, so any consumer can compute with zero ambiguity:
+//!
+//! ```text
+//! canonical_value = slope * source_value + intercept
+//! ```
+//!
+//! Design: `docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md`.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// The compiled-in dictionary. A parse failure here is a build-time bug in the
+/// shipped resource, not a runtime condition — see [`index`].
+const DICTIONARY_JSON: &str = include_str!("../dictionary.json");
+
+/// What kind of clinical concept an entry describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Category {
+    Lab,
+    Vital,
+    Drug,
+}
+
+/// International codes for a concept. Each is a separate slot — multiple coding
+/// systems are never collapsed into one field (design §6 red line 4). Absent
+/// codes are `None`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Codes {
+    #[serde(default)]
+    pub loinc: Option<String>,
+    #[serde(default)]
+    pub rxnorm: Option<String>,
+    #[serde(default)]
+    pub atc: Option<String>,
+    #[serde(default)]
+    pub omop_concept_id: Option<i64>,
+}
+
+/// One accepted source unit and its affine conversion to the entry's
+/// `canonical_unit`: `canonical_value = slope * source_value + intercept`.
+/// The canonical unit itself is the row `slope = 1, intercept = 0`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UnitConversion {
+    /// UCUM unit notation, e.g. `umol/L`, `mg/dL`, `10*9/L`, `mmol/mol`.
+    pub unit: String,
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// A single dictionary entry (lab / vital / drug). Lab and vital entries carry
+/// `system` / `canonical_unit` / `units`; drug entries carry `ingredient`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Entry {
+    /// Internal canonical key, e.g. `creatinine`, `metformin`.
+    pub key: String,
+    /// Canonical Chinese display name.
+    pub canonical_name: String,
+    pub category: Category,
+    /// LOINC specimen, e.g. `serum/plasma` — keeps serum ≠ urine from
+    /// collapsing (design §6 red line 2). `None` for drugs.
+    #[serde(default)]
+    pub system: Option<String>,
+    pub codes: Codes,
+    /// Canonical unit (UCUM). `None` for drugs.
+    #[serde(default)]
+    pub canonical_unit: Option<String>,
+    /// Explicit conversions; empty for drugs.
+    #[serde(default)]
+    pub units: Vec<UnitConversion>,
+    /// Active ingredient (English); `Some` only for drugs.
+    #[serde(default)]
+    pub ingredient: Option<String>,
+    /// Exact aliases — a normalized hit yields confidence 1.0.
+    pub aliases: Vec<String>,
+    /// Known OCR misreads — a normalized hit yields confidence 0.5 (suspect,
+    /// routed to human review rather than trusted).
+    #[serde(default)]
+    pub ocr_confusions: Vec<String>,
+    /// Human-readable caveat about this entry's coding/conversion choices, e.g.
+    /// a deliberate non-standard concept or a source-unit assumption.
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+/// Top-level dictionary document.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Dictionary {
+    pub version: String,
+    pub entries: Vec<Entry>,
+}
+
+/// A successful normalization. Mapping is always *additive*: the caller keeps
+/// the original raw term + span; this only annotates it (design §6 red line 1).
+#[derive(Debug, Clone)]
+pub struct Match {
+    pub key: String,
+    pub canonical_name: String,
+    pub category: Category,
+    pub codes: Codes,
+    /// Active ingredient (drugs only).
+    pub ingredient: Option<String>,
+    /// The dictionary alias that matched (traceable back to the data).
+    pub matched_alias: String,
+    /// 1.0 for an exact alias hit, 0.5 for an OCR-confusion hit.
+    pub confidence: f32,
+}
+
+/// A resolved alias: which entry it belongs to and the original alias text.
+struct AliasHit {
+    entry_idx: usize,
+    alias: String,
+}
+
+/// Lazily-built lookup index over the dictionary.
+struct Index {
+    entries: Vec<Entry>,
+    /// normalized alias -> hit (confidence 1.0).
+    aliases: HashMap<String, AliasHit>,
+    /// normalized ocr_confusion -> hit (confidence 0.5).
+    confusions: HashMap<String, AliasHit>,
+}
+
+/// Normalization applied to BOTH index keys and query terms so lookups are
+/// insensitive to case, full-width forms, and internal whitespace (OCR often
+/// splits CJK, e.g. `肌 酐` -> `肌酐`). This is the single shared helper the
+/// design mandates.
+fn normalize_term(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        let ch = to_halfwidth(ch);
+        if ch.is_whitespace() {
+            continue;
+        }
+        for lc in ch.to_lowercase() {
+            out.push(lc);
+        }
+    }
+    out
+}
+
+/// Map a full-width character to its ASCII half-width equivalent. The
+/// ideographic space (U+3000) folds to a normal space (then stripped by
+/// `normalize_term`); full-width `!`..`~` (U+FF01..U+FF5E) map to ASCII
+/// 0x21..0x7E. All other characters pass through unchanged.
+fn to_halfwidth(c: char) -> char {
+    match c {
+        '\u{3000}' => ' ',
+        '\u{FF01}'..='\u{FF5E}' => char::from_u32(c as u32 - 0xFEE0).unwrap_or(c),
+        _ => c,
+    }
+}
+
+/// Parse the compiled-in dictionary and build the alias/confusion indexes.
+///
+/// Invariant: `dictionary.json` is a shipped, version-controlled resource that
+/// is validated by this crate's tests (including `parse_dictionary` and
+/// `no_duplicate_alias_across_entries`). A parse failure or duplicate alias is
+/// therefore a build-time bug, so `expect` documents that invariant rather than
+/// propagating an error that no runtime caller could act on.
+fn build_index() -> Index {
+    let dict: Dictionary = serde_json::from_str(DICTIONARY_JSON)
+        .expect("dictionary.json is a valid, shipped resource");
+
+    let mut aliases: HashMap<String, AliasHit> = HashMap::new();
+    let mut confusions: HashMap<String, AliasHit> = HashMap::new();
+
+    for (entry_idx, entry) in dict.entries.iter().enumerate() {
+        for alias in &entry.aliases {
+            let norm = normalize_term(alias);
+            aliases.insert(
+                norm,
+                AliasHit {
+                    entry_idx,
+                    alias: alias.clone(),
+                },
+            );
+        }
+        for confusion in &entry.ocr_confusions {
+            let norm = normalize_term(confusion);
+            confusions.insert(
+                norm,
+                AliasHit {
+                    entry_idx,
+                    alias: confusion.clone(),
+                },
+            );
+        }
+    }
+
+    Index {
+        entries: dict.entries,
+        aliases,
+        confusions,
+    }
+}
+
+fn index() -> &'static Index {
+    static INDEX: OnceLock<Index> = OnceLock::new();
+    INDEX.get_or_init(build_index)
+}
+
+impl Index {
+    fn to_match(&self, hit: &AliasHit, confidence: f32) -> Match {
+        let e = &self.entries[hit.entry_idx];
+        Match {
+            key: e.key.clone(),
+            canonical_name: e.canonical_name.clone(),
+            category: e.category,
+            codes: e.codes.clone(),
+            ingredient: e.ingredient.clone(),
+            matched_alias: hit.alias.clone(),
+            confidence,
+        }
+    }
+}
+
+/// Map a single candidate term to its canonical concept. Returns `None` on no
+/// hit. This is a lookup, not a full-text scan — locating terms in free text is
+/// the extraction layer's job (design §6).
+///
+/// An exact (normalized) alias hit yields `confidence == 1.0`; an
+/// `ocr_confusions` hit yields `confidence == 0.5`.
+pub fn normalize(raw_term: &str) -> Option<Match> {
+    let norm = normalize_term(raw_term);
+    if norm.is_empty() {
+        return None;
+    }
+    let idx = index();
+    if let Some(hit) = idx.aliases.get(&norm) {
+        return Some(idx.to_match(hit, 1.0));
+    }
+    if let Some(hit) = idx.confusions.get(&norm) {
+        return Some(idx.to_match(hit, 0.5));
+    }
+    None
+}
+
+/// Read-only access to the parsed dictionary (entries), for consumers that need
+/// to enumerate concepts (e.g. entity search auto-complete).
+pub fn dictionary_entries() -> &'static [Entry] {
+    &index().entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every analyte/vital/drug key required by docs/015 §3.5. The dictionary
+    /// may add siblings, but must never drop one of these.
+    const REQUIRED_KEYS: &[&str] = &[
+        // labs: renal, glucose, lipids, liver, CBC, thyroid
+        "creatinine",
+        "egfr",
+        "urea",
+        "uric_acid",
+        "glucose",
+        "hba1c",
+        "cholesterol",
+        "ldl",
+        "hdl",
+        "triglycerides",
+        "alt",
+        "ast",
+        "tbil",
+        "albumin",
+        "wbc",
+        "hgb",
+        "plt",
+        "neut_pct",
+        "tsh",
+        // vitals
+        "bp_systolic",
+        "bp_diastolic",
+        "heart_rate",
+        "body_weight",
+        "bmi",
+        // drugs named in §3.5
+        "metformin",
+        "glimepiride",
+        "acarbose",
+        "empagliflozin",
+        "semaglutide",
+        "insulin_glargine",
+        "insulin_aspart",
+        "valsartan",
+        "amlodipine",
+        "metoprolol",
+        "hydrochlorothiazide",
+        "perindopril",
+        "atorvastatin",
+        "rosuvastatin",
+        "ezetimibe",
+        "aspirin",
+        "clopidogrel",
+        "warfarin",
+        "rivaroxaban",
+        "allopurinol",
+        "levothyroxine",
+        "pantoprazole",
+    ];
+
+    #[test]
+    fn parse_dictionary() {
+        let dict: Dictionary = serde_json::from_str(DICTIONARY_JSON).expect("valid dictionary");
+        assert!(!dict.version.is_empty());
+        assert!(dict.entries.len() >= 50, "unexpectedly few entries");
+    }
+
+    #[test]
+    fn alias_hits_map_to_same_key() {
+        // 谷丙转氨酶 / ALT / GPT / SGPT -> alt
+        for t in ["谷丙转氨酶", "ALT", "GPT", "SGPT"] {
+            let m = normalize(t).unwrap_or_else(|| panic!("no match for {t}"));
+            assert_eq!(m.key, "alt", "term {t}");
+            assert_eq!(m.confidence, 1.0);
+            assert_eq!(m.category, Category::Lab);
+        }
+        // 肌酐 / 血肌酐 / Cr / SCr -> creatinine
+        for t in ["肌酐", "血肌酐", "Cr", "SCr"] {
+            let m = normalize(t).unwrap_or_else(|| panic!("no match for {t}"));
+            assert_eq!(m.key, "creatinine", "term {t}");
+            assert_eq!(m.confidence, 1.0);
+        }
+    }
+
+    #[test]
+    fn normalization_case_fullwidth_and_split() {
+        // full-width ＡＬＴ -> alt
+        assert_eq!(normalize("ＡＬＴ").unwrap().key, "alt");
+        // lowercase crea -> creatinine
+        assert_eq!(normalize("crea").unwrap().key, "creatinine");
+        // OCR-split 肌 酐 (internal space stripped) -> creatinine
+        assert_eq!(normalize("肌 酐").unwrap().key, "creatinine");
+        // full-width ideographic space also stripped
+        assert_eq!(normalize("肌\u{3000}酐").unwrap().key, "creatinine");
+    }
+
+    #[test]
+    fn ocr_confusion_hits_are_low_confidence() {
+        let m = normalize("肌研").expect("ocr confusion should match");
+        assert_eq!(m.key, "creatinine");
+        assert_eq!(m.confidence, 0.5);
+        assert_eq!(m.matched_alias, "肌研");
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        assert!(normalize("完全不是术语").is_none());
+        assert!(normalize("").is_none());
+        assert!(normalize("   ").is_none());
+    }
+
+    #[test]
+    fn matched_alias_is_the_dictionary_form() {
+        // Query normalization must not leak into matched_alias: it reports the
+        // dictionary's original alias, for traceability.
+        let m = normalize("creatinine").unwrap();
+        assert_eq!(m.matched_alias, "Creatinine");
+    }
+
+    #[test]
+    fn drug_carries_ingredient_and_codes() {
+        let m = normalize("格华止").unwrap();
+        assert_eq!(m.key, "metformin");
+        assert_eq!(m.category, Category::Drug);
+        assert_eq!(m.ingredient.as_deref(), Some("Metformin"));
+        assert_eq!(m.codes.rxnorm.as_deref(), Some("6809"));
+        assert_eq!(m.codes.atc.as_deref(), Some("A10BA02"));
+        assert_eq!(m.codes.omop_concept_id, Some(1503297));
+        // drugs have no LOINC / canonical unit
+        assert!(m.codes.loinc.is_none());
+    }
+
+    fn entry_for(key: &str) -> &'static Entry {
+        dictionary_entries()
+            .iter()
+            .find(|e| e.key == key)
+            .unwrap_or_else(|| panic!("missing entry {key}"))
+    }
+
+    #[test]
+    fn creatinine_conversion_is_correct() {
+        let e = entry_for("creatinine");
+        assert_eq!(e.canonical_unit.as_deref(), Some("umol/L"));
+        // canonical row is identity
+        let canonical = e.units.iter().find(|u| u.unit == "umol/L").unwrap();
+        assert_eq!(canonical.slope, 1.0);
+        assert_eq!(canonical.intercept, 0.0);
+        // mg/dL -> umol/L is the molar factor 88.42 (linear, intercept 0)
+        let mgdl = e.units.iter().find(|u| u.unit == "mg/dL").unwrap();
+        assert_eq!(mgdl.slope, 88.42);
+        assert_eq!(mgdl.intercept, 0.0);
+    }
+
+    #[test]
+    fn hba1c_conversion_is_affine_not_a_plain_factor() {
+        let e = entry_for("hba1c");
+        assert_eq!(e.canonical_unit.as_deref(), Some("%"));
+        // IFCC mmol/mol -> NGSP %: NGSP% = 0.09148 * IFCC + 2.152 (AFFINE).
+        // A plain factor (intercept 0) would be clinically wrong.
+        let ifcc = e.units.iter().find(|u| u.unit == "mmol/mol").unwrap();
+        assert_eq!(ifcc.slope, 0.09148);
+        assert_eq!(ifcc.intercept, 2.152);
+        assert!(
+            ifcc.intercept != 0.0,
+            "HbA1c IFCC->NGSP must be affine, not a plain factor"
+        );
+        // Spot-check the value: IFCC 53 mmol/mol ~= NGSP 7.0 %.
+        let ngsp = ifcc.slope * 53.0 + ifcc.intercept;
+        assert!((ngsp - 7.0).abs() < 0.05, "got {ngsp}");
+    }
+
+    #[test]
+    fn completeness_all_required_items_present() {
+        let keys: std::collections::HashSet<&str> = dictionary_entries()
+            .iter()
+            .map(|e| e.key.as_str())
+            .collect();
+        for req in REQUIRED_KEYS {
+            assert!(keys.contains(req), "docs/015 §3.5 item missing: {req}");
+        }
+    }
+
+    #[test]
+    fn labs_and_vitals_have_canonical_unit_and_identity_row() {
+        for e in dictionary_entries() {
+            match e.category {
+                Category::Lab | Category::Vital => {
+                    let cu = e
+                        .canonical_unit
+                        .as_deref()
+                        .unwrap_or_else(|| panic!("{} missing canonical_unit", e.key));
+                    // there must be a units[] row for the canonical unit itself,
+                    // and it must be the identity (slope 1, intercept 0)
+                    let row =
+                        e.units.iter().find(|u| u.unit == cu).unwrap_or_else(|| {
+                            panic!("{} has no units row for canonical {cu}", e.key)
+                        });
+                    assert_eq!(row.slope, 1.0, "{} canonical row slope", e.key);
+                    assert_eq!(row.intercept, 0.0, "{} canonical row intercept", e.key);
+                }
+                Category::Drug => {
+                    // drugs carry no unit machinery, but must carry an ingredient
+                    assert!(e.ingredient.is_some(), "{} drug missing ingredient", e.key);
+                    assert!(
+                        e.canonical_unit.is_none(),
+                        "{} drug has canonical_unit",
+                        e.key
+                    );
+                    assert!(e.units.is_empty(), "{} drug has units", e.key);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn loinc_property_agrees_with_canonical_unit() {
+        // Design §5/§7: a lab's LOINC property/scale must not contradict its
+        // canonical unit. Enforce the molar<->µmol/mmol and mass<->mg/g rule for
+        // every entry whose canonical unit implies a substance-concentration
+        // property, by asserting our deliberate molar-LOINC choices.
+        let molar: &[(&str, &str, &str)] = &[
+            ("creatinine", "14682-9", "umol/L"),
+            ("urea", "22664-7", "mmol/L"),
+            ("uric_acid", "14933-6", "umol/L"),
+            ("glucose", "14749-6", "mmol/L"),
+            ("cholesterol", "14647-2", "mmol/L"),
+            ("ldl", "22748-8", "mmol/L"),
+            ("hdl", "14646-4", "mmol/L"),
+            ("triglycerides", "14927-8", "mmol/L"),
+            ("tbil", "14631-6", "umol/L"),
+        ];
+        for (key, loinc, unit) in molar {
+            let e = entry_for(key);
+            assert_eq!(e.codes.loinc.as_deref(), Some(*loinc), "{key} loinc");
+            assert_eq!(e.canonical_unit.as_deref(), Some(*unit), "{key} unit");
+            // molar canonical must be a mole-based concentration
+            assert!(
+                unit.starts_with("umol") || unit.starts_with("mmol"),
+                "{key} canonical unit not molar"
+            );
+        }
+    }
+
+    #[test]
+    fn no_duplicate_alias_across_entries() {
+        // Fail loudly rather than silently shadow: no normalized alias may be
+        // claimed by two different entries (design §6 / §7). Also guards
+        // ocr_confusions from colliding with aliases.
+        let mut seen: HashMap<String, String> = HashMap::new();
+        for e in dictionary_entries() {
+            for a in e.aliases.iter().chain(e.ocr_confusions.iter()) {
+                let norm = normalize_term(a);
+                if let Some(prev) = seen.get(&norm) {
+                    assert_eq!(
+                        prev, &e.key,
+                        "duplicate normalized alias {norm:?} in entries {prev} and {}",
+                        e.key
+                    );
+                }
+                seen.insert(norm, e.key.clone());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements the lightweight clinical terminology normalization layer from #18 — the reusable **mapping layer only** (dictionary + lookup + tests). No pipeline/DB/UI wiring; that stays with the docs/015 trends work.

## What
New crate `packages/terminology`:
- `dictionary.json` — versioned static dictionary, **54 entries** (19 labs + 5 vitals + 30 drugs), covering docs/015 §3.5.
- `normalize(raw_term) -> Option<Match>` — folds full-width→half-width, case, and internal whitespace (matches OCR-split「肌 酐」). Alias hit → confidence 1.0; known OCR-confusion hit → 0.5; miss → `None`. Mapping is **additive** — raw term is never replaced.

## Correctness ("不能出错")
- Codes pulled from the local OMOP vocab (LOINC / RxNorm / ATC + OMOP standard `concept_id`), **not** hand-guessed.
- LOINC property/scale matched to each canonical unit (molar LOINC for SI molar canonicals — e.g. creatinine `14682-9` µmol/L, not the mass `2160-0`).
- Explicit conversions as `canonical = slope×value + intercept` (linear + the HbA1c NGSP↔IFCC **affine**). No runtime conversion code — the data alone is unambiguous.
- Independently reviewed against OMOP vocab (every code + factor re-verified). Two findings fixed pre-merge: glucose fasting-LOINC → generic `14749-6`; urea `mg/dL`=BUN-as-N documented. `note` field records deliberate deviations (egfr non-standard MDRD concept, urea BUN assumption).

## Deferred (by design)
Runtime conversion/validation code, `plausible_range` safety valve, drug dose fields, full-text scan, pipeline/DB/UI wiring, OTA dictionary updates — all belong to the 015 extraction/trends layer. `source_document_id/location` are attached by the caller.

## Tests / gates
`cargo fmt` clean · `cargo clippy -p terminology -- -D warnings` no warnings · `cargo test -p terminology` 13/13 pass.

Spec: `docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md`

Closes #18