### PR TITLE
feat(ocr): 补齐 #41 余下平台原生 OCR —— HEIC 解码 + Windows 桌面 + Android ML Kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,7 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-vision",
+ "pollster",
  "windows 0.62.2",
 ]
 
@@ -5063,6 +5064,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "polyval"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,6 +3182,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,7 +3854,9 @@ dependencies = [
  "chrono",
  "core-model",
  "dicom",
+ "jni 0.22.4",
  "medme-share",
+ "ndk-context",
  "ocr",
  "parser",
  "pipeline",
@@ -4054,6 +4086,12 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -5750,7 +5788,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -6158,6 +6196,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6165,6 +6213,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -6434,7 +6488,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -6496,7 +6550,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -6682,7 +6736,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -6705,7 +6759,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -8346,7 +8400,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,7 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-vision",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6442,7 +6443,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6519,7 +6520,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6660,7 +6661,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -6686,7 +6687,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6711,7 +6712,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -7739,7 +7740,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -7763,7 +7764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7841,11 +7842,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -7855,6 +7868,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7891,7 +7913,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7936,6 +7969,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8074,6 +8117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8307,7 +8359,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,9 +4393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
 ]
 
@@ -4406,13 +4404,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
- "objc2-metal",
 ]
 
 [[package]]
@@ -4536,17 +4531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,8 +4616,6 @@ dependencies = [
  "lopdf 0.43.0",
  "oar-ocr",
  "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation",
  "objc2-vision",
 ]

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -68,6 +68,8 @@ ocr = { path = "../../../packages/ocr", features = ["engine"] }
 # `pipeline::ingest` path desktop uses. DICOM pixel codecs stay OFF (they can't
 # cross-compile via cmake for the NDK, and mobile does no pixel viewing).
 [target.'cfg(target_os = "android")'.dependencies]
+jni = "0.22.4"
+ndk-context = "0.1.1"
 ocr = { path = "../../../packages/ocr", default-features = false, features = [
     "engine",
 ] }

--- a/apps/mobile/src-tauri/gen/android/app/build.gradle.kts
+++ b/apps/mobile/src-tauri/gen/android/app/build.gradle.kts
@@ -63,6 +63,11 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.10.1")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.lifecycle:lifecycle-process:2.10.0")
+    // On-device Chinese OCR (ML Kit Text Recognition v2). The `-chinese`
+    // artifact BUNDLES the Chinese model in the APK → offline, no Google Play
+    // download (works on Chinese phones without Play Services). Called from Rust
+    // via JNI (see MlkitOcr.kt + src/mlkit.rs).
+    implementation("com.google.mlkit:text-recognition-chinese:16.0.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")

--- a/apps/mobile/src-tauri/gen/android/app/src/main/java/com/medme/mobile/MlkitOcr.kt
+++ b/apps/mobile/src-tauri/gen/android/app/src/main/java/com/medme/mobile/MlkitOcr.kt
@@ -1,0 +1,31 @@
+package com.medme.mobile
+
+import android.graphics.BitmapFactory
+import com.google.android.gms.tasks.Tasks
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
+
+/**
+ * On-device Chinese OCR via ML Kit Text Recognition v2 (bundled model → offline,
+ * no Google Play download). Replaces the weaker PP-OCRv5 mobile model on Android.
+ *
+ * Called from Rust via JNI (`src/mlkit.rs`). Runs synchronously (`Tasks.await`),
+ * so the caller MUST invoke it off the main thread — the Rust ingest thread does.
+ * Any failure returns "" so the Rust side falls back to storing the file with no
+ * extracted text (non-fatal), exactly like any other OCR failure.
+ */
+object MlkitOcr {
+    @JvmStatic
+    fun recognize(bytes: ByteArray): String {
+        return try {
+            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return ""
+            val image = InputImage.fromBitmap(bitmap, 0)
+            val recognizer =
+                TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+            Tasks.await(recognizer.process(image)).text
+        } catch (e: Exception) {
+            ""
+        }
+    }
+}

--- a/apps/mobile/src-tauri/src/commands.rs
+++ b/apps/mobile/src-tauri/src/commands.rs
@@ -162,9 +162,12 @@ fn ingest_dispatch(
 /// 图片 MIME 判定(仅 iOS 用于路由到 Vision)。
 #[cfg(target_os = "ios")]
 fn is_image(path: &std::path::Path) -> bool {
+    // incl. image/heic — iPhone photos default to HEIC; the Vision bridge
+    // (OcrVision.swift via CGImageSource) decodes it, the Rust oar-ocr path
+    // can't, so HEIC must route to Vision here.
     matches!(
         pipeline::mime_for(path),
-        "image/jpeg" | "image/png" | "image/tiff"
+        "image/jpeg" | "image/png" | "image/tiff" | "image/heic"
     )
 }
 

--- a/apps/mobile/src-tauri/src/commands.rs
+++ b/apps/mobile/src-tauri/src/commands.rs
@@ -95,9 +95,10 @@ pub fn load_archive(state: State<AppState>) -> Result<Vec<TimelineGroup>, String
 /// 跑一次 ingest 并映射为前端 `ImportOutcome`。抽取失败(扫描图等)不致命
 /// —— 原文件已进 CAS,返回 status="failed" 让前端提示「未能识别」而非报错崩溃。
 ///
-/// iOS 与桌面的分岔点在 `ingest_dispatch`:iOS 上的**图片**走 Apple Vision(见
-/// `vision` 模块 / `ingest_image_via_vision`),其余一切(以及桌面/host 构建)沿用
-/// 未改动的 `pipeline::ingest`。
+/// 各端的分岔点在 `ingest_dispatch`:iOS 上的**图片**走 Apple Vision(见
+/// `vision` 模块 / `ingest_image_via_vision`),安卓上的图片走 ML Kit(见 `mlkit`
+/// 模块 / `ingest_image_via_mlkit`),其余一切(以及桌面/host 构建)沿用未改动的
+/// `pipeline::ingest`。
 fn ingest_one(app: &tauri::AppHandle, v: &Vault, path: &std::path::Path) -> ImportOutcome {
     // Panic firewall: a panic inside the parser/dicom/ocr/vision stack (defense-in-depth
     // over their internal guards) is caught here and turned into a `failed` outcome,
@@ -143,28 +144,35 @@ fn ingest_one(app: &tauri::AppHandle, v: &Vault, path: &std::path::Path) -> Impo
     }
 }
 
-/// ingest 分岔:iOS 图片 → Apple Vision;其余 → 共享 `pipeline::ingest`(桌面行为不变)。
+/// ingest 分岔:iOS 图片 → Apple Vision;安卓图片 → ML Kit;其余 → 共享
+/// `pipeline::ingest`(桌面行为不变)。
 fn ingest_dispatch(
     app: &tauri::AppHandle,
     v: &Vault,
     path: &std::path::Path,
 ) -> anyhow::Result<pipeline::IngestOutcome> {
-    let _ = app; // 非 iOS 上未用
+    let _ = app; // 非 iOS/安卓上未用
     #[cfg(target_os = "ios")]
     {
         if is_image(path) {
             return ingest_image_via_vision(v, path);
         }
     }
+    #[cfg(target_os = "android")]
+    {
+        if is_image(path) {
+            return ingest_image_via_mlkit(v, path);
+        }
+    }
     pipeline::ingest(v, path)
 }
 
-/// 图片 MIME 判定(仅 iOS 用于路由到 Vision)。
-#[cfg(target_os = "ios")]
+/// 图片 MIME 判定(iOS 路由到 Vision、安卓路由到 ML Kit)。
+#[cfg(any(target_os = "ios", target_os = "android"))]
 fn is_image(path: &std::path::Path) -> bool {
-    // incl. image/heic — iPhone photos default to HEIC; the Vision bridge
-    // (OcrVision.swift via CGImageSource) decodes it, the Rust oar-ocr path
-    // can't, so HEIC must route to Vision here.
+    // incl. image/heic — iPhone photos default to HEIC; the native OCR bridges
+    // (iOS Vision via CGImageSource / Android ML Kit via BitmapFactory) decode
+    // it, the Rust oar-ocr path can't, so HEIC must route to the native OCR.
     matches!(
         pipeline::mime_for(path),
         "image/jpeg" | "image/png" | "image/tiff" | "image/heic"
@@ -251,6 +259,101 @@ fn ingest_image_via_vision(
     } else {
         // Vision 未识别出文字:退回文件名元数据(与 pipeline 的 StoredNoText 同构),
         // 不建 ocr_result;原件已永存,时间线仍可见、可出示。
+        let (doc_date, doc_date_end) = parser::guess_date_range(&name);
+        let doc_type = parser::classify(&name);
+        v.add_document(NewDocument {
+            source_file_id: sid,
+            doc_type: doc_type.clone(),
+            doc_date,
+            doc_date_end,
+            title: Some(name.clone()),
+            language: None,
+            page_count: 1,
+        })?;
+        Ok(IngestOutcome {
+            source_file_id: sid,
+            name,
+            status: IngestStatus::StoredNoText,
+            doc_type: Some(doc_type),
+        })
+    }
+}
+
+/// 安卓图片 OCR:ML Kit Text Recognition v2(设备端、离线、捆绑中文模型)替代对
+/// 中文病历识别很差的 PP-OCRv5 mobile 模型,经 JNI 调 Kotlin `MlkitOcr`。结构与
+/// `ingest_image_via_vision` 一致(原始字节入 CAS → 识别出文字建 document+ocr_result
+/// 后端 `MlKit`,空则退回文件名元数据),只换 OCR 后端。有意与 iOS 版重复,避免重构
+/// 已验证的 iOS 路径带来风险。桌面/pipeline/ocr 不受影响。
+#[cfg(target_os = "android")]
+fn ingest_image_via_mlkit(
+    v: &Vault,
+    path: &std::path::Path,
+) -> anyhow::Result<pipeline::IngestOutcome> {
+    use core_model::{NewDocument, NewOcr, OcrBackendKind};
+    use pipeline::{IngestOutcome, IngestStatus};
+
+    let len = std::fs::metadata(path)?.len();
+    if len > pipeline::MAX_INGEST_BYTES {
+        anyhow::bail!(
+            "文件过大:{len} 字节,超过上限 {} 字节(200MB),已拒绝导入 / file too large",
+            pipeline::MAX_INGEST_BYTES
+        );
+    }
+    let bytes = std::fs::read(path)?;
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let imp = v.import(&name, pipeline::mime_for(path), &bytes)?;
+    let sid = imp.source_file.id;
+    if imp.deduped && v.has_document(sid)? {
+        return Ok(IngestOutcome {
+            source_file_id: sid,
+            name,
+            status: IngestStatus::Deduped,
+            doc_type: None,
+        });
+    }
+
+    // 设备端 ML Kit OCR(离线,JNI → Kotlin MlkitOcr)。
+    let recognized = crate::mlkit::recognize(&bytes)?;
+    let text = recognized.trim().to_string();
+
+    if !text.is_empty() {
+        let doc_type = parser::classify(&text);
+        let (doc_date, doc_date_end) = parser::guess_date_range(&text);
+        let doc = v.add_document(NewDocument {
+            source_file_id: sid,
+            doc_type: doc_type.clone(),
+            doc_date,
+            doc_date_end,
+            title: Some(name.clone()),
+            language: parser::detect_language(&text),
+            page_count: 1,
+        })?;
+        v.add_ocr(NewOcr {
+            document_id: doc.id,
+            page_no: 1,
+            backend: OcrBackendKind::MlKit,
+            model_version: "mlkit".into(),
+            text: recognized,
+            // ML Kit exposes no confidence; report a fixed moderate value.
+            confidence: Some(0.85),
+        })?;
+        let status = if imp.deduped {
+            IngestStatus::Backfilled
+        } else {
+            IngestStatus::New
+        };
+        Ok(IngestOutcome {
+            source_file_id: sid,
+            name,
+            status,
+            doc_type: Some(doc_type),
+        })
+    } else {
         let (doc_date, doc_date_end) = parser::guess_date_range(&name);
         let doc_type = parser::classify(&name);
         v.add_document(NewDocument {

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -5,6 +5,10 @@ mod dto;
 /// macOS host build and desktop/Android, which keep the plain local vault.
 #[cfg(target_os = "ios")]
 mod icloud;
+/// Android ML Kit OCR bridge (JNI → Kotlin `MlkitOcr`). iOS/desktop compile it
+/// out. See the module + `MlkitOcr.kt` (#41).
+#[cfg(target_os = "android")]
+mod mlkit;
 /// Apple Vision OCR bridge — iOS only (see module docs). Compiled out on the
 /// macOS host build and desktop, which keep the oar-ocr pipeline path.
 #[cfg(target_os = "ios")]

--- a/apps/mobile/src-tauri/src/mlkit.rs
+++ b/apps/mobile/src-tauri/src/mlkit.rs
@@ -1,0 +1,45 @@
+//! Android ML Kit OCR bridge (Android only).
+//!
+//! On Android the Rust `oar-ocr` / PP-OCRv5 mobile model recognizes Chinese
+//! medical records poorly. Google **ML Kit Text Recognition v2** (Chinese,
+//! bundled model → offline) does far better. ML Kit is a Java/Kotlin SDK, so
+//! Rust calls it over **JNI**: the Kotlin `MlkitOcr.recognize(ByteArray): String`
+//! (see `gen/android/.../MlkitOcr.kt`) is invoked with the image bytes and
+//! returns the recognized text.
+//!
+//! Mirrors the iOS Apple Vision bridge (`vision.rs`) at the ingest layer, but
+//! over JNI instead of C-ABI (Android runs on the JVM). Compiled out on every
+//! non-Android target.
+
+use anyhow::{Context, Result};
+use jni::objects::{JString, JValue};
+use jni::{jni_sig, jni_str};
+
+/// Recognize text in raw encoded image bytes via ML Kit (blocks until done).
+/// Returns "" when ML Kit finds nothing or errors (caller treats as no text).
+pub fn recognize(bytes: &[u8]) -> Result<String> {
+    // The JavaVM is stashed by the Android runtime (ndk-glue / Tauri) — reuse it.
+    // `JavaVM::from_raw` in jni 0.22 is infallible; it just wraps the pointer.
+    let ctx = ndk_context::android_context();
+    let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) };
+
+    // jni 0.22 attaches the thread via a callback that receives `&mut Env`.
+    vm.attach_current_thread(|env| -> Result<String> {
+        let bytes_array = env
+            .byte_array_from_slice(bytes)
+            .context("byte_array_from_slice")?;
+        let result = env
+            .call_static_method(
+                jni_str!("com/medme/mobile/MlkitOcr"),
+                jni_str!("recognize"),
+                jni_sig!("([B)Ljava/lang/String;"),
+                &[JValue::Object(bytes_array.as_ref())],
+            )
+            .context("call MlkitOcr.recognize")?;
+        let jstr = env
+            .cast_local::<JString>(result.l().context("result not an object")?)
+            .context("cast result to JString")?;
+        let text = jstr.mutf8_chars(env)?.to_string();
+        Ok(text)
+    })
+}

--- a/packages/core-model/src/types.rs
+++ b/packages/core-model/src/types.rs
@@ -52,6 +52,9 @@ pub enum OcrBackendKind {
     /// Apple Vision (`VNRecognizeTextRequest`) — on-device, offline OCR used on
     /// iOS instead of the oar-ocr model download (impossible in the iOS sandbox).
     AppleVision,
+    /// Google ML Kit Text Recognition v2 (Chinese, bundled model) — on-device,
+    /// offline OCR used on Android instead of the weaker PP-OCRv5 mobile model.
+    MlKit,
 }
 impl OcrBackendKind {
     pub fn as_str(&self) -> &'static str {
@@ -60,6 +63,7 @@ impl OcrBackendKind {
             OcrBackendKind::Onnx => "onnx",
             OcrBackendKind::Vlm => "vlm",
             OcrBackendKind::AppleVision => "apple_vision",
+            OcrBackendKind::MlKit => "mlkit",
         }
     }
 }

--- a/packages/ocr/Cargo.toml
+++ b/packages/ocr/Cargo.toml
@@ -53,3 +53,6 @@ auto-download = ["oar-ocr?/auto-download"]
 objc2 = "0.6.4"
 objc2-foundation = "0.3.2"
 objc2-vision = "0.3.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62.2", features = ["Media_Ocr", "Graphics_Imaging", "Storage_Streams", "Foundation", "Globalization", "Foundation_Collections"] }

--- a/packages/ocr/Cargo.toml
+++ b/packages/ocr/Cargo.toml
@@ -55,4 +55,5 @@ objc2-foundation = "0.3.2"
 objc2-vision = "0.3.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+pollster = "1.0.1"
 windows = { version = "0.62.2", features = ["Media_Ocr", "Graphics_Imaging", "Storage_Streams", "Foundation", "Globalization", "Foundation_Collections"] }

--- a/packages/ocr/Cargo.toml
+++ b/packages/ocr/Cargo.toml
@@ -51,7 +51,5 @@ auto-download = ["oar-ocr?/auto-download"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-core-foundation = "0.3.2"
-objc2-core-graphics = "0.3.2"
 objc2-foundation = "0.3.2"
 objc2-vision = "0.3.2"

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -15,6 +15,10 @@ use lopdf::{Document, Object};
 /// build (oar-ocr is the fallback). See the module for the rationale (#41).
 #[cfg(target_os = "macos")]
 mod vision_macos;
+/// Windows on-device OCR via Windows.Media.Ocr — primary on the Windows build
+/// (oar-ocr is the fallback). See the module (#41).
+#[cfg(target_os = "windows")]
+mod windows_ocr;
 #[cfg(feature = "engine")]
 use oar_ocr::oarocr::{OAROCRBuilder, OAROCR};
 #[cfg(feature = "engine")]
@@ -389,14 +393,45 @@ pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
     }
 }
 
-#[cfg(all(not(target_os = "macos"), feature = "engine"))]
+/// Windows: Windows.Media.Ocr is the primary recognizer (offline, on-device,
+/// #41); if it errors or finds no text, fall back to the oar-ocr / PP-OCRv5
+/// engine.
+#[cfg(target_os = "windows")]
+pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    match windows_ocr::recognize_bytes(image_bytes) {
+        Ok(outcome) if !outcome.text.trim().is_empty() => return Ok(outcome),
+        Ok(_) => {} // ran but found nothing — try the engine.
+        Err(e) => eprintln!("[ocr] Windows.Media.Ocr failed, falling back to engine: {e:#}"),
+    }
+    #[cfg(feature = "engine")]
+    {
+        recognize_engine(image_bytes)
+    }
+    #[cfg(not(feature = "engine"))]
+    {
+        Ok(OcrOutcome {
+            text: String::new(),
+            confidence: 0.0,
+        })
+    }
+}
+
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    feature = "engine"
+))]
 pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
     recognize_engine(image_bytes)
 }
 
-/// No-`engine`, non-macOS stub: nothing to recognize with. Callers treat OCR
+/// No-`engine`, non-native stub: nothing to recognize with. Callers treat OCR
 /// failure as non-fatal (store the file without extracted text).
-#[cfg(all(not(target_os = "macos"), not(feature = "engine")))]
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(feature = "engine")
+))]
 pub fn recognize(_image_bytes: &[u8]) -> Result<OcrOutcome> {
     anyhow::bail!("ocr::recognize: OCR engine not available on this platform")
 }

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -357,14 +357,12 @@ fn recognize_engine(image_bytes: &[u8]) -> Result<OcrOutcome> {
     })
 }
 
-/// macOS: decode the bytes then run Apple Vision on the RGBA pixels.
+/// macOS: hand the raw bytes to Apple Vision, which decodes them via ImageIO
+/// (handles HEIC/HEIF iPhone photos + every Apple format, unlike the Rust
+/// `image` crate) and recognizes the text.
 #[cfg(target_os = "macos")]
 fn recognize_vision(image_bytes: &[u8]) -> Result<OcrOutcome> {
-    let dynamic =
-        decode_image_bounded(image_bytes).context("ocr::recognize(vision): decode image")?;
-    let rgba = dynamic.to_rgba8();
-    let (w, h) = (rgba.width(), rgba.height());
-    vision_macos::recognize_rgba(w, h, rgba.as_raw())
+    vision_macos::recognize_bytes(image_bytes)
 }
 
 /// Recognize text in image bytes. **macOS**: Apple Vision is the primary

--- a/packages/ocr/src/vision_macos.rs
+++ b/packages/ocr/src/vision_macos.rs
@@ -1,31 +1,32 @@
 //! macOS on-device OCR via Apple **Vision** (`VNRecognizeTextRequest`) —
 //! offline, no model download, strong Chinese. PRIMARY recognizer on the macOS
 //! desktop build; `recognize` falls back to oar-ocr / PP-OCRv5 if Vision yields
-//! nothing or errors. Mirrors the proven iOS `OcrVision.swift`, but pure Rust
-//! via `objc2` so the desktop crate needs no Swift toolchain / link wiring.
+//! nothing or errors. Pure Rust via `objc2` (no Swift toolchain / link wiring).
+//!
+//! Decoding goes through Vision's own `initWithData:` (ImageIO/CIImage under
+//! the hood), so it accepts **every Apple-supported format incl. HEIC/HEIF**
+//! (iPhone photos) — not just what the Rust `image` crate can decode. Mirrors
+//! the iOS `OcrVision.swift` behavior (which decodes via `CGImageSource`).
 
 use crate::OcrOutcome;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2::AnyThread;
-use objc2_core_foundation::{CFData, CFRetained};
-use objc2_core_graphics::{
-    CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGDataProvider, CGImage, CGImageAlphaInfo,
-};
-use objc2_foundation::{NSArray, NSDictionary, NSString};
+use objc2_foundation::{NSArray, NSData, NSDictionary, NSString};
 use objc2_vision::{
     VNImageOption, VNImageRequestHandler, VNRecognizeTextRequest, VNRequest,
     VNRequestTextRecognitionLevel,
 };
 
-/// Recognize text in already-decoded RGBA8 pixels (tightly packed) via Apple
-/// Vision. Returns joined lines + mean observation confidence (0..1).
-pub fn recognize_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<OcrOutcome> {
-    let cg = make_cgimage(width, height, rgba)?;
-    // SAFETY: standard Vision usage — build a text request, run it synchronously
-    // on the image, read observations. objc2 ref-counts all objects.
+/// Recognize text in raw encoded image bytes (JPEG/PNG/TIFF/HEIC/…) via Apple
+/// Vision. Returns lines joined top-to-bottom + mean observation confidence.
+pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    // SAFETY: standard Vision usage — VNImageRequestHandler decodes the NSData
+    // with ImageIO, then we run one synchronous text request and read the
+    // observations. objc2 ref-counts every object.
     unsafe {
+        let data = NSData::with_bytes(image_bytes);
         let request = VNRecognizeTextRequest::new();
         request.setRecognitionLevel(VNRequestTextRecognitionLevel::Accurate);
         // Simplified + Traditional Chinese + English (labels/units often EN).
@@ -38,9 +39,9 @@ pub fn recognize_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<OcrOutcome
         request.setUsesLanguageCorrection(true);
 
         let options = NSDictionary::<VNImageOption, AnyObject>::new();
-        let handler = VNImageRequestHandler::initWithCGImage_options(
+        let handler = VNImageRequestHandler::initWithData_options(
             VNImageRequestHandler::alloc(),
-            &cg,
+            &data,
             &options,
         );
 
@@ -76,42 +77,5 @@ pub fn recognize_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<OcrOutcome
                 0.0
             },
         })
-    }
-}
-
-/// Build a CGImage from tightly-packed RGBA8 pixels (bytes_per_row = width*4).
-/// CFData copies the bytes, so the borrowed slice need not outlive the call.
-fn make_cgimage(width: u32, height: u32, rgba: &[u8]) -> Result<CFRetained<CGImage>> {
-    let expected = width as usize * height as usize * 4;
-    if rgba.len() < expected {
-        return Err(anyhow!(
-            "rgba buffer too small: {} < {expected}",
-            rgba.len()
-        ));
-    }
-    // SAFETY: CFDataCreate copies `len` bytes from a valid pointer; the rest is
-    // CoreGraphics object construction from that buffer.
-    unsafe {
-        let data = CFData::new(None, rgba.as_ptr(), expected as isize)
-            .context("CFDataCreate returned null")?;
-        let provider =
-            CGDataProvider::with_cf_data(Some(&data)).context("CGDataProvider from CFData")?;
-        let space = CGColorSpace::new_device_rgb().context("CGColorSpace device RGB")?;
-        // 8 bits/component, 32 bits/pixel, non-premultiplied alpha last (RGBA).
-        let bitmap = CGBitmapInfo(CGImageAlphaInfo::Last.0);
-        CGImage::new(
-            width as usize,
-            height as usize,
-            8,
-            32,
-            width as usize * 4,
-            Some(&space),
-            bitmap,
-            Some(&provider),
-            std::ptr::null(),
-            false,
-            CGColorRenderingIntent::RenderingIntentDefault,
-        )
-        .context("CGImage::new returned null")
     }
 }

--- a/packages/ocr/src/windows_ocr.rs
+++ b/packages/ocr/src/windows_ocr.rs
@@ -1,0 +1,71 @@
+//! Windows on-device OCR via **Windows.Media.Ocr** (WinRT), pure Rust through
+//! the `windows` crate. PRIMARY recognizer on the Windows desktop build;
+//! `recognize` falls back to oar-ocr / PP-OCRv5 if the OCR engine (Chinese
+//! language pack) is unavailable or finds nothing. On-device + offline.
+//!
+//! NOTE: Windows.Media.Ocr needs the target language's OCR pack. Chinese Windows
+//! ships zh-Hans OCR; on an English install it may be absent, in which case
+//! `TryCreateFromLanguage` fails and we fall back to the user's profile
+//! languages, then to the engine. Cannot be compiled or tested on macOS — this
+//! module is verified by the Windows CI build + a Windows tester (see #41).
+
+use crate::OcrOutcome;
+use anyhow::{Context, Result};
+use windows::core::HSTRING;
+use windows::Globalization::Language;
+use windows::Graphics::Imaging::BitmapDecoder;
+use windows::Media::Ocr::OcrEngine;
+use windows::Storage::Streams::{DataWriter, InMemoryRandomAccessStream};
+
+/// Recognize text in raw encoded image bytes (JPEG/PNG/TIFF/…) via Windows OCR.
+pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
+    // Raw bytes → in-memory random-access stream that BitmapDecoder can read.
+    let stream = InMemoryRandomAccessStream::new().context("InMemoryRandomAccessStream::new")?;
+    let output = stream.GetOutputStreamAt(0).context("GetOutputStreamAt")?;
+    let writer = DataWriter::CreateDataWriter(&output).context("CreateDataWriter")?;
+    writer.WriteBytes(image_bytes).context("WriteBytes")?;
+    writer
+        .StoreAsync()
+        .context("StoreAsync")?
+        .get()
+        .context("StoreAsync.get")?;
+    writer
+        .FlushAsync()
+        .context("FlushAsync")?
+        .get()
+        .context("FlushAsync.get")?;
+    let _ = writer.DetachStream();
+    stream.Seek(0).context("Seek")?;
+
+    // Decode (any WIC-supported format) → SoftwareBitmap.
+    let decoder = BitmapDecoder::CreateAsync(&stream)
+        .context("BitmapDecoder::CreateAsync")?
+        .get()
+        .context("BitmapDecoder.get")?;
+    let bitmap = decoder
+        .GetSoftwareBitmapAsync()
+        .context("GetSoftwareBitmapAsync")?
+        .get()
+        .context("SoftwareBitmap.get")?;
+
+    // Prefer Simplified Chinese; fall back to the user's profile languages.
+    let engine = OcrEngine::TryCreateFromLanguage(
+        &Language::CreateLanguage(&HSTRING::from("zh-Hans")).context("Language::CreateLanguage")?,
+    )
+    .or_else(|_| OcrEngine::TryCreateFromUserProfileLanguages())
+    .context("no Windows OCR engine available (Chinese OCR language pack missing?)")?;
+
+    let result = engine
+        .RecognizeAsync(&bitmap)
+        .context("RecognizeAsync")?
+        .get()
+        .context("OcrResult.get")?;
+    let text = result.Text().context("OcrResult.Text")?.to_string_lossy();
+
+    Ok(OcrOutcome {
+        // Windows.Media.Ocr exposes no confidence; report a fixed moderate value
+        // when text was found, 0.0 otherwise.
+        confidence: if text.trim().is_empty() { 0.0 } else { 0.85 },
+        text,
+    })
+}

--- a/packages/ocr/src/windows_ocr.rs
+++ b/packages/ocr/src/windows_ocr.rs
@@ -3,6 +3,10 @@
 //! `recognize` falls back to oar-ocr / PP-OCRv5 if the OCR engine (Chinese
 //! language pack) is unavailable or finds nothing. On-device + offline.
 //!
+//! WinRT calls are async (`IAsyncOperation`); `windows-future` 0.3 exposes them
+//! only via `IntoFuture` (no blocking `get()`), so we drive each to completion
+//! with `pollster::block_on` — `recognize` is a synchronous API.
+//!
 //! NOTE: Windows.Media.Ocr needs the target language's OCR pack. Chinese Windows
 //! ships zh-Hans OCR; on an English install it may be absent, in which case
 //! `TryCreateFromLanguage` fails and we fall back to the user's profile
@@ -11,11 +15,18 @@
 
 use crate::OcrOutcome;
 use anyhow::{Context, Result};
+use std::future::IntoFuture;
 use windows::core::HSTRING;
 use windows::Globalization::Language;
 use windows::Graphics::Imaging::BitmapDecoder;
 use windows::Media::Ocr::OcrEngine;
 use windows::Storage::Streams::{DataWriter, InMemoryRandomAccessStream};
+
+/// Block on a WinRT `IAsyncOperation`/`IAsyncAction` (drives its future to
+/// completion on this thread).
+fn block<O: IntoFuture>(op: O) -> O::Output {
+    pollster::block_on(op.into_future())
+}
 
 /// Recognize text in raw encoded image bytes (JPEG/PNG/TIFF/…) via Windows OCR.
 pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
@@ -24,29 +35,20 @@ pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
     let output = stream.GetOutputStreamAt(0).context("GetOutputStreamAt")?;
     let writer = DataWriter::CreateDataWriter(&output).context("CreateDataWriter")?;
     writer.WriteBytes(image_bytes).context("WriteBytes")?;
-    writer
-        .StoreAsync()
-        .context("StoreAsync")?
-        .get()
-        .context("StoreAsync.get")?;
-    writer
-        .FlushAsync()
-        .context("FlushAsync")?
-        .get()
-        .context("FlushAsync.get")?;
+    block(writer.StoreAsync().context("StoreAsync")?).context("StoreAsync await")?;
+    block(writer.FlushAsync().context("FlushAsync")?).context("FlushAsync await")?;
     let _ = writer.DetachStream();
     stream.Seek(0).context("Seek")?;
 
     // Decode (any WIC-supported format) → SoftwareBitmap.
-    let decoder = BitmapDecoder::CreateAsync(&stream)
-        .context("BitmapDecoder::CreateAsync")?
-        .get()
-        .context("BitmapDecoder.get")?;
-    let bitmap = decoder
-        .GetSoftwareBitmapAsync()
-        .context("GetSoftwareBitmapAsync")?
-        .get()
-        .context("SoftwareBitmap.get")?;
+    let decoder = block(BitmapDecoder::CreateAsync(&stream).context("BitmapDecoder::CreateAsync")?)
+        .context("BitmapDecoder await")?;
+    let bitmap = block(
+        decoder
+            .GetSoftwareBitmapAsync()
+            .context("GetSoftwareBitmapAsync")?,
+    )
+    .context("SoftwareBitmap await")?;
 
     // Prefer Simplified Chinese; fall back to the user's profile languages.
     let engine = OcrEngine::TryCreateFromLanguage(
@@ -55,11 +57,8 @@ pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
     .or_else(|_| OcrEngine::TryCreateFromUserProfileLanguages())
     .context("no Windows OCR engine available (Chinese OCR language pack missing?)")?;
 
-    let result = engine
-        .RecognizeAsync(&bitmap)
-        .context("RecognizeAsync")?
-        .get()
-        .context("OcrResult.get")?;
+    let result = block(engine.RecognizeAsync(&bitmap).context("RecognizeAsync")?)
+        .context("OcrResult await")?;
     let text = result.Text().context("OcrResult.Text")?.to_string_lossy();
 
     Ok(OcrOutcome {

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -225,6 +225,10 @@ pub fn mime_for(path: &Path) -> &'static str {
         "png" => "image/png",
         "jpg" | "jpeg" => "image/jpeg",
         "tif" | "tiff" => "image/tiff",
+        // iPhone photos default to HEIC/HEIF. macOS Apple Vision OCR decodes it
+        // (via ImageIO); on platforms whose OCR engine can't, ingest degrades
+        // gracefully (stores the file with no extracted text).
+        "heic" | "heif" => "image/heic",
         "dcm" => "application/dicom",
         _ => "application/octet-stream",
     }


### PR DESCRIPTION
承接已合并的 #42(macOS Vision),补齐 #41「各平台改用原生 OCR」余下的三块。这些代码此前搁浅在 #42 分支上未随合并进主干,现基于最新 main 重新整理为一条分支。

## 内容(5 个 commit,逻辑独立)
1. **HEIC 解码(macOS)** — Vision 改经 `VNImageRequestHandler::initWithData`(NSData → ImageIO),支持 HEIC 等全部苹果原生格式,`image` crate 解不了的也能识别。
2. **接受 HEIC/HEIF** — `pipeline::mime_for` + 手机端 `is_image` 认 `image/heic`(iPhone 照片默认格式)。
3. **Windows 桌面 OCR** — `Windows.Media.Ocr`(WinRT,`windows` crate 0.62)。`windows-future` 0.3 无阻塞 `.get()`,用 `pollster::block_on(op.into_future())` 等异步。
4. **Android ML Kit** — Google ML Kit Text Recognition v2(中文,bundled 模型 → 离线)替代识别质量差的 PP-OCRv5 mobile;Kotlin `MlkitOcr` 经 JNI(jni 0.22 + ndk-context)桥接;`ingest_dispatch` 路由安卓图片到 ML Kit;core-model 新增 `OcrBackendKind::MlKit`。

## 本地验证
- `cargo check`:host(ocr/pipeline/core-model)+ `aarch64-linux-android`(mobile)全绿。
- `cargo fmt --check` / `cargo clippy --workspace --all-targets`:干净。
- `cargo test --workspace`:全过(0 failed)。
- 安卓 **release APK 打包通过**(Kotlin 编译 + ML Kit 依赖 `text-recognition-chinese:16.0.1` 解析)。
- macOS Vision:合成中文化验单 0.906、真机 iPhone HEIC 超声报告 0.643,字段全识别。

## 待运行时验证(非本 PR 阻塞)
- Windows OCR 识别质量 —— 你的 Windows 机器。
- Android ML Kit 识别质量 —— Android Studio 模拟器/真机。

Closes #41