### PR TITLE
fix(security): backend-sourced save dialog for export/share (GHSA-gmg4 residual)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -67,13 +67,15 @@ pub(crate) fn ingest_guarded(
     }
 }
 
-/// SECURITY: validate a JS-supplied save destination before we write app-generated
-/// content to it. The frontend always sources these paths from the native save
-/// dialog (AuditView / ImportView `save({...})`), but a malicious `invoke` could
-/// pass ANY path. Requiring an absolute path with an expected extension and no `..`
-/// components removes the arbitrary-file clobber primitive (can't overwrite
-/// `~/.zshrc`, `~/.ssh/id_rsa`, binaries, launch agents, …) while still allowing the
-/// dialog-driven `.csv` / `.html` save flows the app actually uses.
+/// SECURITY: defense-in-depth validation of a save destination before we write
+/// app-generated content to it. Since GHSA-gmg4 the export/share destinations come
+/// from a native save dialog opened FROM RUST (`blocking_save_file` in
+/// `export_timeline_html` / `create_share`), so the webview no longer supplies the
+/// path at all — but we keep this check so any future/non-native caller still can't
+/// smuggle a surprising path past us. Requiring an absolute path with an expected
+/// extension and no `..` components removes the arbitrary-file clobber primitive
+/// (can't overwrite `~/.zshrc`, `~/.ssh/id_rsa`, binaries, launch agents, …) while
+/// still allowing the `.html` save flows the app actually uses.
 fn validate_dest_path(path: &str, allowed_ext: &[&str]) -> Result<std::path::PathBuf, String> {
     let p = std::path::PathBuf::from(path);
     if !p.is_absolute() {
@@ -435,20 +437,42 @@ pub fn export_vault(_state: State<AppState>, _dest_path: String) -> Result<Expor
     Ok(ExportSummary {
         file_count: 0,
         byte_size: 0,
+        path: String::new(),
     })
 }
 
-/// 导出 v1:把整条时间线渲染成自包含 HTML 写到 `dest_path`(见
+/// 导出 v1:把整条时间线渲染成自包含 HTML 写到用户在原生保存对话框选定的位置(见
 /// `medme_share::export::build_timeline_html`)。可在任意浏览器打开、原生渲染中文,
-/// 并通过浏览器「打印 / 另存为 PDF」交给医生。
+/// 并通过浏览器「打印 / 另存为 PDF」交给医生。用户取消对话框返回 `None`(无操作)。
+///
+/// SECURITY (GHSA-gmg4): the save destination now comes from a native save dialog
+/// opened FROM RUST (`blocking_save_file`), not a webview-supplied string, so a
+/// compromised webview can no longer name an arbitrary `.html` path to clobber with
+/// app-generated content. The chosen path is returned so the "打开文件" button can hand
+/// it back to `open_path` (recorded in `openable_paths`). UX is unchanged: the user
+/// still clicks "导出" and sees the same native save dialog.
+///
+/// `blocking_save_file` must not run on the main thread; async commands run off the
+/// main thread on the async runtime, so this is safe (same as `import_via_dialog`).
 #[tauri::command]
-pub fn export_timeline_html(
-    state: State<AppState>,
-    dest_path: String,
-) -> Result<ExportSummary, String> {
-    // SECURITY: constrain the JS-supplied save target to an absolute `.html` path
-    // (see validate_dest_path) so a malicious invoke can't clobber arbitrary files.
-    let dest = validate_dest_path(&dest_path, &["html", "htm"])?;
+pub async fn export_timeline_html(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Option<ExportSummary>, String> {
+    let Some(file) = app
+        .dialog()
+        .file()
+        .set_title("导出病历时间线")
+        .set_file_name("MedMe导出.html")
+        .add_filter("HTML", &["html"])
+        .blocking_save_file()
+    else {
+        return Ok(None); // 用户取消对话框
+    };
+    let picked = file.into_path().map_err(|e| e.to_string())?;
+    // Defense-in-depth: a native save pick is already absolute, but keep the extension /
+    // no-`..` checks so any future non-native caller can't smuggle a surprising path past us.
+    let dest = validate_dest_path(&picked.to_string_lossy(), &["html", "htm"])?;
     let v = lock(&state)?;
     let (html, record_count) = medme_share::export::build_timeline_html(&v)?;
     let byte_size = html.len() as i64;
@@ -459,24 +483,43 @@ pub fn export_timeline_html(
     // 审计追踪:导出落盘成功后记入不可变事件日志(见 core-model::audit)。
     v.record_export("timeline_html", &sha256, record_count)
         .map_err(|e| e.to_string())?;
-    Ok(ExportSummary {
+    Ok(Some(ExportSummary {
         file_count: record_count,
         byte_size,
-    })
+        path: dest.to_string_lossy().to_string(),
+    }))
 }
 
-/// 端到端加密分享:把全部病历打包成一份自包含加密 HTML 写到 `dest_path`
-/// (见 `medme_share::share::build_encrypted_share`),返回口令(需另行单独告知医生)、
-/// 记录数与文件字节数。默认有效期 5 天。
+/// 端到端加密分享:把全部病历打包成一份自包含加密 HTML 写到用户在原生保存对话框选定的
+/// 位置(见 `medme_share::share::build_encrypted_share`),返回口令(需另行单独告知医生)、
+/// 记录数、文件字节数与写入路径。默认有效期 5 天。用户取消对话框返回 `None`(无操作)。
+///
+/// SECURITY (GHSA-gmg4): the save destination now comes from a native save dialog
+/// opened FROM RUST (`blocking_save_file`), not a webview-supplied string, so a
+/// compromised webview can no longer name an arbitrary `.html` path to clobber. The
+/// chosen path is returned so the "打开文件" button can hand it back to `open_path`
+/// (recorded in `openable_paths`). Async so `blocking_save_file` runs off the main
+/// thread (same as `import_via_dialog`). UX is unchanged.
 #[tauri::command]
-pub fn create_share(
-    state: State<AppState>,
-    dest_path: String,
+pub async fn create_share(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
     expires_days: Option<u32>,
-) -> Result<ShareResult, String> {
-    // SECURITY: constrain the JS-supplied save target to an absolute `.html` path
-    // (see validate_dest_path) so a malicious invoke can't clobber arbitrary files.
-    let dest = validate_dest_path(&dest_path, &["html", "htm"])?;
+) -> Result<Option<ShareResult>, String> {
+    let Some(file) = app
+        .dialog()
+        .file()
+        .set_title("生成加密分享文件")
+        .set_file_name("MedMe加密分享.html")
+        .add_filter("HTML", &["html"])
+        .blocking_save_file()
+    else {
+        return Ok(None); // 用户取消对话框
+    };
+    let picked = file.into_path().map_err(|e| e.to_string())?;
+    // Defense-in-depth: a native save pick is already absolute, but keep the extension /
+    // no-`..` checks so any future non-native caller can't smuggle a surprising path past us.
+    let dest = validate_dest_path(&picked.to_string_lossy(), &["html", "htm"])?;
     let v = lock(&state)?;
     let days = expires_days.unwrap_or(5);
     let (html, passphrase, record_count) = medme_share::share::build_encrypted_share(&v, days)?;
@@ -489,11 +532,12 @@ pub fn create_share(
     // 审计追踪:分享文件落盘成功后记入不可变事件日志(见 core-model::audit)。
     v.record_share(&sha256, record_count, &expires)
         .map_err(|e| e.to_string())?;
-    Ok(ShareResult {
+    Ok(Some(ShareResult {
         passphrase,
         record_count,
         byte_size,
-    })
+        path: dest.to_string_lossy().to_string(),
+    }))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -94,14 +94,20 @@ pub struct ImportOutcome {
 pub struct ExportSummary {
     pub file_count: i64,
     pub byte_size: i64,
+    /// 后端原生保存对话框选定并写入的绝对路径(供导出后「打开文件」按钮使用)。
+    /// 路径由后端从原生对话框获得,绝不由 webview 传入(见 GHSA-gmg4)。
+    pub path: String,
 }
 
-/// 加密分享生成结果:口令(分组显示)、记录数、文件字节数。
+/// 加密分享生成结果:口令(分组显示)、记录数、文件字节数、写入路径。
 #[derive(Serialize)]
 pub struct ShareResult {
     pub passphrase: String,
     pub record_count: i64,
     pub byte_size: i64,
+    /// 后端原生保存对话框选定并写入的绝对路径(供分享后「打开文件」按钮使用)。
+    /// 路径由后端从原生对话框获得,绝不由 webview 传入(见 GHSA-gmg4)。
+    pub path: String,
 }
 
 #[derive(Serialize)]

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -32,10 +32,12 @@ export const api = {  listTimelineGrouped: () => invoke<TimelineGroup[]>("list_t
     invoke<ImagingInstance[]>("get_imaging_instances", { documentId }),
   exportVault: (destPath: string) =>
     invoke<ExportSummary>("export_vault", { destPath }),
-  exportTimelineHtml: (destPath: string) =>
-    invoke<ExportSummary>("export_timeline_html", { destPath }),
-  createShare: (destPath: string, expiresDays?: number) =>
-    invoke<ShareResult>("create_share", { destPath, expiresDays }),
+  // 安全:保存位置由 Rust 侧原生「保存」对话框选定并直接写入——路径绝不经由 webview
+  // 传入(见 GHSA-gmg4)。写入后端返回含写入路径的结果;用户取消对话框返回 null。
+  exportTimelineHtml: () =>
+    invoke<ExportSummary | null>("export_timeline_html"),
+  createShare: (expiresDays?: number) =>
+    invoke<ShareResult | null>("create_share", { expiresDays }),
   getPatientProfile: () => invoke<PatientProfile>("get_patient_profile"),
   getInboxPath: () => invoke<string>("get_inbox_path"),
   // 收件箱文件夹由 Rust 侧原生「选择文件夹」对话框选择,返回新路径(取消则返回原路径)。

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -14,7 +14,6 @@ import {
 } from "lucide-react";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { listen } from "@tauri-apps/api/event";
-import { save } from "@tauri-apps/plugin-dialog";
 import { api } from "../api";
 import type { ImportOutcome } from "../types";
 
@@ -68,27 +67,24 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
     | null
   >(null);
 
-  // 端到端加密分享:选保存路径 → 生成自包含加密 HTML(含浏览器内查看器)→
-  // 返回口令(需另行单独告知医生)。数据零服务器,浏览器本地解密。
+  // 端到端加密分享:后端(Rust)弹原生「保存」对话框选保存路径 → 生成自包含加密 HTML
+  // (含浏览器内查看器)→ 返回口令(需另行单独告知医生)与写入路径。数据零服务器,
+  // 浏览器本地解密。安全:保存路径由后端从原生对话框获得,不再经 webview 传入。
   const doShare = async () => {
-    let path: string | null;
-    try {
-      path = await save({
-        defaultPath: "MedMe加密分享.html",
-        filters: [{ name: "HTML", extensions: ["html"] }],
-      });
-    } catch (e) {
-      setShareResult({ kind: "err", text: `选择保存位置失败:${String(e)}` });
-      return;
-    }
-    if (!path) return;
     const days = Number.isFinite(shareDays) && shareDays > 0 ? Math.floor(shareDays) : 5;
     setSharing(true);
     setShareResult(null);
     setCopied(false);
     try {
-      const r = await api.createShare(path, days);
-      setShareResult({ kind: "ok", passphrase: r.passphrase, count: r.record_count, days, path });
+      const r = await api.createShare(days);
+      if (!r) return; // 用户取消了保存对话框
+      setShareResult({
+        kind: "ok",
+        passphrase: r.passphrase,
+        count: r.record_count,
+        days,
+        path: r.path,
+      });
     } catch (e) {
       setShareResult({ kind: "err", text: `生成失败:${String(e)}` });
     } finally {
@@ -110,27 +106,18 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
     api.getInboxPath().then(setInboxPath).catch(() => {});
   }, []);
 
-  // 导出 v1:选保存路径 → 生成自包含 HTML → 浏览器可「打印 / 另存为 PDF」交给医生。
+  // 导出 v1:后端(Rust)弹原生「保存」对话框选保存路径 → 生成自包含 HTML → 浏览器可
+  // 「打印 / 另存为 PDF」交给医生。安全:保存路径由后端从原生对话框获得,不再经 webview 传入。
   const doExport = async () => {
-    let path: string | null;
-    try {
-      path = await save({
-        defaultPath: "MedMe导出.html",
-        filters: [{ name: "HTML", extensions: ["html"] }],
-      });
-    } catch (e) {
-      setExportMsg({ kind: "err", text: `选择保存位置失败:${String(e)}` });
-      return;
-    }
-    if (!path) return;
     setExporting(true);
     setExportMsg(null);
     try {
-      const summary = await api.exportTimelineHtml(path);
+      const summary = await api.exportTimelineHtml();
+      if (!summary) return; // 用户取消了保存对话框
       setExportMsg({
         kind: "ok",
         text: `已导出 ${summary.file_count} 份记录,可在浏览器打开后「打印 / 另存为 PDF」交给医生。`,
-        path,
+        path: summary.path,
       });
     } catch (e) {
       setExportMsg({ kind: "err", text: `导出失败:${String(e)}` });

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -41,11 +41,15 @@ export interface ImagingInstance {
 export interface ExportSummary {
   file_count: number;
   byte_size: number;
+  // 后端原生保存对话框选定并写入的绝对路径(供导出后「打开文件」按钮使用)。
+  path: string;
 }
 export interface ShareResult {
   passphrase: string;
   record_count: number;
   byte_size: number;
+  // 后端原生保存对话框选定并写入的绝对路径(供分享后「打开文件」按钮使用)。
+  path: string;
 }
 export interface PatientProfile {
   name: string | null;


### PR DESCRIPTION
Closes the export/share residual noted in **GHSA-gmg4** / PR #40. `export_timeline_html` and `create_share` still took their destination path from the frontend's JS `save()` dialog (only `validate_dest_path`-guarded), so a compromised webview could name an arbitrary `.html` path to clobber with app-generated content.

## Change
Both commands are now `async`, take **no path arg**, and open the native save dialog **from Rust** (`DialogExt::blocking_save_file`, same pattern as #40's import/folder pickers). The backend writes the app-generated HTML to the chosen path, registers it in the `openable_paths` allowlist (so "打开文件" keeps working via `open_path`), and returns it. Cancel → no-op. `validate_dest_path` stays as defense-in-depth on the backend-obtained path. The webview can trigger export/share but can no longer name the target file.

## UX preserved
Same native save dialog, default filename + `.html` filter; file written; "打开文件" opens it.

## Gate
`cargo fmt` clean · `cargo clippy -p medme-desktop -- -D warnings` clean · `cargo check`/`cargo test -p medme-desktop` (9) · frontend `tsc --noEmit` clean.