### PR TITLE
chore(release): bump 1.1.0

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MedMe",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "identifier": "com.medme.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MedMe",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "identifier": "com.medme.mobile",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## 1.1.0 内测版
自 1.0.2 以来合入的用户可见 + spine 改动集齐,bump 版本以出新一轮内测构建。

**含**:设置页滚动修复(#29)· 关闭 iCloud 同步新功能(#27)· 术语扩到 191(#24)· 安全加固(#26)+ imaging DoS 修复(#33)· CI 修复(#34)· 依赖升级。

改 3 处版本号(desktop / mobile tauri.conf + iOS Info.plist ShortVersion)。build 号由 tauri 从 conf 设为 1.1.0(> 上次 1.0.2、唯一)。

> 机械 bump —— CI 绿后合。