### PR TITLE
fix(desktop): StoredNoText 状态文案改为诚实终态,不再暗示"待 OCR" (#63)

### DIFF
--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -21,7 +21,7 @@ const STATUS_META: Record<string, { label: string; cls: string }> = {
   new: { label: "新增并索引", cls: "text-emerald-700 bg-emerald-50" },
   backfilled: { label: "补充索引", cls: "text-emerald-700 bg-emerald-50" },
   deduped: { label: "已存在 · 去重", cls: "text-slate-600 bg-slate-100" },
-  stored_no_text: { label: "已保存 · 待 OCR", cls: "text-amber-700 bg-amber-50" },
+  stored_no_text: { label: "已保存 · 未识别到文字", cls: "text-amber-700 bg-amber-50" },
   instance_attached: { label: "已并入检查", cls: "text-sky-700 bg-sky-50" },
   failed: { label: "导入失败", cls: "text-rose-700 bg-rose-50" },
 };


### PR DESCRIPTION
Closes #63(桌面文案部分) · 1.2 完整性审计

## Summary
- `ImportView.tsx` 中 `stored_no_text` 状态的标签原为「已保存 · 待 OCR」,暗示系统会在后台继续自动识别文字 —— 但实际上没有自动重试/后台 OCR 机制,该状态其实是终态。
- 改为「已保存 · 未识别到文字」,如实描述当前状态,不再承诺不存在的后续处理。样式(`cls`)不变。
- 已检查 `DocumentView.tsx` 中的相关文案(「此文件尚未识别出文字。原始文件已完整保存…」),该文案未承诺自动处理,予以保留,未改动。

## Test plan
- [x] `cd apps/desktop && pnpm exec tsc --noEmit` 通过
- [x] 确认 diff 仅涉及 `ImportView.tsx` 的这一行标签文案