### PR TITLE
fix(desktop): 移除会谎报成功的 export_vault stub 入口 (#62)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -431,15 +431,10 @@ pub fn decode_dicom_frame(
     Ok(tauri::ipc::Response::new(wire))
 }
 
-#[tauri::command]
-pub fn export_vault(_state: State<AppState>, _dest_path: String) -> Result<ExportSummary, String> {
-    // C2/后续:真正打包 objects/ + JSON 清单。此处占位返回 0,避免未实现命令。
-    Ok(ExportSummary {
-        file_count: 0,
-        byte_size: 0,
-        path: String::new(),
-    })
-}
+// 注:整库备份(打包 objects/ + JSON 清单,数据可携带)尚未实现。此前这里有个
+// `export_vault` 占位命令,会**谎报成功**(返回 file_count:0 的 Ok),一旦被调用
+// 就是个「假备份」地雷。它没有接任何 UI,故直接移除入口(命令 + api 绑定),
+// 待真正设计备份/导出 UI 时再实现真打包,不留会撒谎的 stub(#62)。
 
 /// 导出 v1:把整条时间线渲染成自包含 HTML 写到用户在原生保存对话框选定的位置(见
 /// `medme_share::export::build_timeline_html`)。可在任意浏览器打开、原生渲染中文,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -116,7 +116,6 @@ pub fn run() {
             commands::render_dicom,
             commands::decode_dicom_frame,
             commands::get_imaging_instances,
-            commands::export_vault,
             commands::export_timeline_html,
             commands::create_share,
             commands::get_patient_profile,

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -30,8 +30,6 @@ export const api = {  listTimelineGrouped: () => invoke<TimelineGroup[]>("list_t
     invoke<ArrayBuffer>("decode_dicom_frame", { sourceFileId, frameIndex }),
   getImagingInstances: (documentId: number) =>
     invoke<ImagingInstance[]>("get_imaging_instances", { documentId }),
-  exportVault: (destPath: string) =>
-    invoke<ExportSummary>("export_vault", { destPath }),
   // 安全:保存位置由 Rust 侧原生「保存」对话框选定并直接写入——路径绝不经由 webview
   // 传入(见 GHSA-gmg4)。写入后端返回含写入路径的结果;用户取消对话框返回 null。
   exportTimelineHtml: () =>


### PR DESCRIPTION
Closes #62 · 1.2 完整性审计 · 批次④桌面

export_vault 占位命令未接 UI 却返回 file_count:0 的 Ok(假备份地雷)。移除命令+注册+api 绑定;整库备份待有 UI 时正经实现。ExportSummary 保留(时间线导出用)。

验证:desktop 编译 + 前端 tsc + fmt 干净。