### PR TITLE
fix(ocr): 桌面 OCR 溯源据实记录引擎(Vision/WinRT),不再谎称 ONNX (#56)

### DIFF
--- a/packages/core-model/src/types.rs
+++ b/packages/core-model/src/types.rs
@@ -52,6 +52,9 @@ pub enum OcrBackendKind {
     /// Apple Vision (`VNRecognizeTextRequest`) — on-device, offline OCR used on
     /// iOS instead of the oar-ocr model download (impossible in the iOS sandbox).
     AppleVision,
+    /// Windows.Media.Ocr (WinRT) — on-device, offline OCR used on the Windows
+    /// desktop build as the primary recognizer (PP-OCRv5 ONNX is the fallback).
+    WindowsOcr,
     /// Google ML Kit Text Recognition v2 (Chinese, bundled model) — on-device,
     /// offline OCR used on Android instead of the weaker PP-OCRv5 mobile model.
     MlKit,
@@ -63,6 +66,7 @@ impl OcrBackendKind {
             OcrBackendKind::Onnx => "onnx",
             OcrBackendKind::Vlm => "vlm",
             OcrBackendKind::AppleVision => "apple_vision",
+            OcrBackendKind::WindowsOcr => "windows_ocr",
             OcrBackendKind::MlKit => "mlkit",
         }
     }

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -57,10 +57,26 @@ pub fn set_model_dir(dir: PathBuf) {
 /// Result of an OCR recognition call: the recognized text plus a confidence
 /// score (mean of the recognized text lines' per-line confidences, `0..1`;
 /// `0.0` when no lines were recognized).
+/// Which OCR engine actually produced an [`OcrOutcome`]. Lets callers (the
+/// ingest pipeline) record accurate provenance instead of hardcoding one
+/// engine — on macOS/Windows the primary recognizer is Apple Vision /
+/// Windows.Media.Ocr, not the ONNX fallback the metadata used to always claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OcrBackend {
+    /// Apple Vision (`VNRecognizeTextRequest`) — macOS on-device.
+    AppleVision,
+    /// Windows.Media.Ocr (WinRT) — Windows on-device.
+    WindowsOcr,
+    /// oar-ocr / PP-OCRv5 ONNX engine (Linux, and the macOS/Windows fallback).
+    Onnx,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct OcrOutcome {
     pub text: String,
     pub confidence: f32,
+    /// The engine that produced `text` (provenance for the vault's audit trail).
+    pub backend: OcrBackend,
 }
 
 /// Mean of `Some` confidences, or `0.0` if there are none. Pure float helper
@@ -358,6 +374,7 @@ fn recognize_engine(image_bytes: &[u8]) -> Result<OcrOutcome> {
     Ok(OcrOutcome {
         text: lines.join("\n"),
         confidence: mean_confidence(&confidences),
+        backend: OcrBackend::Onnx,
     })
 }
 
@@ -389,6 +406,7 @@ pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
         Ok(OcrOutcome {
             text: String::new(),
             confidence: 0.0,
+            backend: OcrBackend::AppleVision,
         })
     }
 }
@@ -412,6 +430,7 @@ pub fn recognize(image_bytes: &[u8]) -> Result<OcrOutcome> {
         Ok(OcrOutcome {
             text: String::new(),
             confidence: 0.0,
+            backend: OcrBackend::WindowsOcr,
         })
     }
 }
@@ -521,7 +540,29 @@ pub fn recognize_pdf(pdf_bytes: &[u8]) -> Result<OcrOutcome> {
     Ok(OcrOutcome {
         text: page_texts.join("\n"),
         confidence: mean_confidence(&page_confidences),
+        // Page images went through `recognize`, whose primary engine is
+        // platform-fixed; label with that platform's engine.
+        backend: pdf_ocr_backend(),
     })
+}
+
+/// The primary OCR engine `recognize` uses on this platform — used to label
+/// [`recognize_pdf`]'s aggregate outcome (its page images all go through
+/// `recognize`).
+#[inline]
+fn pdf_ocr_backend() -> OcrBackend {
+    #[cfg(target_os = "macos")]
+    {
+        OcrBackend::AppleVision
+    }
+    #[cfg(target_os = "windows")]
+    {
+        OcrBackend::WindowsOcr
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        OcrBackend::Onnx
+    }
 }
 
 /// Collect raw JPEG bytes for every `DCTDecode` image XObject directly
@@ -807,6 +848,7 @@ mod tests {
             Ok(OcrOutcome {
                 text: "line".to_string(),
                 confidence: 1.0,
+                backend: OcrBackend::Onnx,
             })
         });
         assert_eq!(
@@ -832,6 +874,7 @@ mod tests {
             Ok(OcrOutcome {
                 text: "ok".to_string(),
                 confidence: 0.5,
+                backend: OcrBackend::Onnx,
             })
         });
         assert_eq!(calls, 3);

--- a/packages/ocr/src/vision_macos.rs
+++ b/packages/ocr/src/vision_macos.rs
@@ -76,6 +76,7 @@ pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
             } else {
                 0.0
             },
+            backend: crate::OcrBackend::AppleVision,
         })
     }
 }

--- a/packages/ocr/src/windows_ocr.rs
+++ b/packages/ocr/src/windows_ocr.rs
@@ -66,5 +66,6 @@ pub fn recognize_bytes(image_bytes: &[u8]) -> Result<OcrOutcome> {
         // when text was found, 0.0 otherwise.
         confidence: if text.trim().is_empty() { 0.0 } else { 0.85 },
         text,
+        backend: crate::OcrBackend::WindowsOcr,
     })
 }

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -237,6 +237,17 @@ fn store_no_text(vault: &Vault, sid: i64, name: &str) -> anyhow::Result<IngestOu
     })
 }
 
+/// 把 `ocr::recognize`/`recognize_pdf` 报告的实际引擎映射为 vault 里记录的
+/// (后端, 模型版本) —— 桌面上 mac/Win 的主引擎是 Apple Vision / Windows.Media.Ocr,
+/// 不再一律谎称 ONNX/ppocr-v5(#56 溯源准确性)。
+fn ocr_provenance(b: ocr::OcrBackend) -> (OcrBackendKind, &'static str) {
+    match b {
+        ocr::OcrBackend::AppleVision => (OcrBackendKind::AppleVision, "apple-vision"),
+        ocr::OcrBackend::WindowsOcr => (OcrBackendKind::WindowsOcr, "windows-media-ocr"),
+        ocr::OcrBackend::Onnx => (OcrBackendKind::Onnx, "ppocr-v5"),
+    }
+}
+
 pub fn mime_for(path: &Path) -> &'static str {
     match path
         .extension()
@@ -321,6 +332,7 @@ pub fn ingest(vault: &Vault, path: &Path) -> anyhow::Result<IngestOutcome> {
             // 扫描图 PDF(无文本层):尝试从页面图片 OCR 补文本,像图片一样处理。
             match ocr::recognize_pdf(&bytes) {
                 Ok(outcome) if !outcome.text.trim().is_empty() => {
+                    let (backend, model_version) = ocr_provenance(outcome.backend);
                     let text = outcome.text;
                     let doc_type = parser::classify(&text);
                     let (doc_date, doc_date_end) = parser::guess_date_range(&text);
@@ -336,8 +348,8 @@ pub fn ingest(vault: &Vault, path: &Path) -> anyhow::Result<IngestOutcome> {
                     vault.add_ocr(NewOcr {
                         document_id: doc.id,
                         page_no: 1,
-                        backend: OcrBackendKind::Onnx,
-                        model_version: "ppocr-v5-pdf".into(),
+                        backend,
+                        model_version: model_version.into(),
                         text,
                         confidence: Some(outcome.confidence),
                     })?;
@@ -366,6 +378,7 @@ pub fn ingest(vault: &Vault, path: &Path) -> anyhow::Result<IngestOutcome> {
             match ocr::recognize(&bytes) {
                 Ok(outcome) if !outcome.text.trim().is_empty() => {
                     // OCR 成功:像文本文档一样处理(分类/日期取自识别文本)
+                    let (backend, model_version) = ocr_provenance(outcome.backend);
                     let text = outcome.text;
                     let doc_type = parser::classify(&text);
                     let (doc_date, doc_date_end) = parser::guess_date_range(&text);
@@ -381,8 +394,8 @@ pub fn ingest(vault: &Vault, path: &Path) -> anyhow::Result<IngestOutcome> {
                     vault.add_ocr(NewOcr {
                         document_id: doc.id,
                         page_no: 1,
-                        backend: OcrBackendKind::Onnx,
-                        model_version: "ppocr-v5".into(),
+                        backend,
+                        model_version: model_version.into(),
                         text,
                         confidence: Some(outcome.confidence),
                     })?;


### PR DESCRIPTION
Closes #56 · 1.2 完整性审计 · 批次②核心

OcrOutcome 新增 `backend` 字段,各引擎据实标注;core-model 补 `WindowsOcr` 变体;pipeline 用 `ocr_provenance` 映射真实(后端,模型版本),替代硬编码 Onnx/ppocr-v5。

验证:workspace 编译 + ocr/pipeline/core-model 测试全过 + fmt/clippy 干净。⚠️ windows_ocr.rs 为 cfg(windows),本地/CI 未编译到(仅加字段,Windows 出包 CI 兜)。