### PR TITLE
fix(mobile): 设置页可滚动 + adaptive 视口

### DIFF
--- a/apps/mobile/src/App.css
+++ b/apps/mobile/src/App.css
@@ -16,7 +16,8 @@
 }
 
 .app {
-  height: 100vh;
+  height: 100vh; /* fallback */
+  height: 100dvh; /* iOS 动态视口:排除地址栏/工具条,底部 tab 不被顶出屏外 */
   display: flex;
   flex-direction: column;
   background: var(--screen);
@@ -45,8 +46,9 @@
 
 /* Scroll body */
 .body {
-  flex: 1 1 auto; overflow-y: auto; -webkit-overflow-scrolling: touch;
-  padding: 16px; display: flex; flex-direction: column; gap: 14px;
+  /* min-height:0 让 flex 列子项能收缩并真正滚动(否则内容一多撑高 .app、overflow 失效、底部被挡) */
+  flex: 1 1 auto; min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch;
+  padding: 16px 16px calc(16px + env(safe-area-inset-bottom)); display: flex; flex-direction: column; gap: 14px;
 }
 .sect { font-size: 13px; color: var(--faint); font-weight: 700; letter-spacing: .04em; margin: 4px 0 -4px; }
 


### PR DESCRIPTION
Closes #29

## 问题
iOS 上设置页内容超出一屏时**无法滚动**,底部内容被挡(「同步与备份」「关于」等看不全)。

## 根因
`.body` 是 flex 列子项但缺 `min-height:0` —— flex 子项默认 `min-height:auto` 不肯收缩到内容以下,内容一多就撑高 `.app`、把底部 tab 顶出屏外,`overflow-y:auto` 也就失效。叠加 `.app` 用 `100vh`(iOS 上不等于可视高度)。

## 改动(仅 CSS)
- `.body` 加 `min-height:0` —— flex 列子项能收缩并真正滚动。
- `.app` 用 `100dvh`(动态视口,排除地址栏/工具条),保留 `100vh` 作旧浏览器回退。
- `.body` 底部 padding 加 `env(safe-area-inset-bottom)`,最后一项不贴底。