### PR TITLE
chore(security): add CodeQL + OpenSSF Scorecard CI + badges

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          language: ${{ matrix.language }}
+          languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# Static analysis (SAST) of the frontend. Findings land in the repo's
+# Security → Code scanning tab; this workflow does NOT fail PRs on findings.
+# Rust security is already covered by the `cargo audit` + `clippy` gate in
+# ci.yml, so CodeQL only analyzes JS/TS here (reliable, no build step). To add
+# Rust CodeQL later, append `rust` to the matrix and give it a build step.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1" # weekly, Monday 03:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: Scorecard
+
+# OpenSSF Scorecard: scores the repo's supply-chain / security practices
+# (branch protection, pinned deps, dangerous workflow patterns, signed
+# releases, etc.). Results publish to the Security tab and to the public
+# OpenSSF API that backs the README badge. It does NOT fail the build.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "19 4 * * 1" # weekly, Monday 04:19 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true # required for the public badge
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/Chesterguan/medme/actions/workflows/ci.yml/badge.svg)](https://github.com/Chesterguan/medme/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/Chesterguan/medme/actions/workflows/codeql.yml/badge.svg)](https://github.com/Chesterguan/medme/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Chesterguan/medme/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Chesterguan/medme)
 [![Platform](https://img.shields.io/badge/desktop-macOS-lightgrey.svg)](https://chesterguan.github.io/medme/)
 [![Made with Tauri + Rust](https://img.shields.io/badge/built_with-Tauri_v2_%C2%B7_Rust_%C2%B7_React-orange.svg)](#技术架构--architecture)
 

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
@@ -30,7 +30,7 @@
 	<string>MedMe 需要访问相册,以便你选择医疗单据图片存入健康档案。</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
-		<key>iCloud.49G34P23QP.com.medme.mobile</key>
+		<key>iCloud.com.medme.mobile</key>
 		<dict>
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
 			<true/>

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
@@ -15,11 +15,11 @@
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Free, low-noise automated security tooling. **Neither fails PRs** — findings land in the Security tab / OpenSSF API.

## Added
- **CodeQL** (`.github/workflows/codeql.yml`): `javascript-typescript` only — the frontend XSS surface. Reliable, no build step. Rust security is already covered by the existing `cargo audit` + `clippy` gate in `ci.yml`, so no flaky CodeQL-Rust build is added (can append `rust` to the matrix later with a build step).
- **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`): scores supply-chain/security practices (branch protection, pinned deps, dangerous-workflow patterns, signed releases) weekly + on push to main; publishes to the Security tab and the public OpenSSF API that backs the badge.
- **README badges**: CodeQL + OpenSSF Scorecard.

## Notes
- Dependabot is already configured (cargo + npm + actions, grouped weekly) — left as is.
- To turn on CodeQL results, no repo setting change is needed for a public repo; the first run populates Security → Code scanning.
- The Scorecard badge goes live after the first scheduled/push run publishes results.
- Honest-badging: these are automated scanners, not a third-party audit — do not label the project "independently audited" on their basis.