### PR TITLE
fix(ci): Scorecard 用有效版本 v2.4.3(修 main 上反复失败)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## 根因(你让我查的 Actions 大面积失败)
`.github/workflows/scorecard.yml` 里 `ossf/scorecard-action@v2` —— 这个 action **只发 `v2.x.y` 和 SHA,没有移动 `v2` major tag**,所以每次 push 到 main 的 **Scorecard 都在 setup 阶段直接失败**:
```
Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```
(#25 引入时钉错了。其它 action `@v4/@v7` 都能解析,main 的 CI 本身是绿的。)

## 改动
`@v2` → `@v2.4.3`(当前最新有效 tag,与仓库其它 action 用版本 tag 的写法一致)。

> CI/流程 改动 —— 等你 approve 后我合。合并后下次 push 的 Scorecard 应能跑起来。