### PR TITLE
fix(security): stop trusting webview-supplied paths in desktop IPC (GHSA-gmg4)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,7 +1,10 @@
 use crate::dto::*;
 use core_model::{DocType, Document, Vault};
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{Manager, State};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;
 
 /// DocumentSummary + 影像检查切片数(imaging overhaul P1):影像 study 文档在时间线
@@ -23,6 +26,11 @@ pub struct AppState {
     /// 收件箱 notify 监听器,需要在 AppState 里存活,否则一超出作用域就会被 drop 从而
     /// 停止监听。setup() 里启动后写入;生命周期与 App 一致。
     pub inbox_watcher: Mutex<Option<notify::RecommendedWatcher>>,
+    /// SECURITY (GHSA-gmg4): allowlist of canonical file paths that MedMe itself just
+    /// wrote via a backend-driven flow (exported HTML / encrypted share / audit CSV).
+    /// `open_path` only opens the vault subtree or a path in here, so a compromised
+    /// webview can't turn `open_path` into a "launch any file/app on disk" primitive.
+    pub openable_paths: Mutex<HashSet<PathBuf>>,
 }
 
 // SECURITY/robustness: recover a poisoned lock instead of failing every command.
@@ -82,6 +90,33 @@ fn validate_dest_path(path: &str, allowed_ext: &[&str]) -> Result<std::path::Pat
         return Err(format!("拒绝:目标文件扩展名必须是 {allowed_ext:?} 之一"));
     }
     Ok(p)
+}
+
+/// SECURITY (GHSA-gmg4): record a file MedMe just wrote (export / share / audit CSV) as
+/// openable, so the corresponding "打开文件" button can hand it to `open_path` while
+/// arbitrary webview-named paths stay rejected. Stored canonicalized to match
+/// `open_path`'s canonical comparison.
+fn remember_openable(state: &State<AppState>, path: &std::path::Path) {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        let mut set = state
+            .openable_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set.insert(canon);
+    }
+}
+
+/// The app's exports directory (`<app_data_dir>/exports`), created on demand. Used as
+/// the fixed, backend-controlled destination for the audit CSV so `write`-style IPC no
+/// longer accepts a webview-supplied path.
+fn exports_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("exports");
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir)
 }
 
 #[tauri::command]
@@ -164,33 +199,30 @@ pub fn get_document(state: State<AppState>, id: i64) -> Result<DocumentDetail, S
     })
 }
 
-#[tauri::command]
-pub fn import_paths(
-    state: State<AppState>,
-    paths: Vec<String>,
-) -> Result<Vec<ImportOutcome>, String> {
-    let v = lock(&state)?;
+/// Ingest a batch of files into the vault, one `ImportOutcome` per file (a single bad
+/// file is recorded as `failed` and never aborts the batch — same tolerance as
+/// `inbox::scan_inbox`).
+///
+/// SECURITY (GHSA-gmg4): this takes already-resolved `PathBuf`s from a TRUSTED source
+/// only — either the Rust-side native file picker (`import_via_dialog`) or the OS
+/// drag-drop event delivered to the Tauri core (`lib.rs` window handler). It is
+/// deliberately NOT a `#[tauri::command]`: the webview can no longer name an arbitrary
+/// absolute path (e.g. `~/.ssh/id_rsa`) to be read into the vault and later exfiltrated
+/// via `read_source_bytes`. The minimal `is_file()` guard rejects directories / device
+/// nodes / dangling paths before we touch them.
+pub(crate) fn ingest_files(v: &Vault, paths: &[PathBuf]) -> Vec<ImportOutcome> {
     let mut out = Vec::new();
-    for p in paths {
-        let path = std::path::Path::new(&p);
-        // SECURITY: these paths come from the native file picker / OS drag-drop, so we
-        // deliberately do NOT confine them to a directory (import-from-anywhere is the
-        // point). Minimal guard: reject anything that isn't an existing regular file
-        // before touching it, so a malicious `invoke` can't aim ingest at directories,
-        // device nodes, or dangling paths. Residual trust: whatever real file the user
-        // (or a crafted invoke) points at gets read into the vault.
+    for path in paths {
         if !path.is_file() {
             out.push(ImportOutcome {
-                name: p.clone(),
+                name: path.to_string_lossy().to_string(),
                 source_file_id: 0,
                 status: "failed".to_string(),
                 doc_type: None,
             });
             continue;
         }
-        // 单个文件失败不该拖垮整批 —— 记一条失败结果继续处理剩下的文件(与
-        // inbox.rs::scan_inbox 的容错方式一致),而不是 `?` 提前返回丢弃已成功的导入。
-        match ingest_guarded(&v, path) {
+        match ingest_guarded(v, path) {
             Ok(o) => {
                 let status = match o.status {
                     pipeline::IngestStatus::New => "new",
@@ -211,7 +243,7 @@ pub fn import_paths(
                 let name = path
                     .file_name()
                     .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| p.clone());
+                    .unwrap_or_else(|| path.to_string_lossy().to_string());
                 eprintln!("[import] ingest failed for {}: {e}", path.display());
                 out.push(ImportOutcome {
                     name,
@@ -222,6 +254,45 @@ pub fn import_paths(
             }
         }
     }
+    out
+}
+
+/// Import files the user picks in a native file dialog that is opened FROM RUST.
+///
+/// SECURITY (GHSA-gmg4): this replaces the old `import_paths(paths)` command, which
+/// trusted an arbitrary `Vec<String>` from the webview. In Tauri 2 any app command is
+/// invokable directly from the (potentially XSS'd) webview, so `import_paths` was an
+/// arbitrary-file-read primitive: `invoke('import_paths', { paths: ['~/.ssh/id_rsa'] })`
+/// then read the bytes back via `read_source_bytes`. Here the paths never originate in
+/// the webview — they come straight out of the OS picker into the backend, so the
+/// webview can no longer name a path to read. UX is unchanged: the user clicks "选择文件
+/// 导入" and sees the same native file picker.
+///
+/// `blocking_pick_files` must not run on the main thread; async commands run off the
+/// main thread on the async runtime, so this is safe (see the plugin docs).
+#[tauri::command]
+pub async fn import_via_dialog(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Vec<ImportOutcome>, String> {
+    let picked = app
+        .dialog()
+        .file()
+        .set_title("选择要导入的病历文件")
+        .add_filter(
+            "病历文件",
+            &["pdf", "png", "jpg", "jpeg", "tif", "tiff", "txt", "dcm"],
+        )
+        .blocking_pick_files();
+    let Some(files) = picked else {
+        return Ok(Vec::new()); // 用户取消对话框
+    };
+    let paths: Vec<PathBuf> = files
+        .into_iter()
+        .filter_map(|f| f.into_path().ok())
+        .collect();
+    let v = lock(&state)?;
+    let out = ingest_files(&v, &paths);
     v.rebuild_encounters().map_err(|e| e.to_string())?;
     Ok(out)
 }
@@ -384,6 +455,8 @@ pub fn export_timeline_html(
     let byte_size = html.len() as i64;
     let sha256 = core_model::cas::sha256_hex(html.as_bytes());
     std::fs::write(&dest, html).map_err(|e| e.to_string())?;
+    // 允许随后用「打开文件」按钮打开这份刚写出的导出(见 open_path 的 allowlist)。
+    remember_openable(&state, &dest);
     // 审计追踪:导出落盘成功后记入不可变事件日志(见 core-model::audit)。
     v.record_export("timeline_html", &sha256, record_count)
         .map_err(|e| e.to_string())?;
@@ -411,6 +484,8 @@ pub fn create_share(
     let byte_size = html.len() as i64;
     let sha256 = core_model::cas::sha256_hex(html.as_bytes());
     std::fs::write(&dest, html).map_err(|e| e.to_string())?;
+    // 允许随后用「打开文件」按钮打开这份刚写出的分享文件(见 open_path 的 allowlist)。
+    remember_openable(&state, &dest);
     let expires = (chrono::Utc::now() + chrono::Duration::days(days as i64)).to_rfc3339();
     // 审计追踪:分享文件落盘成功后记入不可变事件日志(见 core-model::audit)。
     v.record_share(&sha256, record_count, &expires)
@@ -447,18 +522,28 @@ pub fn get_inbox_path(app: tauri::AppHandle) -> String {
 /// 注意:不会重新定位正在运行的 notify watcher(仍监听旧目录),需重启应用才会
 /// 切到新目录监听;新路径下一次启动扫描/手动导入始终立即生效。
 #[tauri::command]
-pub fn set_inbox_path(
+pub async fn set_inbox_path(
     app: tauri::AppHandle,
-    state: State<AppState>,
-    path: String,
-) -> Result<(), String> {
-    let new_path = std::path::PathBuf::from(&path);
-    // SECURITY: the watch folder is user-chosen and can legitimately live anywhere, so
-    // we don't confine it to the vault. Minimal guard: require an absolute path and
-    // reject one that already exists as a non-directory, so a malicious invoke can't
-    // aim create_dir_all at a surprising relative/into-a-file location. Residual: this
-    // trusts the picker-driven directory choice (it only creates dirs; it does not read
-    // or clobber file contents).
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    // SECURITY (GHSA-gmg4): the destination comes from a native FOLDER dialog opened
+    // from Rust, not from a webview-supplied string, so a compromised webview can no
+    // longer point `create_dir_all` / the watch folder at a surprising location.
+    let Some(folder) = app
+        .dialog()
+        .file()
+        .set_title("选择自动收件箱文件夹")
+        .blocking_pick_folder()
+    else {
+        // 用户取消:保持现状。
+        return Ok(crate::inbox::read_inbox_path(&app)
+            .to_string_lossy()
+            .to_string());
+    };
+    let new_path = folder.into_path().map_err(|e| e.to_string())?;
+    // Defense-in-depth: a native folder pick is already absolute + existing, but keep
+    // the checks so any future/non-native caller can't smuggle a relative/into-a-file
+    // path past us.
     if !new_path.is_absolute() {
         return Err("拒绝:收件箱路径必须是绝对路径".to_string());
     }
@@ -468,7 +553,7 @@ pub fn set_inbox_path(
     std::fs::create_dir_all(&new_path).map_err(|e| e.to_string())?;
     crate::inbox::write_inbox_path(&app, &new_path).map_err(|e| e.to_string())?;
     crate::inbox::scan_inbox(&app, &state);
-    Ok(())
+    Ok(new_path.to_string_lossy().to_string())
 }
 
 /// 在系统文件管理器中打开收件箱目录(不存在则先创建)。
@@ -481,17 +566,39 @@ pub fn open_inbox(app: tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
-/// 用系统默认程序打开任意文件/目录 —— 用于导出完成后一键在浏览器打开导出的 HTML。
+/// 用系统默认程序打开保险箱目录,或 MedMe 刚导出/分享/导出审计清单写出的文件
+/// (用于导出完成后一键在浏览器打开导出的 HTML)。
 #[tauri::command]
-pub fn open_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
-    // SECURITY: this hands a path to the OS default handler (which can launch apps), so
-    // require it to actually exist before opening it — that removes the "blind-open an
-    // arbitrary string" primitive. Residual trust: the frontend only calls this with
-    // the vault root or a file MedMe just exported to a user-chosen save location, so we
-    // deliberately do NOT confine it to the vault (that would break "open the HTML I
-    // just saved anywhere").
-    if !std::path::Path::new(&path).exists() {
-        return Err("拒绝:目标路径不存在".to_string());
+pub fn open_path(
+    app: tauri::AppHandle,
+    state: State<AppState>,
+    path: String,
+) -> Result<(), String> {
+    // SECURITY (GHSA-gmg4): this hands a path to the OS default handler, which can launch
+    // apps / open documents — a classic confused-deputy primitive. A compromised webview
+    // must NOT be able to `invoke('open_path', { path: '/Applications/...'} )` or open
+    // an arbitrary file. So we only open (a) the vault subtree (the "打开文件夹" button)
+    // or (b) a path MedMe itself just wrote through a backend flow (export / share /
+    // audit CSV, recorded in `openable_paths`). Everything else is rejected.
+    let canonical = std::fs::canonicalize(&path).map_err(|_| "拒绝:目标路径不存在".to_string())?;
+
+    let vault_root = {
+        let v = lock(&state)?;
+        std::fs::canonicalize(v.root()).ok()
+    };
+    let in_vault = vault_root
+        .as_ref()
+        .map(|root| canonical.starts_with(root))
+        .unwrap_or(false);
+    let is_openable = {
+        let set = state
+            .openable_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set.contains(&canonical)
+    };
+    if !in_vault && !is_openable {
+        return Err("拒绝:只能打开保险箱内或本应用刚导出的文件".to_string());
     }
     app.opener()
         .open_path(path, None::<String>)
@@ -566,14 +673,25 @@ pub fn get_vault_path(state: State<AppState>) -> Result<String, String> {
 ///
 /// 搬迁 → 持久化新位置 → 换掉 AppState 里的 Vault 并重建派生库,返回新路径。
 #[tauri::command]
-pub fn set_vault_path(
+pub async fn set_vault_path(
     app: tauri::AppHandle,
-    state: State<AppState>,
-    new_dir: String,
+    state: State<'_, AppState>,
 ) -> Result<String, String> {
-    // SECURITY: new_dir 来自原生「选择文件夹」对话框,但仍做基本校验 —— 要求绝对路径、
-    // 不含 `..`,已存在则必须是目录,避免恶意 invoke 把数据搬到意外/相对位置。
-    let target = std::path::PathBuf::from(&new_dir);
+    // SECURITY (GHSA-gmg4): the new location comes from a native FOLDER dialog opened
+    // from Rust, not a webview-supplied string — a compromised webview can no longer
+    // relocate the vault to an attacker-chosen path. Cancelling leaves the vault where
+    // it is. The absolute / no-`..` / existing-dir checks stay as defense-in-depth so
+    // any non-native caller still can't smuggle a surprising path past us.
+    let Some(folder) = app
+        .dialog()
+        .file()
+        .set_title("选择数据保险箱新位置")
+        .blocking_pick_folder()
+    else {
+        let v = lock(&state)?;
+        return Ok(v.root().to_string_lossy().to_string());
+    };
+    let target = folder.into_path().map_err(|e| e.to_string())?;
     if !target.is_absolute() {
         return Err("拒绝:新位置必须是绝对路径".to_string());
     }
@@ -608,15 +726,24 @@ pub fn get_audit_log(state: State<AppState>) -> Result<Vec<AuditEntryDto>, Strin
     Ok(entries.iter().map(AuditEntryDto::from).collect())
 }
 
-/// 把文本写到用户选择的路径 —— 目前仅用于审计视图「导出审计清单」(CSV)。
+/// 导出审计清单 CSV。内容由审计视图按不可变事件日志生成(纯应用数据,不含路径),
+/// 后端把它写进固定的导出目录并返回写入路径,供随后用「打开文件」按钮打开。
 #[tauri::command]
-pub fn write_text_file(path: String, contents: String) -> Result<(), String> {
-    // SECURITY: this is the only raw text-write IPC command and is used solely by the
-    // audit view's "export audit CSV" (via the native save dialog). Constrain the
-    // JS-supplied target to an absolute `.csv` path (see validate_dest_path) so a
-    // malicious invoke can't turn this into an arbitrary-file write primitive.
-    let dest = validate_dest_path(&path, &["csv"])?;
-    std::fs::write(&dest, contents).map_err(|e| e.to_string())
+pub fn export_audit_csv(
+    app: tauri::AppHandle,
+    state: State<AppState>,
+    contents: String,
+) -> Result<String, String> {
+    // SECURITY (GHSA-gmg4): this replaces the old `write_text_file(path, contents)`,
+    // which took a webview-supplied destination and could be turned into an
+    // arbitrary-file write. The destination is now backend-controlled (the app's exports
+    // dir) — the webview only supplies app-generated CSV text, never a path.
+    let dir = exports_dir(&app)?;
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let dest = dir.join(format!("MedMe审计清单-{ts}.csv"));
+    std::fs::write(&dest, contents).map_err(|e| e.to_string())?;
+    remember_openable(&state, &dest);
+    Ok(dest.to_string_lossy().to_string())
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -80,7 +80,9 @@ pub struct DocumentDetail {
     pub ocr_backend: Option<String>,
 }
 
-#[derive(Serialize)]
+// Clone 是为了把导入结果作为 Tauri 事件负载(`import-results`)从 Rust 拖放处理器
+// 发给前端 —— Emitter::emit 要求 `Serialize + Clone`。
+#[derive(Serialize, Clone)]
 pub struct ImportOutcome {
     pub name: String,
     pub source_file_id: i64,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,9 +5,10 @@ mod vault_loc;
 
 use commands::AppState;
 use core_model::Vault;
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 /// This machine's persistent device id, stored in `<app_data_dir>/device_id`
 /// (OUTSIDE the vault, which may live in a shared cloud folder). Created with a
@@ -30,11 +31,44 @@ fn machine_device_id(app_data_dir: &Path) -> String {
     id
 }
 
+/// Ingest OS-dropped files (trusted paths from the Tauri core's drag-drop event) off the
+/// main thread, then tell the frontend: `import-results` carries the per-file outcomes so
+/// the import view can show them, and `vault-changed` refreshes the timeline + banner
+/// (same event the watch folder emits). Runs on a worker thread because ingest (OCR /
+/// DICOM) must not block the UI event loop that delivered the drop event.
+fn handle_file_drop(app: &tauri::AppHandle, paths: Vec<PathBuf>) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let state = app.state::<AppState>();
+        let outcomes = {
+            // Recover a poisoned lock rather than panicking the worker (see commands::lock).
+            let vault = state
+                .vault
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let out = commands::ingest_files(&vault, &paths);
+            let _ = vault.rebuild_encounters(); // 幂等,与手动导入一致
+            out
+        };
+        let _ = app.emit("import-results", outcomes);
+        let _ = app.emit("vault-changed", ());
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        // SECURITY (GHSA-gmg4): handle file drag-drop in the Rust core, where the paths
+        // are delivered by the OS and are trustworthy, instead of round-tripping them
+        // through the (potentially XSS'd) webview via an `import_paths(paths)` command.
+        // The webview can no longer name an arbitrary path to be read into the vault.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
+                handle_file_drop(window.app_handle(), paths.clone());
+            }
+        })
         .setup(|app| {
             // Machine-local device id lives in app_data_dir (NOT the vault), so a
             // shared/cloud vault folder never leaks one machine's id to another —
@@ -50,6 +84,7 @@ pub fn run() {
             app.manage(AppState {
                 vault: Mutex::new(vault),
                 inbox_watcher: Mutex::new(None),
+                openable_paths: Mutex::new(HashSet::new()),
             });
 
             // Watch Folder(见 docs/011_Storage_Sync.md §7):确保收件箱目录存在、启动扫描
@@ -71,7 +106,7 @@ pub fn run() {
             commands::list_timeline_grouped,
             commands::search,
             commands::get_document,
-            commands::import_paths,
+            commands::import_via_dialog,
             commands::load_demo_data,
             commands::read_source_bytes,
             commands::render_dicom,
@@ -89,7 +124,7 @@ pub fn run() {
             commands::get_vault_path,
             commands::set_vault_path,
             commands::get_audit_log,
-            commands::write_text_file,
+            commands::export_audit_csv,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -15,8 +15,9 @@ export const api = {  listTimelineGrouped: () => invoke<TimelineGroup[]>("list_t
   search: (query: string, limit = 30) =>
     invoke<SearchResult[]>("search", { query, limit }),
   getDocument: (id: number) => invoke<DocumentDetail>("get_document", { id }),
-  importPaths: (paths: string[]) =>
-    invoke<ImportOutcome[]>("import_paths", { paths }),
+  // 安全:文件选择器在 Rust 侧弹出并直接导入用户所选文件——路径绝不经由 webview 传入
+  // (旧 import_paths 会信任任意前端路径,可被 XSS 用来读取任意文件)。返回逐个文件结果。
+  importViaDialog: () => invoke<ImportOutcome[]>("import_via_dialog"),
   // 一键「加载示例数据」(张建国):导入随应用打包的 demo-data/,返回处理的文件数。
   loadDemoData: () => invoke<number>("load_demo_data"),
   // 后端用 tauri::ipc::Response 返回原始字节(而非 Vec<u8> 序列化成 JSON number[]),
@@ -37,14 +38,17 @@ export const api = {  listTimelineGrouped: () => invoke<TimelineGroup[]>("list_t
     invoke<ShareResult>("create_share", { destPath, expiresDays }),
   getPatientProfile: () => invoke<PatientProfile>("get_patient_profile"),
   getInboxPath: () => invoke<string>("get_inbox_path"),
-  setInboxPath: (path: string) => invoke<void>("set_inbox_path", { path }),
+  // 收件箱文件夹由 Rust 侧原生「选择文件夹」对话框选择,返回新路径(取消则返回原路径)。
+  setInboxPath: () => invoke<string>("set_inbox_path"),
   openInbox: () => invoke<void>("open_inbox"),
   openPath: (path: string) => invoke<void>("open_path", { path }),
   openUrl: (url: string) => invoke<void>("open_url", { url }),
   getVaultPath: () => invoke<string>("get_vault_path"),
-  // 更换保险箱位置:把现有病历搬到 newDir(指向云同步文件夹即可多设备同步),返回新路径。
-  setVaultPath: (newDir: string) => invoke<string>("set_vault_path", { newDir }),
+  // 更换保险箱位置:Rust 侧弹原生「选择文件夹」对话框,把现有病历搬到所选目录
+  //(指向云同步文件夹即可多设备同步),返回新路径(取消则返回原路径)。
+  setVaultPath: () => invoke<string>("set_vault_path"),
   getAuditLog: () => invoke<AuditEntry[]>("get_audit_log"),
-  writeTextFile: (path: string, contents: string) =>
-    invoke<void>("write_text_file", { path, contents }),
+  // 导出审计清单 CSV:内容由前端按审计条目生成,后端写入固定导出目录并返回写入路径。
+  exportAuditCsv: (contents: string) =>
+    invoke<string>("export_audit_csv", { contents }),
 };

--- a/apps/desktop/src/components/AuditView.tsx
+++ b/apps/desktop/src/components/AuditView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { ShieldAlert, ArrowLeft, Copy, Check, FileDown } from "lucide-react";
-import { save } from "@tauri-apps/plugin-dialog";
 import { api } from "../api";
 import type { AuditEntry } from "../types";
 
@@ -24,6 +23,7 @@ function shortHash(h: string | null): string {
 export default function AuditView({ onNav }: { onNav: (id: string) => void }) {
   const [entries, setEntries] = useState<AuditEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [copiedSeq, setCopiedSeq] = useState<number | null>(null);
 
   useEffect(() => {
@@ -40,12 +40,11 @@ export default function AuditView({ onNav }: { onNav: (id: string) => void }) {
     }
   };
 
+  // 导出审计清单 CSV:内容在此按不可变事件日志生成,由后端写入固定的导出目录并返回
+  // 路径。安全:不再由 webview 指定写入路径(旧 write_text_file 可被滥用为任意写)。
   const exportManifest = async () => {
-    const path = await save({
-      defaultPath: "MedMe审计清单.csv",
-      filters: [{ name: "CSV", extensions: ["csv"] }],
-    }).catch(() => null);
-    if (!path) return;
+    setError(null);
+    setNotice(null);
     const header = "seq,timestamp,device_id,action,detail,sha256\n";
     const rows = entries
       .map((e) =>
@@ -54,7 +53,12 @@ export default function AuditView({ onNav }: { onNav: (id: string) => void }) {
           .join(","),
       )
       .join("\n");
-    await api.writeTextFile(path, header + rows).catch((e) => setError(String(e)));
+    try {
+      const path = await api.exportAuditCsv(header + rows);
+      setNotice(`已导出到:${path}`);
+    } catch (e) {
+      setError(String(e));
+    }
   };
 
   return (
@@ -86,6 +90,12 @@ export default function AuditView({ onNav }: { onNav: (id: string) => void }) {
 
         {error && (
           <div className="rounded-xl px-4 py-2.5 text-sm bg-rose-50 text-rose-700">{error}</div>
+        )}
+
+        {notice && (
+          <div className="rounded-xl px-4 py-2.5 text-sm bg-emerald-50 text-emerald-700 break-all">
+            {notice}
+          </div>
         )}
 
         <div className="flex justify-end">

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { listen } from "@tauri-apps/api/event";
 import { save } from "@tauri-apps/plugin-dialog";
 import { api } from "../api";
 import type { ImportOutcome } from "../types";
@@ -138,6 +139,9 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
     }
   };
 
+  // 拖放:只用 webview 事件驱动高亮动画;实际导入由 Rust 侧的拖放处理器完成(它拿到的
+  // 是 OS 可信路径),完成后发 `import-results` 事件带回逐个文件结果。安全:webview 不再
+  // 把(可能被 XSS 伪造的)路径传给后端读取。
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     getCurrentWebview()
@@ -149,8 +153,10 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
           setDragging(false);
         } else if (p.type === "drop") {
           setDragging(false);
-          const paths = p.paths ?? [];
-          if (paths.length) doImport(paths);
+          if ((p.paths ?? []).length) {
+            setBusy(true);
+            setError(null);
+          }
         }
       })
       .then((f) => {
@@ -162,17 +168,36 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const doImport = (paths: string[]) => {
+  // Rust 拖放处理器导入完成后带回的逐个文件结果(时间线刷新由 App 层的 vault-changed 负责)。
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    listen<ImportOutcome[]>("import-results", (event) => {
+      setResults(event.payload);
+      setBusy(false);
+    }).then((f) => {
+      unlisten = f;
+    });
+    return () => {
+      if (unlisten) unlisten();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 「选择文件导入」:后端(Rust)弹出原生文件选择器并直接导入所选文件,返回逐个文件结果。
+  const pickAndImport = async () => {
     setBusy(true);
     setError(null);
-    api
-      .importPaths(paths)
-      .then((r) => {
+    try {
+      const r = await api.importViaDialog();
+      if (r.length) {
         setResults(r);
         onImported();
-      })
-      .catch((e) => setError(String(e)))
-      .finally(() => setBusy(false));
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -230,6 +255,16 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
           </div>
           <div className="text-xs font-mono text-slate-400 mt-2">
             PDF · 图片(PNG / JPG / TIFF)· TXT · 原始文件永久保存,自动去重
+          </div>
+          <div className="mt-5">
+            <button
+              type="button"
+              onClick={pickAndImport}
+              disabled={busy}
+              className="inline-flex items-center gap-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-wait rounded-xl px-4 py-2.5 transition-colors cursor-pointer"
+            >
+              <FolderOpen className="w-4 h-4" /> 选择文件导入
+            </button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -9,7 +9,6 @@ import {
   CloudCog,
   Lock,
 } from "lucide-react";
-import { open } from "@tauri-apps/plugin-dialog";
 import { api } from "../api";
 
 export default function SettingsView({ onNav }: { onNav: (id: string) => void }) {
@@ -23,22 +22,14 @@ export default function SettingsView({ onNav }: { onNav: (id: string) => void })
     api.getInboxPath().then(setInboxPath).catch((e) => setError(String(e)));
   }, []);
 
-  // 更换保险箱位置:从原生「选择文件夹」对话框选一个目录(选云同步文件夹即可多设备同步),
-  // 后端会把现有病历整体搬过去(或在共享文件夹里与另一台设备合并),再返回新路径。
+  // 更换保险箱位置:后端(Rust)弹出原生「选择文件夹」对话框选一个目录(选云同步文件夹
+  // 即可多设备同步),把现有病历整体搬过去(或在共享文件夹里与另一台设备合并),返回新路径。
+  // 安全:路径来自后端原生对话框,不再由(可能被 XSS 污染的)webview 传入。
   async function changeLocation() {
     setError(null);
-    const picked = await open({
-      directory: true,
-      multiple: false,
-      title: "选择数据保险箱新位置",
-    }).catch((e) => {
-      setError(String(e));
-      return null;
-    });
-    if (!picked || Array.isArray(picked)) return;
     setRelocating(true);
     try {
-      const newPath = await api.setVaultPath(picked);
+      const newPath = await api.setVaultPath();
       setVaultPath(newPath);
     } catch (e) {
       setError(String(e));


### PR DESCRIPTION
Closes the desktop-IPC over-privilege in **GHSA-gmg4**. In Tauri 2, app-defined commands are invokable directly from the webview, so the old flow (frontend picks paths → backend trusts them) let a compromised/XSS'd webview read arbitrary local files and drive other filesystem primitives.

## Changes
- **Import (the arbitrary-read HIGH)**: deleted `import_paths`. Import now uses a **Rust-invoked native file picker** (`import_via_dialog`), and OS **drag-drop is handled in the Rust core** — the webview never supplies a path.
- **Vault / inbox folder**: `set_vault_path` / `set_inbox_path` take no path arg; the directory comes from a **Rust-invoked native folder dialog** (existing absolute/no-`..`/existing-dir checks kept as defense-in-depth).
- **Confine `open_path` / `write_text_file`**: `open_path` restricted to the vault subtree + files MedMe itself just exported; `write_text_file` (arbitrary `.csv`) replaced with `export_audit_csv` writing app-generated content to a fixed exports dir.

## UX preserved
Same native file/folder pickers, same drag-drop zone + per-file results, exports still work. (Minor: drag-drop now imports when dropped anywhere on the window; audit-CSV export saves to the app exports folder and reports the path.)

## Residual (clean follow-ups, not in scope)
`export_timeline_html` / `create_share` still use a JS `save()` dialog behind `validate_dest_path` (absolute, `.html`, no `..`) — app-generated content, no read-back; could be moved backend-side later. `capabilities/default.json` still lists `dialog:allow-open` (now unused, harmless).

## Gate
`cargo fmt` clean · `cargo clippy -p medme-desktop -- -D warnings` clean · `cargo check`/`cargo test -p medme-desktop` pass · frontend `tsc --noEmit` + `vite build` green.