### PR TITLE
fix(security): pin vendored dicomParser.min.js by SHA-256 (GHSA-79jh)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,6 +3795,7 @@ dependencies = [
  "pipeline",
  "rand 0.8.6",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
 ]
 

--- a/packages/share/Cargo.toml
+++ b/packages/share/Cargo.toml
@@ -23,3 +23,5 @@ rand = "0.8"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# 仅供 vendored dicom-parser 的完整性测试(校验内联 JS 未被篡改)。
+sha2 = { workspace = true }

--- a/packages/share/src/share.rs
+++ b/packages/share/src/share.rs
@@ -1215,4 +1215,40 @@ mod tests {
         let decoded = B64URL.decode(stripped).unwrap();
         assert_eq!(decoded, key);
     }
+
+    #[test]
+    fn vendored_dicom_parser_matches_known_good_sha256() {
+        // 供应链完整性:vendored dicom-parser 被 `include_str!` 内联进每一份
+        // 生成的分享查看器,却没有校验和 —— 谁悄悄改了这个文件(如恶意 PR),
+        // 就把 JS 注进了所有未来的查看器而无人察觉。这里把它按 SHA-256 钉死,
+        // 文件漂移哪怕一个字节,CI 就红。更新库版本时,连带更新下方常量与
+        // `vendor/README.md` 里记录的哈希。
+        //
+        // 上游:cornerstonejs/dicom-parser v1.8.12
+        //   https://github.com/cornerstonejs/dicomParser
+        //   （UMD 构建 dist/dicomParser.min.js)
+        const DICOM_PARSER_JS_SHA256: &str =
+            "2b990e92de021a9c0d58f7dca693c95fa76be6398648b68441df9423de284a2b";
+
+        use sha2::{Digest, Sha256};
+        // 与第 240 行的 `include_str!` 同一相对路径,校验编译期真正嵌入的字节。
+        let bytes = include_bytes!("vendor/dicomParser.min.js");
+        let digest = Sha256::digest(bytes);
+        assert_eq!(
+            hex_lower(&digest),
+            DICOM_PARSER_JS_SHA256,
+            "vendored dicom-parser 的 SHA-256 与已知良好值不符 —— \
+             文件被改动过?若确为有意升级,请同步更新常量与 vendor/README.md。"
+        );
+    }
+
+    /// 把字节切片转成小写十六进制字符串(仅测试用,避免引入额外依赖)。
+    fn hex_lower(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            let _ = write!(s, "{b:02x}");
+        }
+        s
+    }
 }

--- a/packages/share/src/vendor/README.md
+++ b/packages/share/src/vendor/README.md
@@ -1,0 +1,33 @@
+# Vendored JavaScript — provenance & integrity
+
+This directory holds third-party JavaScript that is `include_str!`'d into every
+generated share viewer at compile time (so the viewer is self-contained and the
+build needs no `node_modules`). Because these bytes ship inside every viewer we
+produce, each file is pinned by SHA-256 and enforced by a Rust test.
+
+## dicomParser.min.js
+
+- **Library:** dicom-parser (browser UMD build, exposes global `dicomParser`)
+- **Version:** 1.8.12 — **frozen**
+- **Upstream:** https://github.com/cornerstonejs/dicomParser
+- **File:** `dist/dicomParser.min.js` from the above release
+- **SHA-256:** `2b990e92de021a9c0d58f7dca693c95fa76be6398648b68441df9423de284a2b`
+
+### Integrity enforcement
+
+`../share.rs` inlines this file via `include_str!("vendor/dicomParser.min.js")`.
+The test `vendored_dicom_parser_matches_known_good_sha256` (same file,
+`#[cfg(test)]`) `include_bytes!`'s it, computes the SHA-256, and asserts it
+equals the constant above. Any tamper or accidental drift — even one byte —
+fails CI.
+
+### Updating
+
+This file is deliberately frozen at 1.8.12. To change it:
+
+1. Replace the file with the new upstream build.
+2. Recompute the SHA-256 (`shasum -a 256 dicomParser.min.js`).
+3. Update the constant in `../share.rs` **and** the SHA-256 above.
+4. Bump the version noted here.
+
+Track dicom-parser for CVEs; a security advisory is the main reason to unfreeze.


### PR DESCRIPTION
Closes the checksum-pin slice of **GHSA-79jh** (supply-chain hardening).

The vendored `packages/share/src/vendor/dicomParser.min.js` (cornerstonejs/dicom-parser 1.8.12) is inlined into every generated share viewer but had no integrity anchor — a silent tamper (malicious PR / compromised commit) would inject JS into all future viewers with nothing detecting it.

## Change
- `medme-share` integrity test `vendored_dicom_parser_matches_known_good_sha256`: `include_bytes!` the vendored file, SHA-256 it, assert against a documented known-good hash (`2b990e92…284a2b`). One byte of drift fails CI.
- `packages/share/src/vendor/README.md`: provenance (upstream URL, version, hash, CVE-tracking note).
- `sha2` added as a **dev-dependency** only (no runtime change).

## Out of scope (separate follow-ups, still tracked in GHSA-79jh)
Pinning GitHub Actions to commit SHAs; macOS/Windows release signing + notarization + checksums.

## Gate
`cargo fmt` clean · `cargo clippy -p medme-share -- -D warnings` clean · `cargo test -p medme-share` 13 pass (incl. the new integrity test).