### PR TITLE
fix(security): upgrade pdf-extract to drop vulnerable lopdf 0.34 (GHSA-7qw4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,5 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-audit
-      # --ignore RUSTSEC-2026-0187: lopdf stack-overflow DoS on a deeply-nested
-      # PDF, reached ONLY transitively via pdf-extract 0.7.12 (which pins lopdf
-      # 0.34; no released pdf-extract uses the fixed 0.42+, and forcing 0.43
-      # breaks pdf-extract's own API). Accepted risk for now: MedMe is a local
-      # tool, so exploiting it needs the user to import an attacker-crafted PDF,
-      # which only crashes the parse (truth is the append-only log+CAS → no data
-      # loss; no RCE, no exfil). Revisit when pdf-extract updates its lopdf dep.
       - name: cargo audit (fail on vulnerabilities)
-        run: cargo audit --ignore RUSTSEC-2026-0187
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,15 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
@@ -736,6 +745,15 @@ dependencies = [
 
 [[package]]
 name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
@@ -780,6 +798,12 @@ dependencies = [
  "fnv",
  "uuid",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-expr"
@@ -1661,6 +1685,15 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "ecb"
@@ -2952,6 +2985,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -2961,7 +2995,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "block-padding",
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -3602,19 +3636,28 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
+ "aes 0.8.4",
+ "bitflags 2.13.0",
+ "cbc 0.1.2",
+ "ecb 0.1.2",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.3",
  "indexmap 2.14.0",
  "itoa",
  "log",
  "md-5 0.10.6",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.2",
  "rangemap",
- "time",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "weezl 0.1.12",
 ]
 
@@ -3626,9 +3669,9 @@ checksum = "e7407d2ac60a10b2084e208586cb8a556937ee52e221a1796fbd43b66cd96788"
 dependencies = [
  "aes 0.9.1",
  "bitflags 2.13.0",
- "cbc",
+ "cbc 0.2.1",
  "chrono",
- "ecb",
+ "ecb 0.2.0",
  "encoding_rs",
  "flate2",
  "getrandom 0.4.3",
@@ -4695,14 +4738,16 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf-extract"
-version = "0.7.12"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
+ "cff-parser",
  "encoding_rs",
  "euclid",
- "lopdf 0.34.0",
+ "log",
+ "lopdf 0.42.0",
  "postscript",
  "type1-encoding-parser",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 anyhow = "1"
 jieba-rs = "0.7"
-pdf-extract = "0.7"
+pdf-extract = "0.12"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/parser/src/lib.rs
+++ b/packages/parser/src/lib.rs
@@ -22,7 +22,7 @@ pub fn extract(path: &Path) -> anyhow::Result<Extracted> {
     let (text, page_count) = match ext.as_str() {
         "txt" => (std::fs::read_to_string(path)?, 1),
         "pdf" => {
-            // pdf-extract 0.7 PANICS (internal unwrap/index/`unimplemented!`) on
+            // pdf-extract can PANIC (internal unwrap/index/`unimplemented!`) on
             // malformed/truncated PDFs rather than returning Err, and that panic
             // would unwind past the caller's non-fatal fallback and crash the
             // process. Catch it here and convert to a normal Err so the existing
@@ -324,7 +324,7 @@ mod tests {
     /// Builds a structurally-valid single-page PDF (parseable by lopdf) whose
     /// content stream is `content`. When `include_font` is false the page's
     /// Resources have no `/Font`, so a text-show operator referencing `/F1`
-    /// drives pdf-extract 0.7 into an internal panic during text extraction.
+    /// drives pdf-extract into an internal panic during text extraction.
     fn build_pdf(content: &[u8], include_font: bool) -> Vec<u8> {
         let font_res: &[u8] = if include_font {
             b"/Font << /F1 5 0 R >>"
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn malformed_pdf_returns_err_not_panic() {
         // This structurally-valid PDF shows text with a font missing from the
-        // page's Resources, which makes pdf-extract 0.7 PANIC during text
+        // page's Resources, which makes pdf-extract PANIC during text
         // extraction (not return Err). Without the catch_unwind firewall in
         // `extract`, that panic unwinds past the caller's non-fatal fallback and
         // aborts this test process; with it, `extract` returns a normal Err.


### PR DESCRIPTION
Closes **GHSA-7qw4 / RUSTSEC-2026-0187** (CVSS 7.5). `pdf-extract 0.7.12` pulled `lopdf 0.34.0`, whose stack overflow on deeply nested PDF objects **aborts the process** — `catch_unwind` can't catch a stack overflow, so a crafted PDF import crashed the app.

## Fix (clean upgrade — not a workaround)
- Bump `pdf-extract` 0.7 → **0.12** (workspace dep; `parser` inherits it). **No API change** — `pdf_extract::extract_text` compiles unchanged and the existing `catch_unwind` firewall is kept.
- `lopdf` via pdf-extract is now **0.42.0**; the vulnerable **0.34.x is gone** from `Cargo.lock`. (The unrelated `lopdf 0.43` used by `ocr` is untouched.)
- **Remove `--ignore RUSTSEC-2026-0187`** from the CI `cargo audit` step (and its justification comment) — the gate is honest again.
- De-version a few stale parser comments that named pdf-extract 0.7.

## Verification
```
cargo tree -p parser -i lopdf  →  lopdf v0.42.0 └── pdf-extract v0.12.0 └── parser
cargo audit                    →  exit 0, RUSTSEC-2026-0187 gone
```

## Gate
`cargo fmt` clean · `cargo clippy -p parser -- -D warnings` clean · `cargo test -p parser` 15 pass (incl. the malformed-PDF firewall + valid-PDF tests) · `cargo audit` clean.