### PR TITLE
feat(ocr): macOS 桌面改用 Apple Vision OCR(#41 第一块)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,6 +4297,28 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
 ]
 
 [[package]]
@@ -4306,7 +4338,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -4317,10 +4351,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -4344,6 +4381,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-ml"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,6 +4415,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4384,6 +4459,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +4478,17 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4438,6 +4535,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-vision"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-media",
+ "objc2-core-ml",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+]
+
+[[package]]
 name = "objc2-web-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,6 +4576,11 @@ dependencies = [
  "imageproc",
  "lopdf 0.43.0",
  "oar-ocr",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-vision",
 ]
 
 [[package]]

--- a/packages/ocr/Cargo.toml
+++ b/packages/ocr/Cargo.toml
@@ -48,3 +48,10 @@ lopdf.workspace = true
 default = ["engine", "auto-download"]
 engine = ["dep:oar-ocr"]
 auto-download = ["oar-ocr?/auto-download"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-core-foundation = "0.3.2"
+objc2-core-graphics = "0.3.2"
+objc2-foundation = "0.3.2"
+objc2-vision = "0.3.2"

--- a/packages/ocr/examples/vision_check.rs
+++ b/packages/ocr/examples/vision_check.rs
@@ -1,0 +1,15 @@
+// 验证 macOS Apple Vision OCR:读一张图 → ocr::recognize → 打印文字 + 置信度。
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: vision_check <image>");
+    let bytes = std::fs::read(&path).expect("read image");
+    let t = std::time::Instant::now();
+    let out = ocr::recognize(&bytes).expect("recognize");
+    eprintln!(
+        "[{}ms] confidence={:.3}",
+        t.elapsed().as_millis(),
+        out.confidence
+    );
+    println!("{}", out.text);
+}

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -11,6 +11,10 @@ use image::{DynamicImage, GenericImageView, GrayImage, Luma};
 use imageproc::filter::gaussian_blur_f32;
 use imageproc::geometric_transformations::{rotate_about_center, Border, Interpolation};
 use lopdf::{Document, Object};
+/// macOS on-device OCR via Apple Vision — primary recognizer on the desktop
+/// build (oar-ocr is the fallback). See the module for the rationale (#41).
+#[cfg(target_os = "macos")]
+mod vision_macos;
 #[cfg(feature = "engine")]
 use oar_ocr::oarocr::{OAROCRBuilder, OAROCR};
 #[cfg(feature = "engine")]
@@ -292,7 +296,7 @@ fn deskew(gray: &GrayImage, angle_deg: f32) -> GrayImage {
 /// builds the OCR pipeline on first call (models auto-download from
 /// ModelScope on first ever run on this machine).
 #[cfg(feature = "engine")]
-pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
+fn recognize_engine(image_bytes: &[u8]) -> Result<OcrOutcome> {
     let ocr = pipeline()?;
     let dynamic = decode_image_bounded(image_bytes).context("ocr::recognize: decode image")?;
     let dynamic = preprocess(dynamic);
@@ -320,11 +324,48 @@ pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
     })
 }
 
-/// No-`engine` stub (Android build): oar-ocr/ONNX Runtime isn't linked in on
-/// this platform (it wouldn't work there anyway -- see the `engine` feature
-/// doc in Cargo.toml). Always errors; callers already treat OCR failure as
-/// non-fatal and fall back to storing the file without extracted text.
-#[cfg(not(feature = "engine"))]
+/// macOS: decode the bytes then run Apple Vision on the RGBA pixels.
+#[cfg(target_os = "macos")]
+fn recognize_vision(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    let dynamic =
+        decode_image_bounded(image_bytes).context("ocr::recognize(vision): decode image")?;
+    let rgba = dynamic.to_rgba8();
+    let (w, h) = (rgba.width(), rgba.height());
+    vision_macos::recognize_rgba(w, h, rgba.as_raw())
+}
+
+/// Recognize text in image bytes. **macOS**: Apple Vision is the primary
+/// recognizer (offline, strong Chinese, #41); if it errors or finds no text,
+/// fall back to the oar-ocr / PP-OCRv5 engine. **Other platforms**: the engine
+/// (or a stub error when the engine isn't linked in, e.g. a no-`engine` build).
+#[cfg(target_os = "macos")]
+pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    match recognize_vision(image_bytes) {
+        Ok(outcome) if !outcome.text.trim().is_empty() => return Ok(outcome),
+        Ok(_) => {} // Vision ran but found nothing — try the engine.
+        Err(e) => eprintln!("[ocr] Apple Vision failed, falling back to engine: {e:#}"),
+    }
+    #[cfg(feature = "engine")]
+    {
+        recognize_engine(image_bytes)
+    }
+    #[cfg(not(feature = "engine"))]
+    {
+        Ok(OcrOutcome {
+            text: String::new(),
+            confidence: 0.0,
+        })
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), feature = "engine"))]
+pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    recognize_engine(image_bytes)
+}
+
+/// No-`engine`, non-macOS stub: nothing to recognize with. Callers treat OCR
+/// failure as non-fatal (store the file without extracted text).
+#[cfg(all(not(target_os = "macos"), not(feature = "engine")))]
 pub fn recognize(_image_bytes: &[u8]) -> Result<OcrOutcome> {
     anyhow::bail!("ocr::recognize: OCR engine not available on this platform")
 }

--- a/packages/ocr/src/vision_macos.rs
+++ b/packages/ocr/src/vision_macos.rs
@@ -1,0 +1,117 @@
+//! macOS on-device OCR via Apple **Vision** (`VNRecognizeTextRequest`) —
+//! offline, no model download, strong Chinese. PRIMARY recognizer on the macOS
+//! desktop build; `recognize` falls back to oar-ocr / PP-OCRv5 if Vision yields
+//! nothing or errors. Mirrors the proven iOS `OcrVision.swift`, but pure Rust
+//! via `objc2` so the desktop crate needs no Swift toolchain / link wiring.
+
+use crate::OcrOutcome;
+use anyhow::{anyhow, Context, Result};
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::AnyThread;
+use objc2_core_foundation::{CFData, CFRetained};
+use objc2_core_graphics::{
+    CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGDataProvider, CGImage, CGImageAlphaInfo,
+};
+use objc2_foundation::{NSArray, NSDictionary, NSString};
+use objc2_vision::{
+    VNImageOption, VNImageRequestHandler, VNRecognizeTextRequest, VNRequest,
+    VNRequestTextRecognitionLevel,
+};
+
+/// Recognize text in already-decoded RGBA8 pixels (tightly packed) via Apple
+/// Vision. Returns joined lines + mean observation confidence (0..1).
+pub fn recognize_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<OcrOutcome> {
+    let cg = make_cgimage(width, height, rgba)?;
+    // SAFETY: standard Vision usage — build a text request, run it synchronously
+    // on the image, read observations. objc2 ref-counts all objects.
+    unsafe {
+        let request = VNRecognizeTextRequest::new();
+        request.setRecognitionLevel(VNRequestTextRecognitionLevel::Accurate);
+        // Simplified + Traditional Chinese + English (labels/units often EN).
+        let langs = NSArray::from_retained_slice(&[
+            NSString::from_str("zh-Hans"),
+            NSString::from_str("zh-Hant"),
+            NSString::from_str("en-US"),
+        ]);
+        request.setRecognitionLanguages(&langs);
+        request.setUsesLanguageCorrection(true);
+
+        let options = NSDictionary::<VNImageOption, AnyObject>::new();
+        let handler = VNImageRequestHandler::initWithCGImage_options(
+            VNImageRequestHandler::alloc(),
+            &cg,
+            &options,
+        );
+
+        // VNRecognizeTextRequest is a subclass of VNRequest; performRequests
+        // wants an NSArray<VNRequest>.
+        let req: Retained<VNRequest> = Retained::cast_unchecked(request.clone());
+        let requests = NSArray::from_retained_slice(&[req]);
+        handler
+            .performRequests_error(&requests)
+            .map_err(|e| anyhow!("Vision performRequests failed: {e:?}"))?;
+
+        let mut lines: Vec<String> = Vec::new();
+        let mut conf_sum: f32 = 0.0;
+        let mut conf_n: u32 = 0;
+        if let Some(results) = request.results() {
+            for obs in results.iter() {
+                let candidates = obs.topCandidates(1);
+                if let Some(text) = candidates.firstObject() {
+                    let s = text.string().to_string();
+                    if !s.trim().is_empty() {
+                        lines.push(s);
+                        conf_sum += text.confidence();
+                        conf_n += 1;
+                    }
+                }
+            }
+        }
+        Ok(OcrOutcome {
+            text: lines.join("\n"),
+            confidence: if conf_n > 0 {
+                conf_sum / conf_n as f32
+            } else {
+                0.0
+            },
+        })
+    }
+}
+
+/// Build a CGImage from tightly-packed RGBA8 pixels (bytes_per_row = width*4).
+/// CFData copies the bytes, so the borrowed slice need not outlive the call.
+fn make_cgimage(width: u32, height: u32, rgba: &[u8]) -> Result<CFRetained<CGImage>> {
+    let expected = width as usize * height as usize * 4;
+    if rgba.len() < expected {
+        return Err(anyhow!(
+            "rgba buffer too small: {} < {expected}",
+            rgba.len()
+        ));
+    }
+    // SAFETY: CFDataCreate copies `len` bytes from a valid pointer; the rest is
+    // CoreGraphics object construction from that buffer.
+    unsafe {
+        let data = CFData::new(None, rgba.as_ptr(), expected as isize)
+            .context("CFDataCreate returned null")?;
+        let provider =
+            CGDataProvider::with_cf_data(Some(&data)).context("CGDataProvider from CFData")?;
+        let space = CGColorSpace::new_device_rgb().context("CGColorSpace device RGB")?;
+        // 8 bits/component, 32 bits/pixel, non-premultiplied alpha last (RGBA).
+        let bitmap = CGBitmapInfo(CGImageAlphaInfo::Last.0);
+        CGImage::new(
+            width as usize,
+            height as usize,
+            8,
+            32,
+            width as usize * 4,
+            Some(&space),
+            bitmap,
+            Some(&provider),
+            std::ptr::null(),
+            false,
+            CGColorRenderingIntent::RenderingIntentDefault,
+        )
+        .context("CGImage::new returned null")
+    }
+}


### PR DESCRIPTION
关联 #41(第一块:macOS)。

## 问题
跨平台 OCR 走 PP-OCRv5 精简模型,中文病历识别很差(安卓/Windows/桌面);iOS 早已用 Apple Vision(原生、离线、中文强)。

## 改动(macOS 桌面)
用 **objc2 纯 Rust** 调 `VNRecognizeTextRequest`(无需 Swift/链接接线),放进 `packages/ocr::recognize` seam:
- **macOS**:先试 Apple Vision(accurate + zh-Hans/zh-Hant/en),空或错再回退 oar-ocr / PP-OCRv5;
- **其余平台**:完全不变(引擎 / 兜底)。
- `vision_macos.rs`:RGBA → CGImage(objc2-core-graphics)→ Vision,复刻 iOS `OcrVision.swift` 逻辑。
- `examples/vision_check.rs`:OCR 验证工具。

## 本地实测(按"构建≠验证")
对一张仿真中文化验单跑 `ocr::recognize`:
```
[451ms] confidence=0.906
姓名:张建国 · 白细胞 6.2 · 血红蛋白 145 · 血小板 210 · 空腹血糖 6.8 · 总胆固醇 5.8 · 肌酐 88
参考范围/单位(10^9/L、mmol/L、umol/L)、检验日期 2025-02-18、检验者李医生 —— 全部识别正确
```
比 PP-OCRv5 精简模型强一个量级。

## 门禁
`cargo fmt --check` ✓ · `clippy -p ocr` 干净 ✓ · `ocr` 13 测试全过 ✓ · `cargo check -p medme-desktop`(桌面整体)通过 ✓

## 不在本 PR
Windows(Windows.Media.Ocr / WinRT)、安卓(ML Kit)是原生代码、Rust 调不到,各自独立后续。Linux 保留 PP-OCRv5 兜底。

> spine/功能改动 —— 等你 review + approve 后合。