### PR TITLE
fix(security): authenticate append-only log + verify CAS on read (GHSA-m96x, stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ name = "core-model"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "hmac",
  "jieba-rs",
  "regex",
  "rusqlite",
@@ -1516,6 +1517,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -2538,6 +2540,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac-sha256"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["packages/core-model", "packages/parser", "packages/terminology", "pa
 [workspace.dependencies]
 rusqlite = { version = "0.32", features = ["bundled"] }
 sha2 = "0.10"
+hmac = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 anyhow = "1"

--- a/packages/core-model/Cargo.toml
+++ b/packages/core-model/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 rusqlite.workspace = true
 sha2.workspace = true
+hmac.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 jieba-rs.workspace = true

--- a/packages/core-model/src/cas.rs
+++ b/packages/core-model/src/cas.rs
@@ -66,6 +66,34 @@ impl Vault {
         Ok((hash, rel, true))
     }
 
+    /// Read a CAS object and VERIFY it: re-compute sha256 of the bytes and
+    /// require it to equal `hash`. A shared-folder attacker can swap an object's
+    /// bytes (the file is trusted only by its path/filename today); this makes
+    /// every untrusted read self-checking so poisoned/corrupt content is
+    /// rejected instead of trusted. `hash` is validated with `is_object_hash`
+    /// (64-hex) BEFORE building a path, so a forged/malformed hash can't panic
+    /// on the `[0..2]`/`[2..4]` slice or escape `objects/`.
+    ///
+    /// Errors: `Other` for a malformed hash or an integrity mismatch; `Io`
+    /// (kind `NotFound`) when the object hasn't synced in yet — callers that
+    /// tolerate a missing blob (e.g. deferred materialize) match on that.
+    pub fn read_object(&self, hash: &str) -> Result<Vec<u8>, MedmeError> {
+        if !is_object_hash(hash) {
+            return Err(MedmeError::Other(format!(
+                "refusing to read CAS object with malformed hash: {hash:?}"
+            )));
+        }
+        let rel = object_relpath(hash);
+        let bytes = std::fs::read(self.root().join(&rel))?;
+        let actual = sha256_hex(&bytes);
+        if actual != hash {
+            return Err(MedmeError::Other(format!(
+                "CAS object {hash} failed integrity check (bytes hash to {actual}) — poisoned or corrupt"
+            )));
+        }
+        Ok(bytes)
+    }
+
     /// vault 根目录的绝对路径 —— 用于展示给用户(如设置页“数据保险箱位置”)、
     /// 或引导其把该目录放进 iCloud/坚果云等云同步目录以实现多设备同步。
     pub fn root(&self) -> &Path {
@@ -138,5 +166,51 @@ mod tests {
             }
         }
         n
+    }
+
+    #[test]
+    fn read_object_returns_good_bytes_and_rejects_poisoned() {
+        use crate::MedmeError;
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let (h, _, _) = v.store_object(b"hello medme").unwrap();
+
+        // Good bytes: verified read returns them.
+        assert_eq!(v.read_object(&h).unwrap(), b"hello medme");
+
+        // Poison the object: overwrite its file with different bytes (a
+        // shared-folder attacker swapping content behind a trusted filename).
+        let obj = dir.path().join(object_relpath(&h));
+        std::fs::write(&obj, b"evil swapped bytes").unwrap();
+        match v.read_object(&h) {
+            Err(MedmeError::Other(msg)) => assert!(
+                msg.contains("integrity"),
+                "poisoned object must fail integrity, got: {msg}"
+            ),
+            other => panic!("expected integrity error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_object_rejects_malformed_hash_and_reports_missing() {
+        use crate::MedmeError;
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+
+        // Malformed / attacker-controlled hashes never touch the filesystem.
+        for bad in ["../../etc/passwd", "abc", ""] {
+            match v.read_object(bad) {
+                Err(MedmeError::Other(_)) => {}
+                other => panic!("malformed hash {bad:?} must be rejected, got {other:?}"),
+            }
+        }
+
+        // A well-formed but not-yet-synced object reports NotFound (callers
+        // treat that as "defer", distinct from an integrity failure).
+        let missing = sha256_hex(b"never stored");
+        match v.read_object(&missing) {
+            Err(MedmeError::Io(e)) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+            other => panic!("missing object must be Io(NotFound), got {other:?}"),
+        }
     }
 }

--- a/packages/core-model/src/event.rs
+++ b/packages/core-model/src/event.rs
@@ -6,8 +6,16 @@
 //! independent of any particular SQLite database.
 
 use crate::MedmeError;
+use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Genesis `prev_hash` for the first entry of a log segment: 64 hex zeros. A
+/// well-formed chain therefore always starts here, so a segment whose first
+/// entry's `prev_hash` is anything else has been truncated at the head.
+pub const GENESIS_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
 /// Stable reference to a document via its source file's content hash.
 /// v0.1 has one document per source file (`UNIQUE(source_file_id)`), so the
@@ -84,6 +92,16 @@ pub enum Event {
 
 /// One line in the append-only log: an `Event` plus the envelope needed for
 /// ordering, dedup, and (future) sync.
+///
+/// `prev_hash` + `mac` make the synced log tamper-evident and authenticated
+/// (advisory GHSA-m96x). `prev_hash` chains each entry to the previous one in
+/// the SAME segment (sha256 of the previous entry's canonical bytes; genesis =
+/// [`GENESIS_HASH`]) so insert/delete/reorder are detectable. `mac` is an
+/// HMAC-SHA256 over the entry's canonical bytes keyed by the per-vault secret,
+/// so a shared-folder writer without the key cannot forge or tamper an entry
+/// undetected. Both are `Option` and `#[serde(default)]` so legacy logs written
+/// before this change still deserialize (they migrate on open — see
+/// `log::EventLog::migrate_and_seal`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEntry {
     /// sha256 of the canonical JSON of `event` alone (not this envelope) —
@@ -94,9 +112,22 @@ pub struct LogEntry {
     pub device_id: String,
     #[serde(flatten)]
     pub event: Event,
+    /// sha256 of the previous entry's canonical bytes in this segment
+    /// (`GENESIS_HASH` for the first). `None` only for a not-yet-migrated
+    /// legacy entry.
+    #[serde(default)]
+    pub prev_hash: Option<String>,
+    /// HMAC-SHA256 (hex) over this entry's canonical bytes, keyed by the
+    /// per-vault secret. `None` when written without a key (chain-only mode)
+    /// or by a legacy build.
+    #[serde(default)]
+    pub mac: Option<String>,
 }
 
 impl LogEntry {
+    /// Build an UNSEALED entry (`prev_hash`/`mac` unset). Sealing — computing
+    /// the chain link and MAC — happens at append time in
+    /// `log::EventLog::append`, which knows the segment tail and the key.
     pub fn new(seq: i64, ts: String, device_id: String, event: Event) -> Result<Self, MedmeError> {
         Ok(LogEntry {
             event_id: event_id(&event)?,
@@ -104,7 +135,77 @@ impl LogEntry {
             ts,
             device_id,
             event,
+            prev_hash: None,
+            mac: None,
         })
+    }
+
+    /// THE canonical serialization of the authenticated fields — the single
+    /// source of bytes for BOTH the chain hash and the MAC, so the two can
+    /// never drift. Serde emits `Canonical`'s fields in declaration order (the
+    /// same determinism `event_id` already relies on), giving a stable,
+    /// reproducible byte string. A missing `prev_hash` folds to `GENESIS_HASH`
+    /// so a legacy entry hashes identically before and after migration.
+    pub(crate) fn canonical_bytes(&self) -> Result<Vec<u8>, MedmeError> {
+        #[derive(Serialize)]
+        struct Canonical<'a> {
+            seq: i64,
+            ts: &'a str,
+            device_id: &'a str,
+            prev_hash: &'a str,
+            event: &'a Event,
+        }
+        let bytes = serde_json::to_vec(&Canonical {
+            seq: self.seq,
+            ts: &self.ts,
+            device_id: &self.device_id,
+            prev_hash: self.prev_hash.as_deref().unwrap_or(GENESIS_HASH),
+            event: &self.event,
+        })?;
+        Ok(bytes)
+    }
+
+    /// The chain link this entry contributes: sha256 of its canonical bytes.
+    /// The next entry in the segment stores this as its `prev_hash`.
+    pub(crate) fn chain_hash(&self) -> Result<String, MedmeError> {
+        Ok(crate::cas::sha256_hex(&self.canonical_bytes()?))
+    }
+
+    /// HMAC-SHA256 (hex) of this entry's canonical bytes under `key`.
+    pub(crate) fn compute_mac(&self, key: &[u8]) -> Result<String, MedmeError> {
+        // `new_from_slice` only errors on key lengths HMAC can't accept; HMAC
+        // accepts ANY length (it hashes/pads), so this never fails.
+        let mut mac =
+            HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts a key of any length");
+        mac.update(&self.canonical_bytes()?);
+        Ok(hex(&mac.finalize().into_bytes()))
+    }
+
+    /// Constant-time verify of `self.mac` against a freshly computed MAC over
+    /// the canonical bytes. `false` if the MAC is absent, malformed, or wrong.
+    pub(crate) fn verify_mac(&self, key: &[u8]) -> Result<bool, MedmeError> {
+        let Some(stored) = self.mac.as_deref() else {
+            return Ok(false);
+        };
+        let Some(tag) = hex_decode(stored) else {
+            return Ok(false);
+        };
+        let mut mac =
+            HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts a key of any length");
+        mac.update(&self.canonical_bytes()?);
+        Ok(mac.verify_slice(&tag).is_ok())
+    }
+
+    /// Stamp `prev_hash` and (when a key is present) `mac` onto this entry,
+    /// making it a sealed, verifiable log line. Called by `EventLog::append`
+    /// with the segment's tail hash and the vault key, and by migration.
+    pub(crate) fn seal(&mut self, prev_hash: String, key: Option<&[u8]>) -> Result<(), MedmeError> {
+        self.prev_hash = Some(prev_hash);
+        self.mac = match key {
+            Some(k) => Some(self.compute_mac(k)?),
+            None => None,
+        };
+        Ok(())
     }
 }
 
@@ -116,6 +217,26 @@ fn event_id(event: &Event) -> Result<String, MedmeError> {
     let mut h = Sha256::new();
     h.update(&bytes);
     Ok(format!("{:x}", h.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Decode a lowercase/uppercase hex string to bytes; `None` if it isn't valid
+/// even-length hex (a malformed stored MAC then simply fails verification).
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
 }
 
 #[cfg(test)]
@@ -153,5 +274,77 @@ mod tests {
         assert_eq!(back.event_id, entry.event_id);
         assert_eq!(back.seq, entry.seq);
         assert_eq!(back.event, entry.event);
+    }
+
+    /// A truly legacy line (no `prev_hash`/`mac` keys at all) still parses,
+    /// with both folding to `None` via `#[serde(default)]`.
+    #[test]
+    fn legacy_entry_without_prev_hash_or_mac_parses() {
+        let legacy = r#"{"event_id":"x","seq":1,"ts":"2024-01-01T00:00:00Z","device_id":"dev1","type":"FileImported","content_hash":"abc","original_name":"a.pdf","mime_type":"application/pdf","byte_size":3,"imported_at":"2024-01-01T00:00:00Z"}"#;
+        let e: LogEntry = serde_json::from_str(legacy).unwrap();
+        assert!(e.prev_hash.is_none());
+        assert!(e.mac.is_none());
+    }
+
+    const KEY: &[u8] = &[7u8; 32];
+
+    fn entry(seq: i64) -> LogEntry {
+        LogEntry::new(
+            seq,
+            "2024-01-01T00:00:00Z".into(),
+            "dev1".into(),
+            imported(seq),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn canonical_bytes_are_deterministic_and_prev_hash_sensitive() {
+        let mut a = entry(1);
+        a.prev_hash = Some(GENESIS_HASH.to_string());
+        let mut b = entry(1);
+        b.prev_hash = Some(GENESIS_HASH.to_string());
+        assert_eq!(a.canonical_bytes().unwrap(), b.canonical_bytes().unwrap());
+        // Changing prev_hash changes the canonical bytes (so the chain links).
+        b.prev_hash = Some("f".repeat(64));
+        assert_ne!(a.canonical_bytes().unwrap(), b.canonical_bytes().unwrap());
+        // A missing prev_hash folds to GENESIS_HASH — identical bytes.
+        let mut c = entry(1);
+        c.prev_hash = None;
+        assert_eq!(a.canonical_bytes().unwrap(), c.canonical_bytes().unwrap());
+    }
+
+    #[test]
+    fn mac_round_trips_and_detects_tamper() {
+        let mut e = entry(1);
+        e.seal(GENESIS_HASH.to_string(), Some(KEY)).unwrap();
+        assert!(e.prev_hash.is_some() && e.mac.is_some());
+        assert!(e.verify_mac(KEY).unwrap(), "fresh MAC verifies");
+
+        // Wrong key fails.
+        assert!(!e.verify_mac(&[9u8; 32]).unwrap());
+
+        // Tamper the event content → MAC no longer verifies (mac field stale).
+        let mut tampered = e.clone();
+        tampered.event = imported(999);
+        assert!(
+            !tampered.verify_mac(KEY).unwrap(),
+            "tampered content fails MAC"
+        );
+
+        // Absent / malformed stored MAC fails cleanly (no panic).
+        let mut nomac = e.clone();
+        nomac.mac = None;
+        assert!(!nomac.verify_mac(KEY).unwrap());
+        nomac.mac = Some("nothex!!".into());
+        assert!(!nomac.verify_mac(KEY).unwrap());
+    }
+
+    #[test]
+    fn seal_without_key_sets_chain_but_no_mac() {
+        let mut e = entry(1);
+        e.seal(GENESIS_HASH.to_string(), None).unwrap();
+        assert_eq!(e.prev_hash.as_deref(), Some(GENESIS_HASH));
+        assert!(e.mac.is_none(), "chain-only seal leaves MAC unset");
     }
 }

--- a/packages/core-model/src/lib.rs
+++ b/packages/core-model/src/lib.rs
@@ -25,6 +25,12 @@ use rusqlite::Connection;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};
 
+/// Minimum accepted per-vault MAC key length, in bytes. HMAC-SHA256's block is
+/// 32 bytes; a key at least this long carries full-strength entropy, so shorter
+/// keys (an empty or truncated secret) are rejected at the `open_*_with_key`
+/// boundary rather than silently padded and treated as "authenticated".
+const MIN_MAC_KEY_LEN: usize = 32;
+
 /// Truth = `objects/` (CAS) + `log/` (append-only event log).
 /// `medme.db` is a derived cache, materialized by replaying the log; it can
 /// be deleted and rebuilt (see `materialize::Vault::rebuild_from_log`).
@@ -47,7 +53,7 @@ impl Vault {
     /// id and write to the SAME per-device log segment — defeating the
     /// conflict-free per-device segmentation.
     pub fn open(root: &Path) -> Result<Vault, MedmeError> {
-        Self::open_inner(root, &root.join("medme.db"), None)
+        Self::open_inner(root, &root.join("medme.db"), None, None)
     }
 
     /// Like [`Vault::open`], but forces `device_id` to the given machine-local
@@ -59,7 +65,7 @@ impl Vault {
     /// segment. Existing segments (written under whatever id) are untouched and
     /// still read back by `read_all`.
     pub fn open_with_device_id(root: &Path, device_id: &str) -> Result<Vault, MedmeError> {
-        Self::open_inner(root, &root.join("medme.db"), Some(device_id))
+        Self::open_inner(root, &root.join("medme.db"), Some(device_id), None)
     }
 
     /// Open a vault whose **truth** (`objects/` + `log/`) lives under
@@ -81,7 +87,39 @@ impl Vault {
         db_path: &Path,
         device_id: &str,
     ) -> Result<Vault, MedmeError> {
-        Self::open_inner(truth_root, db_path, Some(device_id))
+        Self::open_inner(truth_root, db_path, Some(device_id), None)
+    }
+
+    /// Like [`Vault::open`], but with the per-vault MAC `key` injected so the
+    /// append-only log is authenticated (advisory GHSA-m96x): every appended
+    /// entry gets an HMAC-SHA256 tag, legacy entries are sealed on open, and
+    /// replay quarantines forged/tampered entries. Without a key the other
+    /// constructors run in chain-only mode (structural tamper-EVIDENCE, no
+    /// authentication) so existing callers keep working during the app-layer
+    /// rollout (keychain storage + QR key distribution) that follows this PR.
+    pub fn open_with_key(root: &Path, key: &[u8]) -> Result<Vault, MedmeError> {
+        Self::open_inner(root, &root.join("medme.db"), None, Some(key))
+    }
+
+    /// [`Vault::open_with_device_id`] plus the injected MAC `key` — the shared
+    /// cloud-folder, multi-device case with an authenticated log.
+    pub fn open_with_device_id_and_key(
+        root: &Path,
+        device_id: &str,
+        key: &[u8],
+    ) -> Result<Vault, MedmeError> {
+        Self::open_inner(root, &root.join("medme.db"), Some(device_id), Some(key))
+    }
+
+    /// [`Vault::open_split`] plus the injected MAC `key` — the iOS split
+    /// (truth on iCloud, db local) case with an authenticated log.
+    pub fn open_split_with_key(
+        truth_root: &Path,
+        db_path: &Path,
+        device_id: &str,
+        key: &[u8],
+    ) -> Result<Vault, MedmeError> {
+        Self::open_inner(truth_root, db_path, Some(device_id), Some(key))
     }
 
     /// Shared open logic for [`Vault::open`], [`Vault::open_with_device_id`] and
@@ -95,7 +133,20 @@ impl Vault {
         truth_root: &Path,
         db_path: &Path,
         device_id: Option<&str>,
+        key: Option<&[u8]>,
     ) -> Result<Vault, MedmeError> {
+        // Reject a low-entropy MAC key at the boundary. HMAC accepts any key
+        // length (it pads), so an empty/short per-vault key would run the log
+        // "authenticated" with near-zero entropy — worse than an honest
+        // chain-only open. Fail loudly before touching the vault instead.
+        if let Some(k) = key {
+            if k.len() < MIN_MAC_KEY_LEN {
+                return Err(MedmeError::Other(format!(
+                    "vault MAC key too short: {} bytes (need at least {MIN_MAC_KEY_LEN}) — refusing to run authenticated with a low-entropy key",
+                    k.len()
+                )));
+            }
+        }
         std::fs::create_dir_all(truth_root.join("objects"))?;
         std::fs::write(truth_root.join("VERSION"), "1")?;
         // The db may live outside `truth_root` (split mode); make sure its
@@ -108,7 +159,10 @@ impl Vault {
         schema::migrate(&conn)?;
         schema::ensure_meta_table(&conn)?;
         schema::ensure_imaging_instance_unique_index(&conn)?;
-        let log = log::EventLog::open(truth_root)?;
+        let mut log = log::EventLog::open(truth_root)?;
+        // Inject the MAC key BEFORE any migration/replay, so legacy entries are
+        // sealed with a MAC and the first replay verifies against the key.
+        log.set_key(key.map(|k| k.to_vec()));
 
         let mut vault = Vault {
             conn,
@@ -121,6 +175,12 @@ impl Vault {
             Some(id) => id.to_string(),
             None => vault.ensure_device_id()?,
         };
+
+        // Seal legacy (pre-GHSA-m96x) entries once: add the `prev_hash` chain
+        // and, when a key is present, the `mac`. Idempotent — a no-op on an
+        // already-sealed log. Must precede materialize so the replay below reads
+        // a verified log.
+        vault.log.migrate_and_seal()?;
 
         let log_is_empty = vault.log.is_empty()?;
         let has_existing_rows: i64 =
@@ -196,6 +256,31 @@ mod tests {
         };
         assert_eq!(id1, id2);
         assert!(!id1.is_empty());
+    }
+
+    #[test]
+    fn open_with_key_rejects_short_key_accepts_32_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Empty and undersized keys (1, 31 bytes) are rejected with a clear error
+        // BEFORE the vault is touched — HMAC would otherwise pad them and run
+        // "authenticated" on near-zero entropy.
+        for bad in [vec![], vec![7u8; 1], vec![7u8; 31]] {
+            let n = bad.len();
+            match Vault::open_with_key(dir.path(), &bad) {
+                Err(MedmeError::Other(msg)) => assert!(
+                    msg.contains("key too short"),
+                    "unexpected error for {n}-byte key: {msg}"
+                ),
+                Err(other) => {
+                    panic!("a {n}-byte key must be rejected with a clear error, got {other:?}")
+                }
+                Ok(_) => panic!("a {n}-byte key must be rejected, but the vault opened"),
+            }
+        }
+
+        // A full 32-byte key is accepted and opens the vault.
+        Vault::open_with_key(dir.path(), &[7u8; 32]).unwrap();
     }
 
     // ---- split truth-root / db-path (iCloud sync: truth on iCloud, db local) --

--- a/packages/core-model/src/log.rs
+++ b/packages/core-model/src/log.rs
@@ -13,21 +13,39 @@
 //! merged set reproduces a consistent state regardless of how many devices
 //! contributed or in what filesystem order the segments were enumerated.
 
-use crate::event::LogEntry;
+use crate::event::{LogEntry, GENESIS_HASH};
 use crate::MedmeError;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
 
 pub struct EventLog {
     dir: PathBuf,
+    /// Per-vault 32-byte secret used to HMAC every appended entry and to verify
+    /// entries on read. `None` = chain-only mode (no MAC): entries are still
+    /// chained (`prev_hash`), but that chain is a KEYLESS sha256, so it detects
+    /// only NON-ADVERSARIAL corruption (bit rot / torn writes). A folder-writing
+    /// adversary can insert/delete/reorder and simply RECOMPUTE the whole
+    /// segment's `prev_hash` chain from genesis — every chain check then passes
+    /// with no break logged. Only the keyed MAC gives real tamper/forgery
+    /// detection. Injected by `Vault` via [`EventLog::set_key`]; keychain
+    /// storage + QR distribution of this key is an app-layer follow-up.
+    key: Option<Vec<u8>>,
 }
 
 impl EventLog {
     pub fn open(vault_root: &Path) -> Result<Self, MedmeError> {
         let dir = vault_root.join("log");
         std::fs::create_dir_all(&dir)?;
-        Ok(EventLog { dir })
+        Ok(EventLog { dir, key: None })
+    }
+
+    /// Inject (or clear) the per-vault MAC key. Must be set BEFORE the open-time
+    /// migration/materialize so legacy entries are sealed with a MAC and the
+    /// first replay verifies with the key. See [`crate::Vault::open_with_key`].
+    pub(crate) fn set_key(&mut self, key: Option<Vec<u8>>) {
+        self.key = key;
     }
 
     /// All `.jsonl` segment files in the log dir: every device's per-device
@@ -50,11 +68,21 @@ impl EventLog {
     }
 
     /// Append one event line to the appending device's own segment (keyed by
-    /// `entry.device_id`), creating it on first write.
+    /// `entry.device_id`), creating it on first write. The entry is SEALED here:
+    /// its `prev_hash` is chained to the segment's current tail and its `mac` is
+    /// computed under the vault key (when set), so what lands on disk is always
+    /// tamper-evident and authenticated.
     pub fn append(&self, entry: &LogEntry) -> Result<(), MedmeError> {
         let path = self.device_segment(&entry.device_id);
+        // Chain this entry to the last one already in ITS OWN segment. Appends
+        // to a device's segment are strictly ordered (single writer, monotonic
+        // seq), so file order == chain order.
+        let prev_hash = self.segment_tail_hash(&path)?;
+        let mut sealed = entry.clone();
+        sealed.seal(prev_hash, self.key.as_deref())?;
+
         let mut f = OpenOptions::new().create(true).append(true).open(&path)?;
-        let line = serde_json::to_string(entry)?;
+        let line = serde_json::to_string(&sealed)?;
         writeln!(f, "{line}")?;
         f.flush()?;
         // Durability: fsync the appended line so a "saved" event survives power
@@ -63,21 +91,41 @@ impl EventLog {
         Ok(())
     }
 
-    /// All events across every segment, merged into a deterministic global
-    /// order: primarily by timestamp, tie-broken by `(device_id, seq)`. This
-    /// order is independent of filesystem enumeration, so any device rebuilds
-    /// to the identical state from the same set of segments.
+    /// Chain hash of the last entry currently in `path` — the `prev_hash` the
+    /// next appended entry must carry. `GENESIS_HASH` when the segment is
+    /// absent/empty (a fresh chain) or its tail can't be parsed (a truncated
+    /// last line is ignored; the new entry starts a fresh link from genesis so
+    /// the append never fails on a corrupt tail).
+    fn segment_tail_hash(&self, path: &Path) -> Result<String, MedmeError> {
+        if !path.exists() {
+            return Ok(GENESIS_HASH.to_string());
+        }
+        match read_segment_entries(path)?.last() {
+            Some(tail) => tail.chain_hash(),
+            None => Ok(GENESIS_HASH.to_string()),
+        }
+    }
+
+    /// All *trusted* events across every segment, merged into a deterministic
+    /// global order: primarily by timestamp, tie-broken by `(device_id, seq)`.
+    /// This order is independent of filesystem enumeration, so any device
+    /// rebuilds to the identical state from the same set of segments.
+    ///
+    /// Each segment is verified BEFORE the merge (the chain is per-segment):
+    /// entries with a failing MAC (forged/tampered) and entries after a
+    /// hash-chain break (insert/delete/reorder) are QUARANTINED — skipped and
+    /// logged, never returned to callers, so a shared-folder attacker's writes
+    /// can't poison the replay. A break never aborts the open: the valid prefix
+    /// of every segment still materializes.
     pub fn read_all(&self) -> Result<Vec<LogEntry>, MedmeError> {
         let mut out: Vec<LogEntry> = Vec::new();
         for path in self.segments()? {
-            let f = std::fs::File::open(&path)?;
-            for line in BufReader::new(f).lines() {
-                let line = line?;
-                if line.trim().is_empty() {
-                    continue;
-                }
-                out.push(serde_json::from_str(&line)?);
-            }
+            let entries = read_segment_entries(&path)?;
+            let seg = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("<segment>");
+            out.extend(self.verify_segment(entries, seg));
         }
         out.sort_by(|a, b| {
             a.ts.cmp(&b.ts)
@@ -87,6 +135,141 @@ impl EventLog {
         Ok(out)
     }
 
+    /// Verify one segment's entries (already in file/append order) and return
+    /// only the trusted ones. Two independent checks:
+    ///
+    /// - **MAC** (only when a key is set): recompute the HMAC over each entry's
+    ///   canonical bytes; a mismatch/absence means the entry was forged or
+    ///   tampered → quarantine it. A valid MAC proves the entry (including its
+    ///   `prev_hash`) is exactly as the key holder wrote it.
+    /// - **Chain**: each entry's `prev_hash` must equal the running chain hash.
+    ///   A mismatch is a structural attack (insert/delete/reorder) → quarantine
+    ///   and re-synchronise: the NEXT authentic (MAC-valid) entry is accepted on
+    ///   its own authority and the chain resumes from it. This localises damage
+    ///   — one tampered entry in the middle doesn't discard the authentic
+    ///   entries after it (each still carries a valid MAC) — while every break
+    ///   is still reported.
+    ///
+    /// With no key (chain-only fallback) only the chain is checked, and the
+    /// chain is KEYLESS — it catches bit rot / torn writes, NOT an adversary. A
+    /// folder-writing attacker can insert/delete/reorder AND recompute every
+    /// `prev_hash` from genesis, so the whole segment re-verifies clean with no
+    /// break logged. Chain-only is corruption-detection, not authentication:
+    /// only the MAC (a key) provides real tamper/forgery detection.
+    fn verify_segment(&self, entries: Vec<LogEntry>, seg: &str) -> Vec<LogEntry> {
+        let key = self.key.as_deref();
+        let mut kept: Vec<LogEntry> = Vec::with_capacity(entries.len());
+        // Some(h) = the chain hash the next entry must reference; None = we are
+        // re-syncing after a break and will accept the next authentic entry.
+        let mut expected_prev: Option<String> = Some(GENESIS_HASH.to_string());
+
+        for entry in entries {
+            // 1) Authenticate the entry itself (skipped in chain-only mode).
+            if let Some(k) = key {
+                let ok = entry.verify_mac(k).unwrap_or(false);
+                if !ok {
+                    eprintln!(
+                        "[log] quarantine seq={} in {seg}: MAC verification failed (forged/tampered)",
+                        entry.seq
+                    );
+                    // Its bytes are untrusted → can't extend the chain from it.
+                    expected_prev = None;
+                    continue;
+                }
+            }
+            // 2) Check the structural chain link.
+            let this_prev = entry
+                .prev_hash
+                .clone()
+                .unwrap_or_else(|| GENESIS_HASH.to_string());
+            match &expected_prev {
+                // Re-syncing after a break: accept this (MAC-authentic) entry
+                // and resume the chain from it.
+                None => {}
+                Some(exp) if &this_prev == exp => {}
+                Some(_) => {
+                    eprintln!(
+                        "[log] quarantine seq={} in {seg}: hash-chain break (insert/delete/reorder)",
+                        entry.seq
+                    );
+                    expected_prev = None;
+                    continue;
+                }
+            }
+            // Accepted: advance the chain and keep it.
+            expected_prev = match entry.chain_hash() {
+                Ok(h) => Some(h),
+                Err(e) => {
+                    eprintln!("[log] chain_hash error for seq={} in {seg}: {e}", entry.seq);
+                    None
+                }
+            };
+            kept.push(entry);
+        }
+        kept
+    }
+
+    /// One-time, idempotent migration that seals legacy entries. Existing
+    /// vaults have entries with no `prev_hash`/`mac`; here we treat those
+    /// on-disk entries as TRUSTED-LOCAL (they predate sync / the attack model),
+    /// recompute the `prev_hash` chain from genesis in append order, add the
+    /// `mac` under the vault key (if set), and rewrite each segment ONCE
+    /// (atomic temp-file + rename). Runs before the first replay so the log is
+    /// authenticated from then on.
+    ///
+    /// Idempotent: a segment whose entries already carry a `prev_hash` (and a
+    /// `mac`, when a key is present) is left untouched, and because the chain is
+    /// recomputed deterministically, re-running reproduces byte-identical lines.
+    pub(crate) fn migrate_and_seal(&self) -> Result<(), MedmeError> {
+        let key = self.key.as_deref();
+        for path in self.segments()? {
+            // Migration REWRITES the segment from the lines it parses, so unlike
+            // `read_all` it must never silently drop a line it can't parse: doing
+            // so would permanently lose (e.g.) a forward-compat entry written by a
+            // newer binary. A torn/incomplete FINAL line is skippable (it was
+            // never a completed append); an unparseable NON-final line aborts the
+            // migration of this segment, leaving the file byte-for-byte untouched.
+            let entries = match read_segment_for_migration(&path)? {
+                MigrationParse::Ok(entries) => entries,
+                MigrationParse::AbortUnparsableLine => continue,
+            };
+            if entries.is_empty() {
+                continue;
+            }
+            // Needs sealing if any entry lacks a chain link, or lacks a MAC
+            // while we now hold a key (chain-only → keyed upgrade).
+            let needs = entries
+                .iter()
+                .any(|e| e.prev_hash.is_none() || (key.is_some() && e.mac.is_none()));
+            if !needs {
+                continue;
+            }
+            let mut prev = GENESIS_HASH.to_string();
+            let mut lines: Vec<String> = Vec::with_capacity(entries.len());
+            for mut e in entries {
+                e.seal(prev, key)?;
+                prev = e.chain_hash()?;
+                lines.push(serde_json::to_string(&e)?);
+            }
+            let parent = path.parent().ok_or_else(|| {
+                MedmeError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "log segment path has no parent directory",
+                ))
+            })?;
+            let mut tmp = NamedTempFile::new_in(parent)?;
+            for line in &lines {
+                writeln!(tmp, "{line}")?;
+            }
+            // Durability: fsync bytes before the atomic rename, then fsync the
+            // dir so the replace survives power loss (same discipline as CAS).
+            tmp.as_file().sync_all()?;
+            tmp.persist(&path).map_err(|e| MedmeError::Io(e.error))?;
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    }
+
     pub fn is_empty(&self) -> Result<bool, MedmeError> {
         Ok(self.segments()?.is_empty() || self.read_all()?.is_empty())
     }
@@ -94,6 +277,82 @@ impl EventLog {
     pub fn max_seq(&self) -> Result<i64, MedmeError> {
         Ok(self.read_all()?.iter().map(|e| e.seq).max().unwrap_or(0))
     }
+}
+
+/// Parse a segment file into entries in FILE (append) order. Empty lines are
+/// skipped; an unparseable line (e.g. a torn last write, or a maliciously
+/// corrupted line) is skipped with a warning rather than aborting the read —
+/// the surrounding chain/MAC verification then decides what to trust.
+fn read_segment_entries(path: &Path) -> Result<Vec<LogEntry>, MedmeError> {
+    let f = std::fs::File::open(path)?;
+    let mut out: Vec<LogEntry> = Vec::new();
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<LogEntry>(&line) {
+            Ok(e) => out.push(e),
+            Err(e) => eprintln!("[log] skip unparseable entry in {}: {e}", path.display()),
+        }
+    }
+    Ok(out)
+}
+
+/// Outcome of parsing a segment for MIGRATION, which (unlike `read_all`) rewrites
+/// the file and therefore must not silently drop any line.
+enum MigrationParse {
+    /// Every NON-final line parsed; these entries are safe to reseal + rewrite.
+    /// A torn/incomplete FINAL line, if present, was skipped — it was never a
+    /// completed append.
+    Ok(Vec<LogEntry>),
+    /// A NON-final line failed to parse (e.g. a forward-compat entry from a newer
+    /// binary). Rewriting the segment would permanently drop it, so migration of
+    /// this segment must abort and leave the file byte-unchanged.
+    AbortUnparsableLine,
+}
+
+/// Parse a segment for migration. Non-empty lines are parsed in file order; the
+/// LAST non-empty line is allowed to be unparseable (a torn final write) and is
+/// skipped, but any EARLIER unparseable line aborts (returns
+/// [`MigrationParse::AbortUnparsableLine`]) so the caller leaves the segment
+/// untouched rather than dropping data.
+fn read_segment_for_migration(path: &Path) -> Result<MigrationParse, MedmeError> {
+    let f = std::fs::File::open(path)?;
+    // Collect non-empty lines up front so we can tell whether an unparseable line
+    // is the FINAL one (torn write — skippable) or an interior one (would be
+    // dropped on rewrite — must abort).
+    let raw: Vec<String> = BufReader::new(f)
+        .lines()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    let last = raw.len();
+    let mut out: Vec<LogEntry> = Vec::with_capacity(last);
+    for (i, line) in raw.iter().enumerate() {
+        match serde_json::from_str::<LogEntry>(line) {
+            Ok(e) => out.push(e),
+            Err(e) => {
+                if i + 1 == last {
+                    // Torn/incomplete final line: never a completed append — skip.
+                    eprintln!(
+                        "[log] migrate: skip torn final line in {}: {e}",
+                        path.display()
+                    );
+                } else {
+                    // Interior unparseable line: rewriting would drop it. Abort so
+                    // the segment is left untouched and nothing is lost.
+                    eprintln!(
+                        "[log] migrate: ABORT sealing {} — unparseable non-final line at index {i}: {e}",
+                        path.display()
+                    );
+                    return Ok(MigrationParse::AbortUnparsableLine);
+                }
+            }
+        }
+    }
+    Ok(MigrationParse::Ok(out))
 }
 
 #[cfg(test)]
@@ -216,5 +475,389 @@ mod tests {
         let events = log.read_all().unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].device_id, "legacydev");
+    }
+
+    // ---- tamper-evidence / authentication (advisory GHSA-m96x) --------------
+
+    const KEY: &[u8] = &[7u8; 32];
+
+    /// A keyed log open at `dir`. Distinct timestamps keep `read_all`'s global
+    /// sort equal to append order so assertions on order are stable.
+    fn keyed_log(dir: &Path) -> EventLog {
+        let mut log = EventLog::open(dir).unwrap();
+        log.set_key(Some(KEY.to_vec()));
+        log
+    }
+
+    fn append_n(log: &EventLog, n: i64) {
+        for seq in 1..=n {
+            let ts = format!("2024-01-01T00:00:{:02}Z", seq);
+            log.append(&mk_on("dev1", seq, &ts)).unwrap();
+        }
+    }
+
+    fn seg_path(dir: &Path) -> PathBuf {
+        dir.join("log/dev1-000001.jsonl")
+    }
+
+    fn read_lines(p: &Path) -> Vec<String> {
+        std::fs::read_to_string(p)
+            .unwrap()
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn write_lines(p: &Path, lines: &[String]) {
+        std::fs::write(p, format!("{}\n", lines.join("\n"))).unwrap();
+    }
+
+    #[test]
+    fn keyed_round_trip_appends_verify_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 4);
+
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 4, "all entries verify and are returned");
+        for (i, e) in events.iter().enumerate() {
+            assert_eq!(e.seq, i as i64 + 1);
+            assert!(e.mac.is_some(), "each appended entry is MAC'd");
+            assert!(e.prev_hash.is_some(), "each appended entry is chained");
+            assert!(e.verify_mac(KEY).unwrap());
+        }
+        // First entry chains to genesis; each subsequent to its predecessor.
+        assert_eq!(events[0].prev_hash.as_deref(), Some(GENESIS_HASH));
+        assert_eq!(
+            events[1].prev_hash.as_deref().unwrap(),
+            events[0].chain_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn tampered_entry_is_quarantined_others_survive() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 3);
+
+        // Flip a byte in the MIDDLE entry's event body (change original_name).
+        let mut lines = read_lines(&seg_path(dir.path()));
+        let mut v: serde_json::Value = serde_json::from_str(&lines[1]).unwrap();
+        v["original_name"] = serde_json::Value::String("TAMPERED".into());
+        lines[1] = serde_json::to_string(&v).unwrap();
+        write_lines(&seg_path(dir.path()), &lines);
+
+        // The tampered entry (seq 2) is excluded; seq 1 and 3 survive (seq 3 is
+        // MAC-authentic, so the chain re-synchronises to it). Open succeeds.
+        let events = log.read_all().unwrap();
+        let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![1, 3], "tampered entry quarantined, others kept");
+    }
+
+    #[test]
+    fn forged_entry_without_valid_mac_is_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 2);
+
+        // Append a forged line with a plausible body but no / bogus MAC — as a
+        // shared-folder writer WITHOUT the key could only produce.
+        let mut lines = read_lines(&seg_path(dir.path()));
+        let mut forged = mk_on("dev1", 3, "2024-01-01T00:00:03Z");
+        forged.prev_hash = Some(GENESIS_HASH.to_string());
+        forged.mac = None;
+        lines.push(serde_json::to_string(&forged).unwrap());
+        let mut forged2 = mk_on("dev1", 4, "2024-01-01T00:00:04Z");
+        forged2.prev_hash = Some(GENESIS_HASH.to_string());
+        forged2.mac = Some("deadbeef".into()); // wrong MAC
+        lines.push(serde_json::to_string(&forged2).unwrap());
+        write_lines(&seg_path(dir.path()), &lines);
+
+        let events = log.read_all().unwrap();
+        let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![1, 2], "forged entries excluded, authentic kept");
+    }
+
+    #[test]
+    fn deleted_entry_breaks_chain_valid_prefix_survives() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 4);
+
+        // Delete the third entry (index 2). The chain breaks at what follows.
+        let mut lines = read_lines(&seg_path(dir.path()));
+        lines.remove(2);
+        write_lines(&seg_path(dir.path()), &lines);
+
+        // Open still succeeds; the valid prefix [1,2] survives, the deletion is
+        // detected (seq 4, whose prev_hash no longer links, is quarantined).
+        let events = log.read_all().unwrap();
+        let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![1, 2], "valid prefix survives a mid-log deletion");
+    }
+
+    #[test]
+    fn reordered_entries_break_chain_and_are_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 4);
+
+        // Swap entries 2 and 3 (indices 1 and 2) — each still has a valid MAC,
+        // so only the chain can catch the reorder.
+        let mut lines = read_lines(&seg_path(dir.path()));
+        lines.swap(1, 2);
+        write_lines(&seg_path(dir.path()), &lines);
+
+        let events = log.read_all().unwrap();
+        // seq 1 (genesis) and the resync'd first-out-of-order entry survive; the
+        // reorder is detected (fewer than 4 returned) and open does not abort.
+        assert!(
+            events.len() < 4,
+            "reorder detected: some entries quarantined, got {events:?}"
+        );
+        assert_eq!(events[0].seq, 1, "genesis entry always survives");
+    }
+
+    #[test]
+    fn truncated_last_line_is_skipped_and_prefix_opens() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = keyed_log(dir.path());
+        append_n(&log, 3);
+
+        // Simulate a torn final write: chop the last line in half.
+        let mut lines = read_lines(&seg_path(dir.path()));
+        let last = lines.last_mut().unwrap();
+        *last = last[..last.len() / 2].to_string();
+        write_lines(&seg_path(dir.path()), &lines);
+
+        // Open succeeds on the intact prefix; the torn line is skipped, no panic.
+        let events = log.read_all().unwrap();
+        let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![1, 2], "torn tail skipped, valid prefix opens");
+    }
+
+    #[test]
+    fn chain_only_mode_still_detects_reorder() {
+        // No key set → chain-only fallback: content isn't authenticated, but the
+        // structural chain still flags a reorder.
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path()).unwrap(); // no key
+        append_n(&log, 3);
+        // Entries are chained but unauthenticated (no MAC).
+        assert!(read_lines(&seg_path(dir.path()))
+            .iter()
+            .all(|l| l.contains("prev_hash")));
+
+        let mut lines = read_lines(&seg_path(dir.path()));
+        lines.swap(1, 2);
+        write_lines(&seg_path(dir.path()), &lines);
+
+        let events = log.read_all().unwrap();
+        assert!(
+            events.len() < 3,
+            "chain-only mode still detects the reorder"
+        );
+    }
+
+    #[test]
+    fn chain_only_mode_is_defeated_by_an_adversary_who_recomputes_the_chain() {
+        // Honesty check for the chain-only wording: the keyless `prev_hash` chain
+        // only catches non-adversarial corruption. A folder-writing adversary can
+        // TAMPER an entry and recompute the whole chain from genesis, and nothing
+        // is detected — exactly why only the keyed MAC gives real tamper evidence.
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path()).unwrap(); // no key → chain-only
+        append_n(&log, 3);
+
+        // Adversary: rewrite the segment with the MIDDLE entry's content changed,
+        // then reseal the ENTIRE chain from genesis (keyless — no secret needed).
+        let mut entries: Vec<LogEntry> = read_lines(&seg_path(dir.path()))
+            .iter()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        if let Event::FileImported {
+            ref mut original_name,
+            ..
+        } = entries[1].event
+        {
+            *original_name = "TAMPERED".into();
+        }
+        let mut prev = GENESIS_HASH.to_string();
+        let mut lines = Vec::new();
+        for e in entries.iter_mut() {
+            e.seal(prev, None).unwrap(); // chain-only reseal, no MAC
+            prev = e.chain_hash().unwrap();
+            lines.push(serde_json::to_string(e).unwrap());
+        }
+        write_lines(&seg_path(dir.path()), &lines);
+
+        // All three entries survive and the tampered content is served as trusted
+        // — the recomputed chain evades every check. (A keyed log would quarantine
+        // the tampered entry via its MAC; see `tampered_entry_is_quarantined_*`.)
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 3, "recomputed chain passes verification");
+        let tampered_present = events.iter().any(|e| {
+            matches!(&e.event, Event::FileImported { original_name, .. } if original_name == "TAMPERED")
+        });
+        assert!(
+            tampered_present,
+            "chain-only mode cannot detect the adversarial tamper"
+        );
+    }
+
+    // ---- migration: seal legacy entries once, idempotently ------------------
+
+    /// Write a legacy segment (entries with NO prev_hash/mac keys at all).
+    fn write_legacy_segment(dir: &Path, n: i64) {
+        let log_dir = dir.join("log");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let mut out = String::new();
+        for seq in 1..=n {
+            let ts = format!("2024-01-01T00:00:{:02}Z", seq);
+            let e = mk_on("legacydev", seq, &ts);
+            // Strip the optional keys to produce a genuine pre-change line.
+            let mut v: serde_json::Value = serde_json::to_value(&e).unwrap();
+            let obj = v.as_object_mut().unwrap();
+            obj.remove("prev_hash");
+            obj.remove("mac");
+            out.push_str(&serde_json::to_string(&v).unwrap());
+            out.push('\n');
+        }
+        std::fs::write(log_dir.join("legacydev-000001.jsonl"), out).unwrap();
+    }
+
+    /// One legacy log line (an entry with NO prev_hash/mac keys) as a string, so
+    /// tests can assemble a segment line-by-line (e.g. inserting a torn or
+    /// unparseable line at a chosen position).
+    fn legacy_line(seq: i64, ts: &str) -> String {
+        let e = mk_on("legacydev", seq, ts);
+        let mut v: serde_json::Value = serde_json::to_value(&e).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("prev_hash");
+        obj.remove("mac");
+        serde_json::to_string(&v).unwrap()
+    }
+
+    #[test]
+    fn migrate_seals_legacy_log_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_legacy_segment(dir.path(), 3);
+        let seg = dir.path().join("log/legacydev-000001.jsonl");
+
+        let log = keyed_log(dir.path());
+        // Before migration the raw lines carry no MAC.
+        assert!(read_lines(&seg)
+            .iter()
+            .all(|l| !l.contains("\"mac\"") || l.contains("\"mac\":null")));
+
+        log.migrate_and_seal().unwrap();
+
+        // After migration every entry verifies clean under the key.
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 3, "all legacy entries sealed + verified");
+        for e in &events {
+            assert!(e.mac.is_some() && e.prev_hash.is_some());
+            assert!(e.verify_mac(KEY).unwrap());
+        }
+
+        // Idempotent: re-running produces byte-identical output and no re-write
+        // of an already-sealed segment.
+        let bytes1 = std::fs::read(&seg).unwrap();
+        log.migrate_and_seal().unwrap();
+        let bytes2 = std::fs::read(&seg).unwrap();
+        assert_eq!(bytes1, bytes2, "migration is idempotent (stable bytes)");
+    }
+
+    #[test]
+    fn chain_only_migration_then_key_upgrade_adds_macs() {
+        let dir = tempfile::tempdir().unwrap();
+        write_legacy_segment(dir.path(), 2);
+        let seg = dir.path().join("log/legacydev-000001.jsonl");
+
+        // First migrate WITHOUT a key: adds the chain, no MAC.
+        {
+            let log = EventLog::open(dir.path()).unwrap();
+            log.migrate_and_seal().unwrap();
+        }
+        assert!(read_lines(&seg).iter().all(|l| l.contains("prev_hash")));
+
+        // Reopen WITH a key: migration now upgrades chain-only → MAC'd.
+        let log = keyed_log(dir.path());
+        log.migrate_and_seal().unwrap();
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 2);
+        for e in &events {
+            assert!(e.verify_mac(KEY).unwrap(), "MACs added on key upgrade");
+        }
+    }
+
+    #[test]
+    fn migration_aborts_on_unparseable_non_final_line_and_loses_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("log");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let seg = log_dir.join("legacydev-000001.jsonl");
+
+        // A legacy segment whose MIDDLE line is an entry this build can't parse
+        // (a forward-compat event type from a newer binary). It is NOT the final
+        // line, so rewriting the segment during migration would permanently drop
+        // it — migration must instead abort and leave the file untouched.
+        let future = r#"{"event_id":"future","seq":2,"ts":"2024-01-01T00:00:02Z","device_id":"legacydev","type":"FutureEventFromNewerBuild","payload":123}"#;
+        let lines = vec![
+            legacy_line(1, "2024-01-01T00:00:01Z"),
+            future.to_string(),
+            legacy_line(3, "2024-01-01T00:00:03Z"),
+        ];
+        write_lines(&seg, &lines);
+        let before = std::fs::read(&seg).unwrap();
+
+        // Even though these legacy entries WOULD be sealed, the unparseable
+        // non-final line makes migration a no-op for this segment.
+        let log = keyed_log(dir.path());
+        log.migrate_and_seal().unwrap();
+
+        let after = std::fs::read(&seg).unwrap();
+        assert_eq!(
+            before, after,
+            "segment with an unparseable non-final line is left byte-unchanged (nothing dropped)"
+        );
+    }
+
+    #[test]
+    fn migration_still_seals_segment_with_only_a_torn_final_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("log");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let seg = log_dir.join("legacydev-000001.jsonl");
+
+        // Two complete legacy entries followed by a torn/incomplete FINAL line
+        // (a half-written append that never completed). The torn tail is
+        // skippable, so migration still proceeds and seals the complete entries.
+        let mut lines = vec![
+            legacy_line(1, "2024-01-01T00:00:01Z"),
+            legacy_line(2, "2024-01-01T00:00:02Z"),
+        ];
+        let torn = legacy_line(3, "2024-01-01T00:00:03Z");
+        lines.push(torn[..torn.len() / 2].to_string());
+        write_lines(&seg, &lines);
+
+        let log = keyed_log(dir.path());
+        log.migrate_and_seal().unwrap();
+
+        // The two complete entries are sealed + verify; the torn final line is
+        // dropped (it was never a completed append).
+        let events = log.read_all().unwrap();
+        let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+        assert_eq!(
+            seqs,
+            vec![1, 2],
+            "torn final line dropped, complete entries migrated"
+        );
+        for e in &events {
+            assert!(
+                e.verify_mac(KEY).unwrap(),
+                "migrated entries are MAC-sealed"
+            );
+        }
     }
 }

--- a/packages/core-model/src/materialize.rs
+++ b/packages/core-model/src/materialize.rs
@@ -449,16 +449,33 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
                 eprintln!("[materialize] skip OcrAdded: malformed text_hash");
                 return Ok(ApplyOutcome::Applied);
             }
-            let relpath = cas::object_relpath(text_hash);
-            // The CAS object may not have synced in yet (log arrives before the
-            // blob). Treat a missing object as Deferred — retried once it lands
-            // — rather than aborting the whole materialize / `Vault::open`.
-            let text = match std::fs::read_to_string(vault.root_join(&relpath)) {
-                Ok(t) => t,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Read the OCR text through the VERIFIED CAS reader so a swapped /
+            // poisoned object (bytes that don't hash to `text_hash`) is rejected
+            // rather than injected into the DB + full-text index. Three outcomes:
+            //   - missing blob (not synced yet) → Deferred, retried later;
+            //   - integrity failure (poisoned/corrupt) → quarantine (skip this
+            //     OCR row) — retrying can't help, CAS won't overwrite the path;
+            //   - other I/O error → propagate.
+            let bytes = match vault.read_object(text_hash) {
+                Ok(b) => b,
+                Err(MedmeError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Ok(ApplyOutcome::Deferred);
                 }
-                Err(e) => return Err(e.into()),
+                Err(MedmeError::Other(msg)) => {
+                    eprintln!("[materialize] skip OcrAdded: {msg}");
+                    return Ok(ApplyOutcome::Applied);
+                }
+                Err(e) => return Err(e),
+            };
+            // Verified bytes hash to `text_hash`; legit OCR text is UTF-8.
+            // Corrupt (non-UTF-8) content that still hashed correctly is a
+            // pathological case — quarantine rather than abort the replay.
+            let text = match String::from_utf8(bytes) {
+                Ok(t) => t,
+                Err(_) => {
+                    eprintln!("[materialize] skip OcrAdded: OCR text object is not valid UTF-8");
+                    return Ok(ApplyOutcome::Applied);
+                }
             };
             tx.execute(
                 "INSERT INTO ocr_result
@@ -1264,6 +1281,131 @@ mod tests {
                 "must reject {bad:?}"
             );
         }
+    }
+
+    /// A poisoned CAS text object (bytes swapped so they no longer hash to the
+    /// event's `text_hash`) must be QUARANTINED on materialize — the OCR row is
+    /// skipped, never injected into the DB / full-text index — while the rest of
+    /// the replay (source_file, document) still applies and open succeeds.
+    #[test]
+    fn poisoned_ocr_object_is_quarantined_not_materialized() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_doc(dir.path(), "poison.txt", "PoisonObjNeedle");
+
+        // Swap the OCR text object's bytes for unrelated content at the same
+        // content-addressed path (an attacker poisoning the shared folder).
+        let text_hash = cas::sha256_hex("PoisonObjNeedle".as_bytes());
+        let obj = dir.path().join(cas::object_relpath(&text_hash));
+        std::fs::write(&obj, b"evil swapped ocr text").unwrap();
+        std::fs::remove_file(dir.path().join("medme.db")).unwrap();
+
+        // Open must not error; the poisoned object is skipped.
+        let v = Vault::open(dir.path()).unwrap();
+        assert_eq!(
+            v.debug_count("source_file"),
+            1,
+            "FileImported still applied"
+        );
+        assert_eq!(v.debug_count("document"), 1, "DocumentAdded still applied");
+        assert_eq!(
+            v.debug_count("ocr_result"),
+            0,
+            "poisoned OCR object quarantined, not injected"
+        );
+    }
+
+    /// End-to-end with an injected MAC key: import + document + OCR, then reopen
+    /// with the same key — everything materializes and searches, and the log
+    /// entries are authenticated (MAC present + valid).
+    #[test]
+    fn keyed_vault_round_trips_and_reopens() {
+        const KEY: &[u8] = &[42u8; 32];
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let v = Vault::open_with_key(dir.path(), KEY).unwrap();
+            let imp = v.import("a.txt", "text/plain", b"KeyedNeedle").unwrap();
+            let doc = v
+                .add_document(NewDocument {
+                    source_file_id: imp.source_file.id,
+                    doc_type: DocType::LabReport,
+                    doc_date: Some(chrono::Utc::now()),
+                    doc_date_end: None,
+                    title: Some("keyed".into()),
+                    language: None,
+                    page_count: 1,
+                })
+                .unwrap();
+            v.add_ocr(NewOcr {
+                document_id: doc.id,
+                page_no: 1,
+                backend: OcrBackendKind::Native,
+                model_version: "text-layer".into(),
+                text: "KeyedNeedle".into(),
+                confidence: None,
+            })
+            .unwrap();
+            // Every appended entry is MAC'd under the key.
+            for e in v.log.read_all().unwrap() {
+                assert!(e.verify_mac(KEY).unwrap(), "appended entry authenticated");
+            }
+        }
+
+        // Reopen with the key, wiping the derived db so it rebuilds from the
+        // verified log alone.
+        std::fs::remove_file(dir.path().join("medme.db")).unwrap();
+        let v = Vault::open_with_key(dir.path(), KEY).unwrap();
+        assert_eq!(v.debug_count("document"), 1);
+        assert_eq!(v.debug_count("source_file"), 1);
+        assert_eq!(v.search("KeyedNeedle", 10).unwrap().len(), 1);
+    }
+
+    /// A legacy vault (log entries with no prev_hash/mac) opened WITH a key gets
+    /// its log sealed on open, materializes cleanly, and verifies under the key.
+    /// Reopening is idempotent.
+    #[test]
+    fn legacy_vault_seals_on_keyed_open() {
+        const KEY: &[u8] = &[3u8; 32];
+        let dir = tempfile::tempdir().unwrap();
+        seed_doc(dir.path(), "legacy.txt", "LegacySealNeedle");
+
+        // Strip prev_hash/mac from every segment line → a genuine pre-change log.
+        // (seed_doc's vault is already dropped, so the files are free to edit.)
+        {
+            for entry in std::fs::read_dir(dir.path().join("log")).unwrap() {
+                let p = entry.unwrap().path();
+                if p.extension().and_then(|x| x.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                let stripped: Vec<String> = std::fs::read_to_string(&p)
+                    .unwrap()
+                    .lines()
+                    .filter(|l| !l.trim().is_empty())
+                    .map(|l| {
+                        let mut v: serde_json::Value = serde_json::from_str(l).unwrap();
+                        let o = v.as_object_mut().unwrap();
+                        o.remove("prev_hash");
+                        o.remove("mac");
+                        serde_json::to_string(&v).unwrap()
+                    })
+                    .collect();
+                std::fs::write(&p, format!("{}\n", stripped.join("\n"))).unwrap();
+            }
+        }
+        std::fs::remove_file(dir.path().join("medme.db")).unwrap();
+
+        // Open with the key: migration seals the legacy log, replay is clean.
+        let v = Vault::open_with_key(dir.path(), KEY).unwrap();
+        assert_eq!(v.debug_count("document"), 1, "legacy doc materialized");
+        assert_eq!(v.search("LegacySealNeedle", 10).unwrap().len(), 1);
+        for e in v.log.read_all().unwrap() {
+            assert!(e.verify_mac(KEY).unwrap(), "legacy entry sealed under key");
+        }
+        drop(v);
+
+        // Reopen is idempotent and still verifies.
+        let v2 = Vault::open_with_key(dir.path(), KEY).unwrap();
+        assert_eq!(v2.debug_count("document"), 1);
+        assert_eq!(v2.search("LegacySealNeedle", 10).unwrap().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Core-model machinery for **GHSA-m96x** (Critical): the synced append-only log was unauthenticated and CAS objects were trusted by filename, so a shared-folder writer could forge/tamper/reorder/poison medical records. Independently reviewed (adversarial); review findings folded in.

## What this adds (core-model)
- **HMAC-SHA256** over each entry's canonical bytes (seq, ts, device_id, prev_hash, event) under a **per-vault key**, plus a **per-segment prev_hash chain**. On replay, entries failing MAC/chain are **quarantined** (skipped + logged), never trusted; a break never aborts open — the valid prefix still materializes.
- **CAS `read_object`** re-hashes on read and rejects poisoned/swapped bytes; the OCR read routes through it (missing → Deferred, integrity fail → quarantine).
- **Migration**: one-time, atomic (temp+fsync+rename), idempotent, byte-stable sealing of legacy logs. Crucially it **aborts a segment (leaves it byte-unchanged) rather than dropping an unparseable non-final line** — no entry is ever lost.
- Key injected via `open_*_with_key`; **keys < 32 bytes rejected**. Keyless callers run **chain-only**, documented honestly as corruption-detection only (a folder adversary can recompute a keyless chain) — real authentication needs the key.

## ⚠️ This does NOT close GHSA-m96x yet (honest scope)
This is core-model **stage 1 plumbing**. Every app caller still uses the keyless constructors, so the product currently runs **chain-only**. The Critical is only actually mitigated after the **app-layer follow-up**, which MUST satisfy (per review):
1. Generate + persist the per-vault key at **vault creation**; inject via `*_with_key` at all sites (desktop/cli/mobile).
2. The key must exist **before** the vault ever touches shared/untrusted storage — migration is trust-on-first-use, so a vault tampered *before* a key exists would get sealed as authentic. (Keychain storage + QR cross-device distribution.)
3. Keep the chain-only wording non-adversarial-only (done).
4. Reject empty/short keys at the boundary (done).

Keep the advisory OPEN until that lands.

## Tests / gate
74 core-model tests pass — tamper-quarantine, forgery-excluded, chain break (delete/reorder), migration byte-stable idempotency + no-drop-on-unparseable, torn-final-line, CAS poison rejection, short-key rejection, chain-only-defeated-by-adversary (proves the honest claim). `cargo fmt` clean · `cargo clippy -p core-model -- -D warnings` clean.