### PR TITLE
fix(security): isolate DICOM codec decoding (GHSA-24px)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,3 +36,10 @@ chrono.workspace = true
 [dev-dependencies]
 tempfile = { workspace = true }
 
+# Custom-harness integration test for the isolated DICOM decode subprocess: the
+# test binary re-execs itself as the `--decode-dicom` child, which libtest's
+# default harness can't do (it would parse the flag as a test filter).
+[[test]]
+name = "dicom_subprocess_roundtrip"
+harness = false
+

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -26,12 +26,15 @@ pub struct AppState {
 }
 
 // SECURITY/robustness: recover a poisoned lock instead of failing every command.
-// The ingest/dicom command entry points now run their library calls under
-// `catch_unwind` (see `ingest_guarded` / `render_dicom` / `decode_dicom_frame`), so a
-// bad file can't poison this mutex in the first place. But if some *other* path ever
-// panics while holding the guard, `into_inner()` keeps the Vault usable rather than
-// bricking the whole app past one bad operation — the Vault's own truth is the
-// append-only log + CAS, not transient in-memory state, so a recovered guard is safe.
+// The risky command entry points isolate their library calls so a bad file can't
+// poison this mutex in the first place: ingest runs under `catch_unwind` (see
+// `ingest_guarded`), and DICOM pixel decoding runs in a separate child process
+// (see `render_dicom` / `decode_dicom_frame` → `dicom_subprocess`), which also
+// contains C/C++ codec memory corruption that `catch_unwind` could not. But if
+// some *other* path ever panics while holding the guard, `into_inner()` keeps the
+// Vault usable rather than bricking the whole app past one bad operation — the
+// Vault's own truth is the append-only log + CAS, not transient in-memory state,
+// so a recovered guard is safe.
 fn lock<'a>(s: &'a State<'a, AppState>) -> Result<std::sync::MutexGuard<'a, Vault>, String> {
     Ok(s.vault
         .lock()
@@ -319,15 +322,14 @@ pub fn render_dicom(state: State<AppState>, id: i64) -> Result<tauri::ipc::Respo
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("source_file {id} not found"))?;
     let bytes = std::fs::read(v.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
-    // 面板级 panic 防火墙:畸形/敌意 DICOM 可能让解码器 panic —— 用 catch_unwind
-    // 隔离,转成命令的正常 Err(前端已能处理),既不 unwind 命令线程也不污染 Vault
-    // 锁。dicom 库本身已有内部守护,这里是边界处的纵深防御。
-    let png = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        dicom::render_png(&bytes)
-    })) {
-        Ok(r) => r.map_err(|e| e.to_string())?,
-        Err(_) => return Err("DICOM 渲染时发生内部错误(已隔离)".to_string()),
-    };
+    // SECURITY (advisory GHSA-24px): decode the pixels in a short-lived, isolated
+    // child process rather than in-process. The vendored C/C++ JPEG2000/JPEG-LS
+    // codecs are a memory-corruption RCE surface that `catch_unwind` cannot
+    // contain; the subprocess boundary confines any crash/exploit to the child,
+    // which can't touch the vault or this process. A non-zero exit / timeout /
+    // oversized output comes back as an `Err` and degrades like an unsupported
+    // transfer syntax (the frontend already handles that). See `dicom_subprocess`.
+    let png = crate::dicom_subprocess::render_png(&bytes)?;
     Ok(tauri::ipc::Response::new(png))
 }
 
@@ -348,14 +350,11 @@ pub fn decode_dicom_frame(
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("source_file {source_file_id} not found"))?;
     let bytes = std::fs::read(v.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
-    // 面板级 panic 防火墙(同 render_dicom):压缩传输语法解码路径尤其可能 panic。
-    let frame = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        dicom::decode_frame(&bytes, frame_index)
-    })) {
-        Ok(r) => r.map_err(|e| e.to_string())?,
-        Err(_) => return Err("DICOM 解码时发生内部错误(已隔离)".to_string()),
-    };
-    let wire = frame.into_ipc_bytes().map_err(|e| e.to_string())?;
+    // SECURITY (advisory GHSA-24px): same isolation as `render_dicom` — the
+    // compressed-transfer-syntax decode path (JPEG2000/JPEG-LS via C/C++) runs in
+    // the isolated child process, which returns the IPC bytes (header + raw
+    // pixels) on success or degrades on crash/timeout. See `dicom_subprocess`.
+    let wire = crate::dicom_subprocess::decode_frame_ipc(&bytes, frame_index)?;
     Ok(tauri::ipc::Response::new(wire))
 }
 

--- a/apps/desktop/src-tauri/src/dicom_subprocess.rs
+++ b/apps/desktop/src-tauri/src/dicom_subprocess.rs
@@ -1,0 +1,255 @@
+//! Out-of-process DICOM pixel decoding (advisory GHSA-24px).
+//!
+//! The vendored C/C++ JPEG 2000 (OpenJPEG) / JPEG-LS (CharLS) decoders behind
+//! `dicom`'s `codecs` feature are a memory-corruption RCE surface: an
+//! attacker-crafted codestream can corrupt memory *inside the C/C++ library*.
+//! `catch_unwind` does NOT contain that — it is not a memory-safety boundary for
+//! C++ exceptions or segfaults/aborts. So instead of decoding in the main
+//! process (which holds the open vault), desktop decodes pixels in a short-lived
+//! CHILD process — the same binary re-invoked as `medme-desktop --decode-dicom
+//! <mode> [frame_index]`:
+//!
+//!   parent: check_bounds → spawn child → pipe DICOM to stdin → read result
+//!           from stdout, under a timeout + output-size cap
+//!   child:  read DICOM from stdin → decode (C/C++ codecs) → write result to
+//!           stdout → exit 0; any failure → exit non-zero
+//!
+//! A memory-corruption exploit (crash, segfault, abort, hang) in the codec is
+//! therefore confined to the ephemeral child: it can never touch the vault or
+//! the main process. The parent treats a non-zero exit / timeout / oversized
+//! output as "unable to render" and degrades exactly like the existing
+//! unsupported-transfer-syntax path (the frontend already handles that `Err`).
+//!
+//! Valid DICOMs are unaffected: the child produces the identical bytes the old
+//! in-process `dicom::render_png` / `dicom::decode_frame(...).into_ipc_bytes()`
+//! produced, and the parent relays them verbatim.
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Hidden argv flag that switches the binary into decode-child mode. `main.rs`
+/// checks for this before starting Tauri.
+pub const DECODE_FLAG: &str = "--decode-dicom";
+
+/// Child mode: stdout = windowed PNG (`dicom::render_png`).
+const MODE_RENDER: &str = "render";
+/// Child mode: stdout = one frame's IPC bytes (`dicom::decode_frame` →
+/// `into_ipc_bytes`: 4-byte header length + JSON header + raw pixels).
+const MODE_FRAME: &str = "frame";
+
+/// Kill the child if it hasn't finished within this budget — a malicious
+/// codestream can wedge the C/C++ decoder in a long-running loop.
+const CHILD_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Reject a child whose stdout exceeds this. The header size guard
+/// (`dicom::check_bounds`, run in the parent before spawning) already caps
+/// decoded pixels at 512 MiB; this is a second backstop on the wire. PNG is
+/// compressed and a frame is ~raw pixels + a tiny header, so 768 MiB is ample
+/// headroom over any legitimate output.
+const MAX_OUTPUT_BYTES: usize = 768 * 1024 * 1024;
+
+/// Reads from `r` until EOF, failing if more than `cap` bytes arrive.
+fn read_capped(r: &mut impl Read, cap: usize) -> Result<Vec<u8>, String> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        let n = r.read(&mut chunk).map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        if buf.len() + n > cap {
+            return Err("DICOM 解码输出超出上限(已隔离)".to_string());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    Ok(buf)
+}
+
+/// Feeds `input` to `cmd`'s stdin, reads its stdout (capped at `max_output`),
+/// and enforces `timeout` (kill on overrun). Returns the child's stdout on a
+/// clean exit-0; every other outcome — spawn failure, non-zero exit, crash,
+/// timeout, oversized output — is a plain `Err(String)` the caller degrades on.
+///
+/// The command's args must already be set by the caller; this owns the stdio
+/// wiring. Split out from [`run_parent`] (which hard-codes `current_exe()`) so
+/// the timeout/cap/degrade logic is unit-testable against a fake child.
+fn spawn_and_pipe(
+    mut cmd: Command,
+    input: &[u8],
+    timeout: Duration,
+    max_output: usize,
+) -> Result<Vec<u8>, String> {
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| e.to_string())?;
+
+    // Feed stdin from a dedicated thread so a full stdout pipe can't deadlock us
+    // against a child that is blocked writing while we're blocked writing.
+    let mut stdin = child.stdin.take().ok_or("child stdin unavailable")?;
+    let owned_input = input.to_vec();
+    let writer = std::thread::spawn(move || {
+        let _ = stdin.write_all(&owned_input);
+        // stdin drops here → child sees EOF on its input.
+    });
+
+    // Drain stdout (capped) on another thread, so the main thread is free to
+    // enforce the wall-clock timeout via try_wait.
+    let mut stdout = child.stdout.take().ok_or("child stdout unavailable")?;
+    let reader = std::thread::spawn(move || read_capped(&mut stdout, max_output));
+
+    // Poll for exit up to the deadline; kill (and reap) on timeout.
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err("DICOM 解码超时(已隔离)".to_string());
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    };
+
+    let _ = writer.join();
+    let output = reader
+        .join()
+        .map_err(|_| "decode reader thread panicked".to_string())??;
+
+    // Non-zero exit = decode failure OR a codec crash/abort on a malicious
+    // codestream → degrade like an unsupported transfer syntax.
+    if !status.success() {
+        return Err("DICOM 解码失败(已隔离)".to_string());
+    }
+    Ok(output)
+}
+
+/// Parent side: spawn the isolated decode child (this binary, re-invoked with
+/// [`DECODE_FLAG`] + `mode_args`), feed it `dcm_bytes` on stdin, and return its
+/// stdout.
+fn run_parent(mode_args: &[&str], dcm_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    // Cheap, pure-Rust header guard in the MAIN process: reject decode/
+    // decompression bombs before we even spawn the codec child.
+    dicom::check_bounds(dcm_bytes).map_err(|e| e.to_string())?;
+
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let mut cmd = Command::new(exe);
+    cmd.arg(DECODE_FLAG).args(mode_args);
+    spawn_and_pipe(cmd, dcm_bytes, CHILD_TIMEOUT, MAX_OUTPUT_BYTES)
+}
+
+/// Decode a DICOM to a windowed PNG in an isolated child process. Drop-in
+/// replacement for the old in-process `dicom::render_png`.
+pub fn render_png(dcm_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    run_parent(&[MODE_RENDER], dcm_bytes)
+}
+
+/// Decode one DICOM frame to IPC bytes (header + raw pixels) in an isolated
+/// child process. Drop-in replacement for the old in-process
+/// `dicom::decode_frame(..).into_ipc_bytes()`.
+pub fn decode_frame_ipc(dcm_bytes: &[u8], frame_index: u32) -> Result<Vec<u8>, String> {
+    run_parent(&[MODE_FRAME, &frame_index.to_string()], dcm_bytes)
+}
+
+/// Child side: run one decode from stdin→stdout and return the process exit
+/// code. `args` is the argv slice *after* [`DECODE_FLAG`] (mode, then optional
+/// frame index). This is where the C/C++ codecs actually run, isolated from the
+/// main process. Every failure maps to a non-zero code.
+///
+///   0 = success · 1 = I/O error · 2 = unknown mode · 3 = decode failure
+pub fn run_child(args: &[String]) -> i32 {
+    let mut input = Vec::new();
+    if std::io::stdin().read_to_end(&mut input).is_err() {
+        return 1;
+    }
+
+    // `render_png` / `decode_frame` re-run the header size guard internally, so
+    // the child is bounds-checked too (defense in depth alongside the parent's
+    // pre-spawn `check_bounds`).
+    let result = match args.first().map(String::as_str) {
+        Some(MODE_RENDER) => dicom::render_png(&input),
+        Some(MODE_FRAME) => {
+            let idx: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+            dicom::decode_frame(&input, idx).and_then(|f| f.into_ipc_bytes())
+        }
+        _ => return 2,
+    };
+
+    match result {
+        Ok(bytes) => {
+            let mut out = std::io::stdout();
+            if out.write_all(&bytes).is_err() || out.flush().is_err() {
+                return 1;
+            }
+            0
+        }
+        Err(_) => 3,
+    }
+}
+
+// Unit tests for the parent-side spawn/timeout/cap/degrade wrapper, driven
+// against fake children (small `/bin/sh` programs) so we exercise every failure
+// branch without needing the real codec child. The real end-to-end round trip
+// through `run_child` (stdin DICOM → stdout PNG/IPC) is covered by the
+// custom-harness integration test `tests/dicom_subprocess_roundtrip.rs`.
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn sh(script: &str) -> Command {
+        let mut c = Command::new("/bin/sh");
+        c.arg("-c").arg(script);
+        c
+    }
+
+    #[test]
+    fn relays_child_stdout_on_success() {
+        // `cat` echoes our stdin straight back → parent returns it verbatim.
+        let out = spawn_and_pipe(sh("cat"), b"round trip", Duration::from_secs(5), 1 << 20)
+            .expect("clean exit-0 child");
+        assert_eq!(out, b"round trip");
+    }
+
+    #[test]
+    fn nonzero_exit_degrades() {
+        let err = spawn_and_pipe(sh("exit 7"), b"x", Duration::from_secs(5), 1 << 20)
+            .expect_err("non-zero exit must degrade");
+        assert!(err.contains("已隔离"), "expected degrade error, got: {err}");
+    }
+
+    #[test]
+    fn timeout_kills_and_degrades() {
+        // Child sleeps well past the 150ms budget → parent kills it and degrades.
+        let start = Instant::now();
+        let err = spawn_and_pipe(sh("sleep 30"), b"x", Duration::from_millis(150), 1 << 20)
+            .expect_err("a hung child must time out");
+        assert!(err.contains("超时"), "expected a timeout error, got: {err}");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "kill was not prompt"
+        );
+    }
+
+    #[test]
+    fn oversized_output_degrades() {
+        // Child floods stdout with far more than the 1 KiB cap → parent rejects.
+        let err = spawn_and_pipe(
+            sh("head -c 100000 /dev/zero"),
+            b"x",
+            Duration::from_secs(5),
+            1024,
+        )
+        .expect_err("output over the cap must degrade");
+        assert!(
+            err.contains("上限"),
+            "expected an output-cap error, got: {err}"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,8 @@
 mod commands;
+/// Out-of-process DICOM pixel decode (advisory GHSA-24px). `pub` so `main.rs`
+/// can dispatch the hidden `--decode-dicom` child subcommand, and the
+/// integration test can drive the same round trip.
+pub mod dicom_subprocess;
 mod dto;
 mod inbox;
 mod vault_loc;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,5 +2,21 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Hidden decode-child subcommand (advisory GHSA-24px): when spawned as
+    // `medme-desktop --decode-dicom <mode> [frame_index]`, this process is the
+    // isolated DICOM pixel decoder — read DICOM from stdin, decode via the C/C++
+    // codecs, write the result to stdout, exit. It must be handled BEFORE the
+    // normal Tauri run so the child never opens the vault or a window. A codec
+    // memory-corruption exploit is thus confined to this ephemeral child; the
+    // parent (see `commands::render_dicom` / `decode_dicom_frame`) treats a
+    // crash/timeout as an "unable to render" degrade.
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(pos) = args
+        .iter()
+        .position(|a| a == desktop_lib::dicom_subprocess::DECODE_FLAG)
+    {
+        std::process::exit(desktop_lib::dicom_subprocess::run_child(&args[pos + 1..]));
+    }
+
     desktop_lib::run()
 }

--- a/apps/desktop/src-tauri/tests/dicom_subprocess_roundtrip.rs
+++ b/apps/desktop/src-tauri/tests/dicom_subprocess_roundtrip.rs
@@ -1,0 +1,81 @@
+//! End-to-end round trip for the isolated DICOM decode subprocess (GHSA-24px).
+//!
+//! Custom harness (`harness = false`) so THIS test binary can play both roles:
+//! when re-invoked with `--decode-dicom …` by the parent wrapper it runs the
+//! decode child; otherwise it runs the assertions, which call the real parent
+//! functions (`render_png` / `decode_frame_ipc`). Those spawn `current_exe()`
+//! (this binary) with the hidden flag, so we exercise the genuine stdin→decode
+//! →stdout path — the same code `commands::render_dicom` uses in production —
+//! without having to build the full Tauri binary.
+//!
+//! A normal `libtest` harness can't do this: it would try to parse
+//! `--decode-dicom` as a test filter and abort before our child code runs.
+
+use std::path::Path;
+
+fn sample(name: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../examples/demo-dataset/dicom")
+        .join(name);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn main() {
+    // Child role: this same binary, re-spawned by the parent wrapper.
+    let argv: Vec<String> = std::env::args().collect();
+    if let Some(pos) = argv
+        .iter()
+        .position(|a| a == desktop_lib::dicom_subprocess::DECODE_FLAG)
+    {
+        std::process::exit(desktop_lib::dicom_subprocess::run_child(&argv[pos + 1..]));
+    }
+
+    // Parent/test role.
+    valid_dicom_renders_to_png();
+    valid_frame_decodes_to_ipc_bytes();
+    child_decode_failure_degrades();
+    bogus_bytes_degrade();
+    println!("dicom_subprocess_roundtrip: all checks passed");
+}
+
+/// A valid uncompressed DICOM round-trips to a real PNG through the child.
+fn valid_dicom_renders_to_png() {
+    let png = desktop_lib::dicom_subprocess::render_png(&sample("CT_small.dcm"))
+        .expect("valid DICOM should render via the subprocess");
+    assert_eq!(
+        &png[..8],
+        b"\x89PNG\r\n\x1a\n",
+        "child stdout must be a real PNG"
+    );
+}
+
+/// The frame path round-trips the IPC buffer (header length + JSON + pixels).
+fn valid_frame_decodes_to_ipc_bytes() {
+    let wire = desktop_lib::dicom_subprocess::decode_frame_ipc(&sample("CT_small.dcm"), 0)
+        .expect("valid frame should decode via the subprocess");
+    let hlen = u32::from_le_bytes(wire[0..4].try_into().unwrap()) as usize;
+    assert!(
+        wire.len() > 4 + hlen,
+        "IPC buffer must carry pixels after its header"
+    );
+}
+
+/// A valid header but an out-of-range frame index passes the parent's
+/// pre-spawn bounds check, reaches the child, and makes it exit non-zero — the
+/// parent must degrade (this is the "codec crash confined to child" path).
+fn child_decode_failure_degrades() {
+    let err = desktop_lib::dicom_subprocess::decode_frame_ipc(&sample("CT_small.dcm"), 9999)
+        .expect_err("an undecodable request must degrade, not succeed");
+    assert!(
+        err.contains("已隔离"),
+        "child non-zero exit should degrade, got: {err}"
+    );
+}
+
+/// Non-DICOM bytes are rejected up front by the parent's header guard (they
+/// never even reach the child) — still a graceful degrade.
+fn bogus_bytes_degrade() {
+    let err = desktop_lib::dicom_subprocess::render_png(b"definitely not a dicom file")
+        .expect_err("bogus input must degrade, not succeed");
+    assert!(!err.is_empty(), "degrade must carry an error message");
+}

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -24,10 +24,20 @@ serde_json = "1"
 core-model = { path = "../../../packages/core-model" }
 pipeline = { path = "../../../packages/pipeline" }
 parser = { path = "../../../packages/parser" }
-# DICOM: default-features off here so the Android build does NOT compile the
-# vendored C/C++ pixel codecs (OpenJPEG/CharLS) — they can't cross-compile via
-# cmake for the Android NDK, and mobile does no DICOM pixel viewing. iOS keeps
-# them (re-enabled in the target block below) so iOS behavior is unchanged.
+# DICOM: default-features off for ALL mobile targets (iOS + Android) so the
+# vendored C/C++ pixel codecs (OpenJPEG for JPEG 2000, CharLS for JPEG-LS) are
+# never compiled or linked into a mobile build. Rationale:
+#   * Mobile never *views* DICOM pixels (capture + records + share only), so
+#     dropping the codecs is zero functional loss — the DICOM path degrades to
+#     metadata-only / "unsupported preview" via `dicom`'s existing pure-Rust
+#     fallback (`parse_meta` + `render_png`/`decode_frame` still compile, only
+#     J2K/JPEG-LS transfer syntaxes become unsupported at runtime).
+#   * Security (advisory GHSA-24px): those C/C++ decoders are a memory-corruption
+#     RCE surface. Not linking them removes the surface from mobile entirely.
+#   * Android additionally can't cross-compile them (cmake-rs + CMake 4.x vs the
+#     NDK); iOS could, but has no reason to carry the surface — and it also
+#     shrinks the iOS binary.
+# There is intentionally NO per-target re-enable of `codecs` below.
 dicom = { path = "../../../packages/dicom", default-features = false }
 # OCR: default-features off here (no `engine`, no `auto-download`) so the plain
 # host build stays lean. The per-OS target blocks below re-enable the engine for
@@ -40,12 +50,13 @@ medme-share = { path = "../../../packages/share" }
 chrono.workspace = true
 anyhow.workspace = true
 
-# iOS keeps the full DICOM pixel codecs (unchanged from before this split):
-# Apple targets cross-compile the C/C++ libs fine. Only Android drops them.
-# Same for OCR: iOS keeps oar-ocr/ONNX Runtime for scanned-PDF OCR; Android
-# drops it (doesn't work there, and it's the bulk of the debug .so's size).
+# iOS: OCR keeps oar-ocr/ONNX Runtime for scanned-PDF OCR (Apple targets
+# cross-compile it fine; Android drops it, doing OCR via shipped model files).
+# NOTE: iOS deliberately does NOT re-enable the DICOM `codecs` feature anymore
+# (it used to). Mobile never views DICOM pixels, so the vendored C/C++ JPEG2000
+# /JPEG-LS decoders — a memory-corruption RCE surface (GHSA-24px) — are no
+# longer linked into the iOS binary. See the base `dicom` dep above.
 [target.'cfg(target_os = "ios")'.dependencies]
-dicom = { path = "../../../packages/dicom", features = ["codecs"] }
 ocr = { path = "../../../packages/ocr", features = ["engine"] }
 
 # Android: enable the OCR `engine` but NOT `auto-download`. oar-ocr + ONNX

--- a/packages/dicom/src/lib.rs
+++ b/packages/dicom/src/lib.rs
@@ -149,6 +149,18 @@ fn check_decode_bounds(obj: &FileDicomObject<InMemDicomObject>) -> anyhow::Resul
     Ok(())
 }
 
+/// Parses just the DICOM header and runs the pre-decode size guard
+/// ([`check_decode_bounds`]) — WITHOUT decoding any pixels or invoking the C/C++
+/// codecs. This is the cheap, pure-Rust check the desktop app runs in its MAIN
+/// process to reject decode/decompression bombs BEFORE handing the bytes to the
+/// isolated decode subprocess (advisory GHSA-24px). Returns `Ok(())` when the
+/// declared decoded size is within [`MAX_DECODE_BYTES`].
+pub fn check_bounds(dcm_bytes: &[u8]) -> anyhow::Result<()> {
+    let obj = dicom_object::from_reader(Cursor::new(dcm_bytes))
+        .context("failed to parse DICOM object")?;
+    check_decode_bounds(&obj)
+}
+
 /// Decodes the first frame's pixel data and renders it as an 8-bit,
 /// windowed (VOI LUT applied when present) grayscale PNG.
 ///
@@ -477,6 +489,20 @@ mod tests {
         let bytes = sample("CT_small.dcm");
         assert!(render_png(&bytes).is_ok());
         assert!(decode_frame(&bytes, 0).is_ok());
+    }
+
+    #[test]
+    fn check_bounds_matches_the_decode_guards() {
+        // The pure-Rust pre-spawn guard the desktop main process runs: passes a
+        // sane instance, rejects oversized declared dimensions — same verdict as
+        // the in-decode `check_decode_bounds`, but without touching pixels/codecs.
+        assert!(check_bounds(&sample("CT_small.dcm")).is_ok());
+        let err = check_bounds(&oversized_dcm(60000, 60000))
+            .expect_err("oversized dims must be rejected pre-decode");
+        assert!(
+            err.to_string().contains("decode cap"),
+            "expected the size-cap guard to fire, got: {err:#}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Contains the JPEG2000/JPEG-LS C/C++ codec RCE surface (**GHSA-24px**). Decoding an attacker-crafted compressed DICOM runs untrusted bytes through openjpeg-sys/charls; `catch_unwind` is **not** a memory-safety boundary for C++/segfaults.

Policy (decided): **mobile drops the codecs; desktop keeps rendering but isolates the decode in a short-lived subprocess.**

## Mobile
iOS now inherits the codec-free base `dicom` dep (Android already did) — no more openjpeg-sys/charls linked (verified via `cargo tree --target aarch64-apple-ios`). Mobile never views DICOM pixels → **zero functional loss**; J2K/JPEG-LS degrade to metadata-only.

## Desktop
- New `dicom_subprocess` module + hidden `--decode-dicom` child: reads DICOM from stdin, decodes via the existing `render_png`/`decode_frame`, writes bytes to stdout, exits non-zero on failure — never opens the vault or a window.
- `render_dicom`/`decode_dicom_frame` run the cheap header `check_bounds` in-process (reject decode bombs early), then spawn the child with a **15s timeout + 768 MiB output cap**; crash/timeout/non-zero exit → degrade to "unable to render" (same UX). A codec memory exploit is confined to the ephemeral child, off the vault + main process.
- **Valid DICOMs are byte-for-byte preserved.**

## Tests
`dicom::check_bounds`; fake-child unit tests for the parent's success / non-zero-exit / timeout / output-cap branches; a real end-to-end roundtrip (custom harness that re-execs itself as the child). `cargo fmt/clippy/check` clean; `dicom` 18 pass, `medme-desktop` 9 unit + integration pass.

## ⚠️ Residual (follow-up — keep GHSA-24px open)
`packages/share` (`share.rs`/`export.rs`) also calls `dicom::render_png` **in-process** at share/export creation. `share` builds `dicom` with `default-features=false`, but in the **desktop** workspace build Cargo feature-unification turns codecs ON for the shared dep — so building a share/export from an attacker-supplied DICOM still decodes in-process. Natural follow-up: route that path through the same subprocess. This PR closes the two view-time commands; the share-creation path remains.

## Gate
`cargo fmt` clean · `cargo clippy -p dicom -p medme-desktop -- -D warnings` clean · `cargo test -p dicom` (18) · `cargo test -p medme-desktop` (9 + integration) · `cargo check -p medme-desktop`.