### PR TITLE
ci(security): pin GitHub Actions to commit SHAs (GHSA-79jh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Rust (core crates + CLI)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # CMake + a C/C++ toolchain are required to build the vendored
       # JPEG2000 (OpenJPEG) / JPEG-LS (CharLS) codecs used by the dicom crate.
@@ -33,12 +33,12 @@ jobs:
           sudo apt-get install -y cmake build-essential
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # apps/mobile (medme-mobile) is owned/formatted by the mobile track and
       # excluded here so this check never depends on that crate's state.
@@ -66,15 +66,15 @@ jobs:
     name: Desktop frontend (typecheck + build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -98,8 +98,8 @@ jobs:
     name: Security audit (cargo-audit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: taiki-e/install-action@17dfa9a7aa66ae804b5cbd9f505a33815221f967 # cargo-audit
       - name: cargo audit (fail on vulnerabilities)
         run: cargo audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,15 +31,15 @@ jobs:
         language: [javascript-typescript]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # --- System build deps -------------------------------------------------
       # CMake + a C/C++ toolchain + LLVM/clang are needed to build the vendored
@@ -98,21 +98,21 @@ jobs:
 
       # --- Toolchains --------------------------------------------------------
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Keep a per-OS cache; the Tauri crate lives under apps/desktop/src-tauri.
           key: desktop-${{ matrix.os }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20 # Vite 7 requires Node ^20.19 || >=22.12
           cache: pnpm
@@ -131,7 +131,7 @@ jobs:
       # --- Publish -----------------------------------------------------------
       # Installers land in target/release/bundle/<type>/.
       - name: Upload installers as workflow artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: medme-desktop-${{ matrix.os }}
           if-no-files-found: error
@@ -146,7 +146,7 @@ jobs:
       # On a tag push, attach every OS's installers to a single GitHub Release.
       - name: Attach installers to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           draft: true # publish manually after a quick smoke-test of the installers
           fail_on_unmatched_files: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,18 +23,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true # required for the public badge
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Closes the Actions-pinning slice of **GHSA-79jh**. Mutable tags (`@v4`/`@stable`/`@v2`) let a compromised third-party action tamper with CI — and `desktop-build.yml` runs with `contents: write`. Every `uses:` across the four workflows is now pinned to a full 40-hex commit SHA with the version in a trailing comment (so Dependabot, already configured for `github-actions`, keeps them updated).

- All **22** `uses:` lines pinned (third-party + `actions/*` + `github/codeql-action/*`).
- Each SHA was resolved from its tag (dereferencing annotated tags) and **re-verified** against `repos/<owner>/<repo>/commits/<sha>` — a wrong SHA would break CI, so every one was confirmed to be a real commit on the target repo.
- No behavior change — same commits, just immutable refs.
- `actions/checkout` keeps two SHAs because the repo referenced `@v7` (ci/desktop-build) and `@v4` (codeql/scorecard) — each pinned to its own tag's commit.

Remaining in GHSA-79jh: release-binary signing/notarization (needs signing certs — separate ops decision).

## Validation
YAML parses (`yaml.safe_load`); no `uses:` left on a mutable ref.