### PR TITLE
fix: watch-folder 毒锁恢复 + CLI 单坏文件不中止整批 (#64 部分)

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -24,7 +24,15 @@ fn main() -> anyhow::Result<()> {
     match cli.cmd {
         Cmd::Import { files } => {
             for f in files {
-                let o = pipeline::ingest(&vault, &f)?;
+                // 单个坏文件不中止整批(与桌面/手机的 ingest_guarded / ingest_one
+                // 一致的不变式:一份文件失败只记一行,继续下一份)。
+                let o = match pipeline::ingest(&vault, &f) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        eprintln!("failed {} ({e})", f.display());
+                        continue;
+                    }
+                };
                 let line = match o.status {
                     pipeline::IngestStatus::New => format!(
                         "import {} (id={}, type={})",

--- a/apps/desktop/src-tauri/src/inbox.rs
+++ b/apps/desktop/src-tauri/src/inbox.rs
@@ -145,13 +145,13 @@ pub fn scan_inbox(app: &AppHandle, state: &AppState) {
     let mut imported = 0usize;
     for path in files {
         let ingest_result = {
-            let vault = match state.vault.lock() {
-                Ok(v) => v,
-                Err(_) => {
-                    eprintln!("[inbox] vault lock poisoned, abort scan");
-                    return;
-                }
-            };
+            // 毒锁恢复而非放弃扫描:别处所有取锁点都用 into_inner 恢复(见
+            // commands::lock);保险箱的真相是 log+CAS,恢复出的 guard 是安全的。
+            // 此前这里直接 return,会让监视文件夹在本进程剩余生命里永久停摆。
+            let vault = state
+                .vault
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             // 与手动导入同一条隔离路径:catch_unwind 把解析栈里的 panic 变成 Err,
             // 绝不让它穿过持有的 Vault 锁去毒化互斥量 / 打死监听线程。
             crate::commands::ingest_guarded(&vault, &path)


### PR DESCRIPTION
Closes #64 的两条后端安全项 · 1.2 完整性审计 · 批次⑤

- 桌面 watch-folder 取锁失败直接放弃 → 改 into_inner 恢复(别处一致)。
- CLI import `?` 中止整批 → 逐文件 match、失败 continue(与桌面/手机不变式一致)。

「前台不实时 re-sync」(materialize perf 权衡)与手机 alert 样式项本 PR 不含,留后续。

验证:cli/desktop 编译 + fmt 干净。