### PR TITLE
feat(mobile): 关闭 iCloud 同步(搬回本机,保留 iCloud 副本)

### DIFF
--- a/apps/mobile/src-tauri/src/commands.rs
+++ b/apps/mobile/src-tauri/src/commands.rs
@@ -593,6 +593,52 @@ pub fn enable_icloud_sync(state: State<AppState>) -> Result<bool, String> {
     }
 }
 
+/// 关闭 iCloud 同步(仅 iOS)。把保险箱「真相」从 iCloud 容器**复制**回本机沙盒
+/// (`<Documents>/vault` 重新成为真相),**iCloud 容器里的副本保留不动** —— 其它
+/// 苹果设备若仍开着同步不受影响,也留一份云端备份;用 `copy_to`(只复制、不删源)
+/// 保证这个语义。派生库在本地重建;清掉 `icloud_enabled` 标记,下次启动走本地布局。
+///
+/// 幂等:已是本地布局则清标记后返回。失败不改动当前保险箱,绝不崩溃。
+#[tauri::command]
+pub fn disable_icloud_sync(state: State<AppState>) -> Result<bool, String> {
+    #[cfg(target_os = "ios")]
+    {
+        let local_vault = state.vault_dir.clone();
+        let local_db = local_vault.join("medme.db");
+
+        let mut vault = state.vault.lock().unwrap_or_else(|p| p.into_inner());
+        let mut paths = state.paths.lock().unwrap_or_else(|p| p.into_inner());
+
+        // 已经是本地布局:清标记,幂等返回。
+        if paths.truth_root == local_vault {
+            let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+            return Ok(true);
+        }
+
+        // 复制容器里的真相回本机(objects + log);iCloud 容器内容保持不动。
+        vault
+            .copy_to(&local_vault)
+            .map_err(|e| format!("把保险箱复制回本机失败:{e}"))?;
+
+        // 本地重开:从复制回来的日志重建派生库。
+        let fresh = Vault::open_split(&local_vault, &local_db, &state.device_id)
+            .map_err(|e| format!("在本机打开保险箱失败:{e}"))?;
+        *vault = fresh;
+        paths.truth_root = local_vault;
+        paths.db_path = local_db;
+
+        // 清开启标记 + 清掉 iCloud 布局用的沙盒派生库(已由本地库取代)。
+        let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+        let _ = std::fs::remove_file(state.data_dir.join("medme.db"));
+        Ok(true)
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = &state;
+        Err("iCloud 同步仅在 iOS(苹果设备)上可用".to_string())
+    }
+}
+
 /// 记下「本设备已开启 iCloud 同步」的标记(下次启动据此用 open_split 打开容器)。
 #[cfg(target_os = "ios")]
 fn write_icloud_marker(data_dir: &std::path::Path) -> Result<(), String> {

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -151,6 +151,7 @@ pub fn run() {
             commands::get_vault_path,
             commands::reset_vault,
             commands::enable_icloud_sync,
+            commands::disable_icloud_sync,
             commands::icloud_status,
         ])
         .run(tauri::generate_context!())

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -94,6 +94,7 @@ export default function App() {
   const [lastImport, setLastImport] = useState<ImportOutcome | null>(null);
   const [share, setShare] = useState<ShareResult | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
+  const [confirmDisableIcloud, setConfirmDisableIcloud] = useState(false);
   const [version, setVersion] = useState("");
   // iCloud 同步状态(仅 iOS)。null = 尚未查询 / 不适用。
   const [icloud, setIcloud] = useState<IcloudStatus | null>(null);
@@ -150,6 +151,22 @@ export default function App() {
       setBusy(null);
     }
   }, [icloud, refresh]);
+
+  // 关闭 iCloud 同步:把真相复制回本机(iCloud 里的副本保留),本地成为主副本;
+  // 之后本设备不再自动同步。用 disable_icloud_sync(copy_to,不删源)。
+  const disableIcloud = useCallback(async () => {
+    try {
+      setBusy("正在关闭 iCloud 同步…");
+      await api.disableIcloudSync();
+      setIcloud({ available: true, enabled: false });
+      setConfirmDisableIcloud(false);
+      await refresh();
+    } catch (e) {
+      alert(`关闭 iCloud 同步失败:${e}`);
+    } finally {
+      setBusy(null);
+    }
+  }, [refresh]);
 
   // 采集:iOS WKWebView 里最可靠的相机路径 = 隐藏的 HTML file input。
   //  - `accept="image/*" capture="environment"` → 直接调起后置相机拍照;
@@ -426,17 +443,19 @@ export default function App() {
             {IS_IOS && (
               <button
                 className="row"
-                onClick={enableIcloud}
-                disabled={!!busy || icloud?.enabled === true}
+                onClick={() => (icloud?.enabled ? setConfirmDisableIcloud(true) : enableIcloud())}
+                disabled={!!busy}
               >
                 <span className="ri"><ShieldIcon /></span>
                 <span className="rt">
                   <b>iCloud 同步{icloud?.enabled ? " · 已开启" : ""}</b>
                   <span>
-                    开启后,你的病历在所有苹果设备间自动同步;数据端到端由 iCloud 保管。
+                    {icloud?.enabled
+                      ? "已在所有苹果设备间自动同步。点此关闭:数据搬回本机,iCloud 里的副本保留。"
+                      : "开启后,你的病历在所有苹果设备间自动同步;数据端到端由 iCloud 保管。"}
                   </span>
                 </span>
-                <span className="chev">{icloud?.enabled ? "✓" : "›"}</span>
+                <span className="chev">›</span>
               </button>
             )}
             <div className="info">
@@ -519,6 +538,30 @@ export default function App() {
         </div>
       )}
 
+      {/* 关闭 iCloud 确认:数据搬回本机,iCloud 里的副本保留 */}
+      {confirmDisableIcloud && (
+        <div className="scrim" onClick={() => !busy && setConfirmDisableIcloud(false)}>
+          <div className="dialog" onClick={(e) => e.stopPropagation()}>
+            <h3>关闭 iCloud 同步?</h3>
+            <p>
+              病历会复制回这台手机(本地成为主副本),iCloud 里的副本保留不动。
+              之后这台设备不再自动同步。
+            </p>
+            <div className="acts">
+              <button
+                className="cancel"
+                onClick={() => setConfirmDisableIcloud(false)}
+                disabled={!!busy}
+              >
+                取消
+              </button>
+              <button className="confirm" onClick={disableIcloud} disabled={!!busy}>
+                关闭同步
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* 清空确认:破坏性操作,二次确认 */}
       {confirmReset && (
         <div className="scrim" onClick={() => !busy && setConfirmReset(false)}>

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -30,4 +30,6 @@ export const api = {
   // iCloud 同步(仅 iOS)。status 供开关渲染;enable 迁移真相到 iCloud 容器。
   icloudStatus: () => invoke<IcloudStatus>("icloud_status"),
   enableIcloudSync: () => invoke<boolean>("enable_icloud_sync"),
+  // disable 把真相从 iCloud 容器复制回本机(保留 iCloud 副本),本地成为主副本。
+  disableIcloudSync: () => invoke<boolean>("disable_icloud_sync"),
 };

--- a/packages/core-model/src/materialize.rs
+++ b/packages/core-model/src/materialize.rs
@@ -1328,6 +1328,44 @@ mod tests {
         assert_eq!(v.search("BetaAdoptNeedle", 10).unwrap().len(), 1);
     }
 
+    /// `copy_to` forks the vault to a new location and LEAVES THE SOURCE INTACT
+    /// (used to disable iCloud sync: copy the container vault back to local,
+    /// keep the iCloud copy). After copying into a fresh dir, BOTH the source
+    /// and the target hold the full vault; the target rebuilds usably from the
+    /// copied log (no `medme.db` is copied).
+    #[test]
+    fn copy_to_forks_vault_leaving_source_intact() {
+        let src = tempfile::tempdir().unwrap();
+        seed_doc(src.path(), "alpha.txt", "AlphaCopyNeedle");
+
+        let holder = tempfile::tempdir().unwrap();
+        let local = holder.path().join("local-vault"); // fresh → copy in
+        {
+            let v = Vault::open(src.path()).unwrap();
+            v.copy_to(&local).unwrap();
+        }
+
+        // Source untouched — the iCloud copy is preserved.
+        assert!(
+            src.path().join("objects").exists(),
+            "copy_to leaves source objects"
+        );
+        assert!(src.path().join("log").exists(), "copy_to leaves source log");
+        let vs = Vault::open(src.path()).unwrap();
+        assert_eq!(vs.debug_count("document"), 1, "source still holds its doc");
+
+        // Target holds the full vault after rebuild from the copied log.
+        let v = Vault::open(&local).unwrap();
+        v.rebuild_from_log().unwrap();
+        assert_eq!(v.debug_count("document"), 1, "doc copied to target");
+        assert_eq!(v.debug_count("source_file"), 1);
+        assert_eq!(
+            v.search("AlphaCopyNeedle", 10).unwrap().len(),
+            1,
+            "search rebuilt intact at the target"
+        );
+    }
+
     // ---- machine-local device_id: shared-folder sync must not collide -------
 
     /// Two machines share ONE vault folder (cloud drive). Each opens it with its

--- a/packages/core-model/src/relocate.rs
+++ b/packages/core-model/src/relocate.rs
@@ -61,6 +61,29 @@ impl Vault {
             move_into(&src, new_root)
         }
     }
+
+    /// Copy this vault's truth (CAS `objects/` + `log/` segments) into
+    /// `new_root` **without removing anything from the source** — always the
+    /// copy/adopt path, never a move. Use to fork a vault to a new location
+    /// while keeping the original intact: e.g. disabling iCloud sync copies the
+    /// container vault back to the local sandbox and leaves the iCloud copy
+    /// untouched. The derived `medme.db` is NOT copied; reopen the target with
+    /// `open_split` to rebuild it from the merged log. If `new_root` already
+    /// holds a vault, segments/objects merge in (per-device names never collide;
+    /// CAS dedups; larger log segment wins) — same guarantees as adopt.
+    pub fn copy_to(&self, new_root: &Path) -> Result<(), MedmeError> {
+        let src = self.root().to_path_buf();
+        std::fs::create_dir_all(new_root)?;
+        if paths_equal(&src, new_root) {
+            return Err(MedmeError::Other("目标就是当前位置,无需复制".to_string()));
+        }
+        if is_descendant(new_root, &src) {
+            return Err(MedmeError::Other(
+                "目标不能位于当前保险箱目录内部".to_string(),
+            ));
+        }
+        adopt_into(&src, new_root)
+    }
 }
 
 /// True if `new_root/log` contains at least one `.jsonl` segment — i.e. another


### PR DESCRIPTION
Closes #27

## 问题
手机端 iCloud 同步一旦开启就**禁用、无法关闭/回退**(#27)。

## 方案(用户拍板 = A)
关闭 = 把保险箱真相从 iCloud 容器**复制**回本机(本地重新成为主副本),**iCloud 里的副本保留不动** —— 其它苹果设备若仍开着同步不受影响,也留一份云端备份。

## 改动
- **core-model** `Vault::copy_to`:总是走复制/adopt(复用已验证的 `adopt_into`:CAS 去重、per-device 段不撞、日志取较大者),**永不删源**。区别于 `relocate_to`(空目标会 move 删源)。带测试。
- **mobile 后端** `disable_icloud_sync`:`copy_to` 回沙盒 vault → `open_split` 本地重开重建库 → 清 `icloud_enabled` 标记。幂等;失败不动当前库。
- **mobile 前端**:iCloud 行开启后可点 → 二次确认弹窗(说明"搬回本机、iCloud 副本保留")→ 关闭。

## 测试(全过)
`cargo fmt --check` ✓ · `clippy` 零警告 ✓ · `core-model` 51 测试(含 `copy_to_forks_vault_leaving_source_intact`)✓ · 手机前端 `tsc` ✓ · `aarch64-apple-ios` 目标编译 ✓

> spine/UX 改动 —— 等你 review + approve 后我合。