### PR TITLE
fix(desktop): 文件选择器接受 HEIC/HEIF + 提示如实列出支持格式 (#60)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -285,8 +285,14 @@ pub async fn import_via_dialog(
         .file()
         .set_title("选择要导入的病历文件")
         .add_filter(
+            // HEIC/HEIF included: iPhone photos default to HEIC, and macOS Apple
+            // Vision OCR decodes it (via ImageIO). Without it the picker greyed
+            // out the user's own photos even though drag-drop accepted them —
+            // a dead end on the primary import affordance (#60).
             "病历文件",
-            &["pdf", "png", "jpg", "jpeg", "tif", "tiff", "txt", "dcm"],
+            &[
+                "pdf", "png", "jpg", "jpeg", "tif", "tiff", "heic", "heif", "txt", "dcm",
+            ],
         )
         .blocking_pick_files();
     let Some(files) = picked else {

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -241,7 +241,7 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
             {busy ? "正在导入…" : dragging ? "松开以导入" : "把病历文件拖到这里"}
           </div>
           <div className="text-xs font-mono text-slate-400 mt-2">
-            PDF · 图片(PNG / JPG / TIFF)· TXT · 原始文件永久保存,自动去重
+            PDF · 图片(PNG / JPG / TIFF / HEIC)· TXT · DICOM · 原始文件永久保存,自动去重
           </div>
           <div className="mt-5">
             <button


### PR DESCRIPTION
Closes #60 · 1.2 完整性审计 · 批次④桌面

桌面 picker 过滤器缺 heic/heif → iPhone 照片按钮选不到(只能拖)。补进过滤器 + 提示文案如实列 PNG/JPG/TIFF/HEIC/DICOM。webp/gif/bmp 暂不支持,不列出、不误导。

验证:desktop 编译 + fmt 干净。