### PR TITLE
fix(security): isolate share/export DICOM decode (GHSA-24px residual)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -450,7 +450,15 @@ pub fn export_timeline_html(
     // (see validate_dest_path) so a malicious invoke can't clobber arbitrary files.
     let dest = validate_dest_path(&dest_path, &["html", "htm"])?;
     let v = lock(&state)?;
-    let (html, record_count) = medme_share::export::build_timeline_html(&v)?;
+    // SECURITY (advisory GHSA-24px): render each DICOM's anchor slice in the
+    // isolated decode child, NOT in-process. The desktop workspace build links
+    // the C/C++ JPEG2000/JPEG-LS codecs into the shared `dicom` dep (feature
+    // unification), so decoding attacker-supplied compressed pixels here would be
+    // the same RCE surface the viewer path already isolates. A crash/timeout comes
+    // back as `None` and the export degrades to a text line. See `dicom_subprocess`.
+    let (html, record_count) = medme_share::export::build_timeline_html(&v, &|b| {
+        crate::dicom_subprocess::render_png(b).ok()
+    })?;
     let byte_size = html.len() as i64;
     let sha256 = core_model::cas::sha256_hex(html.as_bytes());
     std::fs::write(&dest, html).map_err(|e| e.to_string())?;
@@ -479,7 +487,15 @@ pub fn create_share(
     let dest = validate_dest_path(&dest_path, &["html", "htm"])?;
     let v = lock(&state)?;
     let days = expires_days.unwrap_or(5);
-    let (html, passphrase, record_count) = medme_share::share::build_encrypted_share(&v, days)?;
+    // SECURITY (advisory GHSA-24px): when an oversized imaging study degrades to a
+    // key-slice PNG, decode that slice in the isolated child process, NOT in-process
+    // — the desktop build links the C/C++ codecs into the shared `dicom` dep, so an
+    // in-process decode of attacker-supplied compressed pixels is an RCE surface. A
+    // crash/timeout degrades to the existing text line. See `dicom_subprocess`.
+    let (html, passphrase, record_count) =
+        medme_share::share::build_encrypted_share(&v, days, &|b| {
+            crate::dicom_subprocess::render_png(b).ok()
+        })?;
     let byte_size = html.len() as i64;
     let sha256 = core_model::cas::sha256_hex(html.as_bytes());
     std::fs::write(&dest, html).map_err(|e| e.to_string())?;

--- a/apps/mobile/src-tauri/src/commands.rs
+++ b/apps/mobile/src-tauri/src/commands.rs
@@ -439,7 +439,13 @@ pub fn create_share(
 ) -> Result<ShareResult, String> {
     let v = lock(&state)?;
     let days = expires_days.unwrap_or(5);
-    let (html, passphrase, record_count) = medme_share::share::build_encrypted_share(&v, days)?;
+    // 移动端 Android 构建把 `dicom` 的 C/C++ `codecs` 关掉,进程内解码不含 RCE 面
+    // (GHSA-24px 仅影响链接了 codecs 的桌面),故直接注入进程内渲染器。
+    let (html, passphrase, record_count) = medme_share::share::build_encrypted_share(
+        &v,
+        days,
+        &medme_share::render_dicom_png_in_process,
+    )?;
     let byte_size = html.len() as i64;
     let sha256 = core_model::cas::sha256_hex(html.as_bytes());
 

--- a/packages/share/src/export.rs
+++ b/packages/share/src/export.rs
@@ -88,11 +88,16 @@ fn fmt_date(d: Option<chrono::DateTime<chrono::Utc>>) -> Option<String> {
 /// 为图片/DICOM 原件生成内嵌预览块;PDF 及其他类型不内嵌(仅保留文字与文件名),
 /// 避免额外的解码/渲染成本。
 ///
-/// 影像(DICOM)导出的是“轻档 · 关键切片”(014 §4):把该检查的**锚点切片**用
-/// `dicom::render_png` 渲成 PNG 内嵌,配一句“完整序列见分享”的说明,像胶片一样能打印。
-/// 渲染务必稳健:遇到不支持的压缩(render_png 失败)或读盘失败时**降级为一行说明**,
-/// 绝不因单条影像中断整份导出。
-fn render_preview(vault: &Vault, sf: &SourceFile) -> Result<Option<String>, String> {
+/// 影像(DICOM)导出的是“轻档 · 关键切片”(014 §4):把该检查的**锚点切片**经注入式
+/// `render_dicom_png`(见 [`crate::DicomPngRenderer`])渲成 PNG 内嵌,配一句“完整序列见
+/// 分享”的说明,像胶片一样能打印。桌面把该渲染器指向隔离子进程(GHSA-24px),故本函数
+/// 在主进程内绝不解码压缩像素。渲染务必稳健:遇到不支持的压缩(渲染器返回 `None`)或读盘
+/// 失败时**降级为一行说明**,绝不因单条影像中断整份导出。
+fn render_preview(
+    vault: &Vault,
+    sf: &SourceFile,
+    render_dicom_png: crate::DicomPngRenderer,
+) -> Result<Option<String>, String> {
     if sf.mime_type.starts_with("image/") {
         let bytes = std::fs::read(vault.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
         let b64 = B64.encode(&bytes);
@@ -106,10 +111,11 @@ fn render_preview(vault: &Vault, sf: &SourceFile) -> Result<Option<String>, Stri
         )));
     }
     if sf.mime_type == "application/dicom" {
-        // 读盘或渲染失败都降级为说明,不中断导出。
+        // 读盘或渲染失败都降级为说明,不中断导出。渲染经注入器(桌面=隔离子进程,
+        // GHSA-24px),本进程不碰编解码器。
         let png = std::fs::read(vault.root_join(&sf.storage_path))
             .ok()
-            .and_then(|bytes| dicom::render_png(&bytes).ok());
+            .and_then(|bytes| render_dicom_png(&bytes));
         return Ok(Some(match png {
             Some(png) => format!(
                 "<figure class=\"imaging\"><img class=\"preview\" src=\"data:image/png;base64,{}\" alt=\"影像关键切片\"><figcaption class=\"caption\">影像:关键切片(完整序列见分享)</figcaption></figure>\n",
@@ -143,7 +149,13 @@ fn format_patient_line(p: &pipeline::PatientProfile) -> String {
 }
 
 /// 构建整条时间线的自包含导出 HTML。返回 `(html, 记录数)`。
-pub fn build_timeline_html(vault: &Vault) -> Result<(String, i64), String> {
+///
+/// `render_dicom_png` 是注入式 DICOM→PNG 渲染器(见 [`crate::DicomPngRenderer`]):
+/// 桌面必须传入子进程隔离版(GHSA-24px),使本函数在主进程内绝不解码压缩像素。
+pub fn build_timeline_html(
+    vault: &Vault,
+    render_dicom_png: crate::DicomPngRenderer,
+) -> Result<(String, i64), String> {
     let records = gather_records(vault)?;
     let profile = pipeline::patient_profile(vault).map_err(|e| e.to_string())?;
 
@@ -165,7 +177,7 @@ pub fn build_timeline_html(vault: &Vault) -> Result<(String, i64), String> {
             (None, _) => "无日期".to_string(),
         };
 
-        let preview = render_preview(vault, sf)?;
+        let preview = render_preview(vault, sf, render_dicom_png)?;
 
         body.push_str("<section class=\"record\">\n");
         body.push_str(&format!(
@@ -283,7 +295,8 @@ mod tests {
             })
             .unwrap();
 
-        let (html, count) = build_timeline_html(&vault).unwrap();
+        let (html, count) =
+            build_timeline_html(&vault, &crate::render_dicom_png_in_process).unwrap();
         assert_eq!(count, 1);
         // 转义生效:原始 <script> 标签不应逐字出现在输出里
         assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
@@ -320,11 +333,73 @@ mod tests {
             })
             .unwrap();
 
-        let (html, count) = build_timeline_html(&vault).unwrap();
+        let (html, count) =
+            build_timeline_html(&vault, &crate::render_dicom_png_in_process).unwrap();
         assert_eq!(count, 1);
         // 关键切片 PNG 已内嵌,配“完整序列见分享”说明。
         assert!(html.contains("data:image/png;base64,"));
         assert!(html.contains("关键切片"));
+    }
+
+    /// Imports a DICOM instance and files it as an imaging document. Shared by the
+    /// decoder-injection seam tests below.
+    fn vault_with_one_dicom(dir: &std::path::Path) -> Vault {
+        let vault = Vault::open(dir).unwrap();
+        let dcm = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/demo-dataset/dicom/CT_small.dcm"
+        ))
+        .unwrap();
+        let imp = vault
+            .import("CT_small.dcm", "application/dicom", &dcm)
+            .unwrap();
+        vault
+            .add_document(NewDocument {
+                source_file_id: imp.source_file.id,
+                doc_type: DocType::ImagingReport,
+                doc_date: Some(chrono::Utc::now()),
+                doc_date_end: None,
+                title: Some("头颅CT".into()),
+                language: None,
+                page_count: 1,
+            })
+            .unwrap();
+        vault
+    }
+
+    #[test]
+    fn dicom_preview_comes_only_from_the_injected_renderer() {
+        // GHSA-24px seam: the export must obtain every DICOM preview PNG from the
+        // injected renderer (which desktop points at an isolated subprocess), never
+        // by calling an in-crate codec itself. Inject a sentinel renderer whose
+        // bytes could not come from a real PNG encoder; if those exact bytes land in
+        // the export, the decode went through the seam and nowhere else.
+        let dir = tempfile::tempdir().unwrap();
+        let vault = vault_with_one_dicom(dir.path());
+        let sentinel: Vec<u8> = b"INJECTED-NOT-A-REAL-PNG".to_vec();
+        let (html, count) = build_timeline_html(&vault, &|_| Some(sentinel.clone())).unwrap();
+        assert_eq!(count, 1);
+        assert!(
+            html.contains(&format!("data:image/png;base64,{}", B64.encode(&sentinel))),
+            "the injected renderer's bytes must be what the export embeds"
+        );
+    }
+
+    #[test]
+    fn dicom_export_degrades_when_injected_renderer_returns_none() {
+        // Behavior preservation: an unsupported/failed decode (renderer → None, as a
+        // crashed/killed subprocess reports) must degrade to the existing one-line
+        // note, exactly like the pre-injection unsupported-transfer-syntax path —
+        // never abort the whole export.
+        let dir = tempfile::tempdir().unwrap();
+        let vault = vault_with_one_dicom(dir.path());
+        let (html, count) = build_timeline_html(&vault, &|_| None).unwrap();
+        assert_eq!(count, 1);
+        assert!(!html.contains("data:image/png;base64,"), "no PNG when None");
+        assert!(
+            html.contains("不支持的压缩格式"),
+            "degrades to the text note"
+        );
     }
 
     #[test]
@@ -334,7 +409,7 @@ mod tests {
         // script.
         let dir = tempfile::tempdir().unwrap();
         let vault = Vault::open(dir.path()).unwrap();
-        let (html, _) = build_timeline_html(&vault).unwrap();
+        let (html, _) = build_timeline_html(&vault, &crate::render_dicom_png_in_process).unwrap();
         assert!(html.contains(
             "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'none'; form-action 'none'; base-uri 'none'\">"
         ));
@@ -357,7 +432,8 @@ mod tests {
     fn handles_empty_vault() {
         let dir = tempfile::tempdir().unwrap();
         let vault = Vault::open(dir.path()).unwrap();
-        let (html, count) = build_timeline_html(&vault).unwrap();
+        let (html, count) =
+            build_timeline_html(&vault, &crate::render_dicom_png_in_process).unwrap();
         assert_eq!(count, 0);
         assert!(html.contains("本导出由 MedMe 生成"));
     }

--- a/packages/share/src/lib.rs
+++ b/packages/share/src/lib.rs
@@ -10,3 +10,23 @@
 
 pub mod export;
 pub mod share;
+
+/// 注入式 DICOM→PNG 渲染器:给定一份 DICOM 实例的原始字节,返回其锚点切片的 PNG;
+/// 无法渲染(不支持的压缩 / 解码失败)时返回 `None`,构建器随即降级为一行文字说明
+/// —— 与本就存在的降级行为逐字一致。
+///
+/// 为何**注入**而不写死成 [`dicom::render_png`]:GHSA-24px。桌面工作区构建里,Cargo
+/// 特性合并会为共享的 `dicom` 依赖打开 C/C++ 的 JPEG2000/JPEG-LS 解码器(`codecs`);
+/// 于是在**主进程**里解码攻击者提供的压缩像素,就是一处内存破坏型 RCE 面(正是 #44
+/// 为「查看」路径关闭的那一处)。因此桌面改为注入一个**在隔离子进程里解码**的渲染器
+/// (见 `dicom_subprocess`),share 包在桌面上自身绝不再调用进程内的编解码器。移动端
+/// Android 构建把 `codecs` 关掉,故 [`render_dicom_png_in_process`] 在那里是安全的。
+pub type DicomPngRenderer<'a> = &'a dyn Fn(&[u8]) -> Option<Vec<u8>>;
+
+/// 进程内 DICOM→PNG 渲染器(经链接进来的 `dicom` 直接解码)。仅在 `dicom` **不含**
+/// C/C++ `codecs` 特性(移动端)或输入可信(测试)时,才可作为 [`DicomPngRenderer`]
+/// 传入。桌面**禁止**使用它 —— 见 [`DicomPngRenderer`](GHSA-24px)—— 而应注入
+/// 子进程隔离的渲染器。
+pub fn render_dicom_png_in_process(dcm_bytes: &[u8]) -> Option<Vec<u8>> {
+    dicom::render_png(dcm_bytes).ok()
+}

--- a/packages/share/src/share.rs
+++ b/packages/share/src/share.rs
@@ -77,9 +77,15 @@ fn decide_imaging_tier(study_bytes: usize, already_embedded: usize) -> ImagingTi
 }
 
 /// 构建加密分享 HTML。返回 `(html, 分组后的口令, 记录数)`。
+///
+/// `render_dicom_png` 是注入式 DICOM→PNG 渲染器(见 [`crate::DicomPngRenderer`]):
+/// 仅在影像因体积上限降级为「锚点切片 PNG」时才会被调用。桌面必须传入子进程隔离版
+/// (GHSA-24px),使本函数在主进程内绝不解码压缩像素;移动端可传
+/// [`crate::render_dicom_png_in_process`]。
 pub fn build_encrypted_share(
     v: &Vault,
     expires_days: u32,
+    render_dicom_png: crate::DicomPngRenderer,
 ) -> Result<(String, String, i64), String> {
     let records = crate::export::gather_records(v)?;
     let profile = pipeline::patient_profile(v).map_err(|e| e.to_string())?;
@@ -144,9 +150,10 @@ pub fn build_encrypted_share(
                 ImagingTier::PngFallback { by_total } => {
                     degraded.push(title.clone());
                     // 锚点切片(第一张)渲成 PNG;不支持的压缩则连 PNG 也没有,只留说明。
+                    // 经注入渲染器解码(桌面=隔离子进程,GHSA-24px),本进程不碰编解码器。
                     let png = slices
                         .first()
-                        .and_then(|b| dicom::render_png(b).ok())
+                        .and_then(|b| render_dicom_png(b))
                         .map(|p| format!("data:image/png;base64,{}", B64.encode(&p)));
                     let note = if by_total {
                         "为控制分享文件体积,本影像未内嵌完整序列(整份已达上限并降级);如需诊断级请当面出示或用托管分享(后续)。".to_string()
@@ -1017,7 +1024,8 @@ mod tests {
             })
             .unwrap();
 
-        let (html, pass, n) = build_encrypted_share(&vault, 5).unwrap();
+        let (html, pass, n) =
+            build_encrypted_share(&vault, 5, &crate::render_dicom_png_in_process).unwrap();
         assert_eq!(n, 1);
         assert!(html.starts_with("<!doctype html>"));
         assert!(html.contains("id=\"share-data\"")); // blob 移进非执行数据节点
@@ -1081,7 +1089,8 @@ mod tests {
             })
             .unwrap();
 
-        let (html, pass, _n) = build_encrypted_share(&vault, 5).unwrap();
+        let (html, pass, _n) =
+            build_encrypted_share(&vault, 5, &crate::render_dicom_png_in_process).unwrap();
 
         // 取出 CSP meta 内容。
         let marker = "Content-Security-Policy\" content=\"";
@@ -1149,7 +1158,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = Vault::open(dir.path()).unwrap();
         vault.import("a.txt", "text/plain", b"x").unwrap();
-        let (html, _pass, _n) = build_encrypted_share(&vault, 5).unwrap();
+        let (html, _pass, _n) =
+            build_encrypted_share(&vault, 5, &crate::render_dicom_png_in_process).unwrap();
 
         assert!(html.contains("function isDataImage"), "validator present");
         assert!(html.contains("isDataImage(img)"), "images[] sink validated");
@@ -1210,7 +1220,8 @@ mod tests {
             })
             .unwrap();
 
-        let (html, pass, n) = build_encrypted_share(&vault, 7).unwrap();
+        let (html, pass, n) =
+            build_encrypted_share(&vault, 7, &crate::render_dicom_png_in_process).unwrap();
         assert_eq!(n, 1);
         // 自包含:内联 dicom-parser + 查看器入口都在 HTML 内。
         assert!(html.contains("dicomParser") || html.contains("dicom-parser"));


### PR DESCRIPTION
Closes the share/export residual noted in **GHSA-24px** / PR #44. #44 isolated the desktop DICOM *view* path, but `share`/`export` still decoded DICOM **in-process** via `dicom::render_png`. `medme-share` builds `dicom` with codecs off, but in the desktop workspace build Cargo feature-unification turns the C/C++ codecs ON for the shared dep — so building a share/export from an attacker-supplied JPEG2000/JPEG-LS DICOM decoded in the main process (the RCE surface #44 closed for viewing).

## Change (dependency-injected decoder seam)
- `build_timeline_html` / `render_preview` / `build_encrypted_share` now take a `DicomPngRenderer` instead of calling `dicom::render_png` directly.
- **Desktop** injects the #44 subprocess wrapper (`--decode-dicom` child, `check_bounds` pre-spawn + timeout + output cap) → **no codec runs in the desktop main process**.
- **Mobile** injects the in-process renderer (`render_dicom_png_in_process`) — safe because Android builds `dicom` with codecs off.
- The only remaining in-crate `render_png` call lives inside `render_dicom_png_in_process`, which desktop never invokes.

## Behavior preserved
Valid DICOMs render the identical PNG; unsupported / crash / timeout degrades to the existing text note (never aborts export/share). Share viewer + plaintext export markup untouched.

## Gate
`cargo fmt` clean · `cargo clippy -p medme-share -p medme-desktop -- -D warnings` clean · `cargo check -p medme-desktop` · `cargo test -p medme-share` 16 pass (2 new seam tests).