### PR TITLE
fix(mobile): 分享有效期与"未识别"文案诚实化 (#61, #63)

### DIFF
--- a/apps/mobile/src/App.css
+++ b/apps/mobile/src/App.css
@@ -302,6 +302,7 @@
 .share-sub { font-size: 12.5px; color: var(--muted); }
 .share-tip { font-size: 13px; color: var(--muted); line-height: 1.65; margin-bottom: 14px; }
 .share-tip b { color: var(--ink); font-weight: 700; }
+.share-tip-sub { font-size: 12px; color: var(--faint); margin-top: -6px; }
 .share-pass {
   background: var(--screen); border: 1px solid var(--line); border-radius: 11px; padding: 10px 12px;
   display: flex; align-items: center; gap: 10px; margin-bottom: 14px;

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -745,6 +745,10 @@ function ShareModal({ share, onClose }: { share: ShareResult; onClose: () => voi
           把<b>文件</b>发给医生,<b>口令另发</b>(用不同渠道,如口令走短信、文件走微信);
           医生打开文件、输入口令即可查看。数据端到端加密,<b>不经服务器</b>。
         </p>
+        <p className="share-tip share-tip-sub">
+          有效期 5 天,仅是给医生的复阅提醒,并非强制——文件本身不会到期失效,
+          持有文件与口令者始终可解密查看。
+        </p>
 
         <div className="share-pass">
           <span className="k">口令</span>
@@ -801,7 +805,7 @@ function ClinicalText({ text, docType }: { text: string; docType: string }) {
   if (!raw.trim()) {
     return (
       <div className="doc-body">
-        <span className="muted">此文件尚未识别出文字。原始文件已完整保存,可点「查看原件」出示给医生。</span>
+        <span className="muted">此文件未识别到文字(不会自动重试)。原始文件已完整保存,可点「查看原件」出示给医生。</span>
       </div>
     );
   }


### PR DESCRIPTION
Closes #61(手机侧) #63(文案部分) · 1.2 完整性审计

## 改动

1. **#61 分享有效期披露**:`apps/mobile/src/App.tsx` 的 `ShareModal` 中,`doShare` 调用 `api.createShare(5)` 硬编码 5 天有效期,但分享结果弹层此前从未提及这个 5 天概念,也没说明它是非强制的。新增一行说明:
   > 有效期 5 天,仅是给医生的复阅提醒,并非强制——文件本身不会到期失效,持有文件与口令者始终可解密查看。

   措辞与桌面端 `ImportView.tsx` 中「仅作为给医生的复阅提醒,并非强制——文件本身不会到期失效」保持一致。未新增有效期天数选择器(范围外)。

2. **#63 stored_no_text 文案诚实化**:`ClinicalText` 组件中,当文档识别文本为空时(`stored_no_text` 状态)显示的提示,原文「此文件尚未识别出文字」隐含「稍后会自动识别」的承诺,但实际没有自动重试机制。改为终态措辞:
   > 此文件未识别到文字(不会自动重试)。原始文件已完整保存,可点「查看原件」出示给医生。

## 验证

- `cd apps/mobile && pnpm exec tsc --noEmit` — 通过
- `cd apps/mobile && pnpm run build` — 通过(vite build 成功)