### PR TITLE
fix(ios): 标准化 iCloud 容器 id(去掉 team 前缀)

### DIFF
--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
@@ -30,7 +30,7 @@
 	<string>MedMe 需要访问相册,以便你选择医疗单据图片存入健康档案。</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
-		<key>iCloud.49G34P23QP.com.medme.mobile</key>
+		<key>iCloud.com.medme.mobile</key>
 		<dict>
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
 			<true/>

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/medme-mobile_iOS.entitlements
@@ -15,11 +15,11 @@
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
-		<string>iCloud.49G34P23QP.com.medme.mobile</string>
+		<string>iCloud.com.medme.mobile</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 问题
entitlements / Info.plist 里 iCloud 容器 id 写成了 `iCloud.49G34P23QP.com.medme.mobile`(带 team id),是非标准写法,与后台创建的标准容器对不上,签名/公证会报"profile 不含此容器"。

## 改动
统一为标准 `iCloud.com.medme.mobile`(容器 id 不含 team id;team id 只出现在磁盘 ubiquity 路径里)。已用此配置成功签名 + 公证 + 上传 1.0.2 TestFlight 验证。