### PR TITLE
feat(share): 分享内嵌 PDF 原件 + 查看器「下载原件 PDF」(保真) (#61)

### DIFF
--- a/packages/share/src/share.rs
+++ b/packages/share/src/share.rs
@@ -108,13 +108,31 @@ pub fn build_encrypted_share(
             .clone()
             .unwrap_or_else(|| sf.original_name.clone());
 
-        // 仅内嵌 image/* 原件为 data-URI;PDF 不内嵌(仅文字)。
+        // 内嵌 image/* 原件为 data-URI。
         let mut images: Vec<String> = Vec::new();
         if sf.mime_type.starts_with("image/") {
             let bytes = std::fs::read(v.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
             embedded_bytes += bytes.len();
             let b64 = B64.encode(&bytes);
             images.push(format!("data:{};base64,{}", sf.mime_type, b64));
+        }
+
+        // 内嵌 PDF 原件为 data-URI,让医生下载核对 OCR 原文(保真:原件是真相,见
+        // docs/012)。体积不再是投递约束 —— 临时分享走「联网取密文」而非塞进聊天的
+        // 文件;但仍尊重整份总上限,避免病态大文件撑爆分享。超限则跳过内嵌(仍保留
+        // 识别文字),不静默。
+        let mut pdf_data_uri = serde_json::Value::Null;
+        if sf.mime_type == "application/pdf" {
+            let bytes = std::fs::read(v.root_join(&sf.storage_path)).map_err(|e| e.to_string())?;
+            if embedded_bytes + bytes.len() <= SHARE_TOTAL_CAP {
+                embedded_bytes += bytes.len();
+                pdf_data_uri = serde_json::Value::String(format!(
+                    "data:application/pdf;base64,{}",
+                    B64.encode(&bytes)
+                ));
+            } else {
+                eprintln!("share: PDF 原件「{title}」因整份已达总上限未内嵌(仅保留识别文字)");
+            }
         }
 
         // ── 影像(DICOM):按体积分档内嵌(诊断档 / 关键切片降级)──
@@ -181,6 +199,7 @@ pub fn build_encrypted_share(
             "title": title,
             "text": rec.text,
             "images": images,
+            "pdf": pdf_data_uri,
             "dicom": dicom_json,
         }));
         record_count += 1;
@@ -335,6 +354,8 @@ const VIEWER_HEAD: &str = r####"<!doctype html>
   /* 影像检查:缩略卡 + 说明 */
   .imaging-card { margin: 10px 0; }
   .imaging-open { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; background: #0f172a; color: #fff; border: none; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 600; }
+  .pdf-dl { display: inline-flex; align-items: center; gap: 6px; margin: 8px 0; text-decoration: none; background: #1789c1; color: #fff; border-radius: 10px; padding: 9px 14px; font-size: 13px; font-weight: 600; }
+  .pdf-dl:hover { background: #1560a8; }
   .imaging-open:hover { background: #1e293b; }
   .imaging-open .ico { font-size: 16px; }
   .imaging-meta { font-size: 12px; color: #64748b; margin-top: 6px; line-height: 1.6; }
@@ -423,6 +444,12 @@ function esc(s) {
 function isDataImage(s) {
   return typeof s === "string" &&
     /^data:image\/(png|jpe?g|tiff);base64,[A-Za-z0-9+\/=\s]+$/.test(s);
+}
+// PDF 原件下载锚点的 href 校验:只接受我们自己生成的 data:application/pdf base64
+// (base64 字母表不含 '<' / '"',放进 href 安全)。
+function isDataPdf(s) {
+  return typeof s === "string" &&
+    /^data:application\/pdf;base64,[A-Za-z0-9+\/=\s]+$/.test(s);
 }
 
 // ── 内容解析(移植 ReportContent.tsx)──
@@ -909,6 +936,9 @@ function render(payload) {
     for (const img of (r.images || [])) {
       if (isDataImage(img)) html += '<img class="img" src="' + img + '" alt="原件">';
     }
+    // PDF 原件:下载锚点(download 属性触发下载,不是导航,故不受严格 CSP 影响,
+    // 任意浏览器都能下)。医生下载后可比对识别文字与原件。
+    if (isDataPdf(r.pdf)) html += '<a class="pdf-dl" download="原件.pdf" href="' + r.pdf + '">⬇ 下载原件 PDF(核对识别文字)</a>';
     // 影像检查:诊断档(交互阅片)或降级档(关键切片 PNG + 说明)。
     const dcm = r.dicom;
     if (dcm && dcm.mode === "interactive") {

--- a/web/hosted-viewer/index.html
+++ b/web/hosted-viewer/index.html
@@ -12,7 +12,7 @@
         a=d.find(o,i)
         if a<0:break
         a+=len(o);b=d.find(c,a);print(base64.b64encode(hashlib.sha256(d[a:b].encode()).digest()).decode());i=b" -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-7Z0+4VB3CnpMGP9NdEXdG4wifm/kpyirE2yqr+CEnyc=' 'sha256-JUNLC6F+BNs1/M0gPZrmVKWdweJ4SjaF5D7LyYvsYZw='; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-7Z0+4VB3CnpMGP9NdEXdG4wifm/kpyirE2yqr+CEnyc=' 'sha256-OCIrCd/ySk5NOIVS5qY7Py26jHP/l+j7p3zDiPCR5EQ='; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MedMe 加密分享查看器</title>
 <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%201024%201024%22%3E%0A%3Cdefs%3E%3ClinearGradient%20id%3D%22g%22%20x1%3D%220%22%20y1%3D%220%22%20x2%3D%221%22%20y2%3D%221%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%232bc0d2%22%2F%3E%3Cstop%20offset%3D%220.52%22%20stop-color%3D%22%231789c1%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%231560a8%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%0A%3Crect%20width%3D%221024%22%20height%3D%221024%22%20rx%3D%22232%22%20fill%3D%22url%28%23g%29%22%2F%3E%0A%3Cpath%20transform%3D%22translate%2885.76%2C804.70%29%20scale%280.82760%2C-0.82760%29%22%20d%3D%22M326%20640C320%20672%20323%20688%20335%20688C431%20690%20535%20708%20650%20741C668%20748%20687%20734%20704%20699C720%20664%20716%20650%20691%20658C672%20666%20641%20663%20600%20651C557%20639%20509%20631%20458%20627C405%20623%20371%20615%20355%20605C342%20596%20332%20606%20326%20640ZM212%20393C226%20508%20234%20570%20236%20582C234%20600%20241%20605%20259%20600C274%20594%20292%20586%20310%20578C325%20568%20326%20555%20314%20537C283%20459%20266%20368%20260%20267C252%20165%20254%20101%20266%2075C271%2062%20321%2063%20413%2079C503%2095%20582%20104%20650%20106C717%20108%20757%20111%20772%20115C777%20117%20786%20110%20796%2095C804%2078%20813%2065%20822%2057C830%2047%20832%2034%20829%2020C825%204%20814%200%20798%2010C698%2035%20597%2043%20494%2033C391%2023%20324%2013%20296%203C267%20-6%20246%20-9%20234%20-4C229%20-1%20226%203%20226%2011C226%2018%20220%2040%20210%2077C196%20172%20196%20277%20212%20393ZM567%20292C558%20302%20561%20306%20578%20306C639%20287%20691%20265%20736%20237C740%20234%20741%20219%20737%20189C731%20160%20724%20144%20716%20140C706%20136%20699%20138%20695%20146C689%20154%20683%20165%20675%20179C628%20228%20593%20265%20567%20292ZM761%20328C702%20338%20636%20336%20561%20323C555%20322%20550%20321%20546%20321C538%20294%20525%20267%20509%20240C497%20216%20483%20198%20468%20188C450%20176%20444%20165%20449%20157C451%20149%20434%20142%20397%20135C358%20126%20331%20126%20315%20134C298%20142%20300%20148%20322%20154C324%20154%20335%20159%20355%20169C372%20178%20393%20190%20414%20208C434%20225%20453%20249%20471%20281C473%20291%20476%20300%20480%20309C429%20297%20387%20284%20355%20271C348%20266%20335%20274%20319%20298C302%20321%20310%20330%20342%20324C385%20338%20436%20352%20494%20367C498%20395%20499%20419%20497%20440C489%20438%20480%20435%20471%20431C457%20424%20450%20429%20449%20444C447%20454%20444%20463%20441%20473C422%20448%20400%20427%20377%20408C357%20396%20344%20391%20336%20393C326%20395%20329%20403%20346%20419C385%20473%20409%20513%20421%20540C433%20566%20438%20584%20439%20594C441%20611%20452%20613%20472%20601C489%20587%20502%20577%20511%20571C519%20565%20517%20559%20505%20552C497%20548%20490%20541%20484%20531C480%20525%20475%20517%20467%20507C504%20511%20537%20518%20566%20527C596%20537%20620%20543%20640%20546C649%20547%20656%20538%20660%20520C662%20500%20658%20488%20648%20485C619%20473%20592%20461%20568%20450C564%20449%20563%20448%20562%20447C558%20430%20555%20407%20554%20382C554%20382%20556%20382%20559%20383C598%20391%20635%20396%20671%20402C706%20406%20728%20409%20734%20413C740%20416%20745%20413%20750%20403C754%20394%20760%20387%20768%20383C773%20379%20777%20367%20778%20348C778%20328%20772%20321%20761%20328Z%22%20fill%3D%22%23ffffff%22%2F%3E%0A%3C%2Fsvg%3E">
@@ -68,6 +68,8 @@
   /* 影像检查:缩略卡 + 说明 */
   .imaging-card { margin: 10px 0; }
   .imaging-open { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; background: #0f172a; color: #fff; border: none; border-radius: 10px; padding: 10px 16px; font-size: 14px; font-weight: 600; }
+  .pdf-dl { display: inline-flex; align-items: center; gap: 6px; margin: 8px 0; text-decoration: none; background: #1789c1; color: #fff; border-radius: 10px; padding: 9px 14px; font-size: 13px; font-weight: 600; }
+  .pdf-dl:hover { background: #1560a8; }
   .imaging-open:hover { background: #1e293b; }
   .imaging-open .ico { font-size: 16px; }
   .imaging-meta { font-size: 12px; color: #64748b; margin-top: 6px; line-height: 1.6; }
@@ -173,6 +175,11 @@ function esc(s) {
 function isDataImage(s) {
   return typeof s === "string" &&
     /^data:image\/(png|jpe?g|tiff);base64,[A-Za-z0-9+\/=\s]+$/.test(s);
+}
+// PDF 原件下载锚点 href 校验(base64 字母表不含 '<' / '"',放进 href 安全)。
+function isDataPdf(s) {
+  return typeof s === "string" &&
+    /^data:application\/pdf;base64,[A-Za-z0-9+\/=\s]+$/.test(s);
 }
 
 // ── 内容解析(移植 ReportContent.tsx)──
@@ -661,6 +668,8 @@ function render(payload) {
     for (const img of (r.images || [])) {
       if (isDataImage(img)) html += '<img class="img" src="' + img + '" alt="原件">';
     }
+    // PDF 原件下载(download 属性触发下载,不受严格 CSP 影响)。
+    if (isDataPdf(r.pdf)) html += '<a class="pdf-dl" download="原件.pdf" href="' + r.pdf + '">⬇ 下载原件 PDF(核对识别文字)</a>';
     // 影像检查:诊断档(交互阅片)或降级档(关键切片 PNG + 说明)。
     const dcm = r.dicom;
     if (dcm && dcm.mode === "interactive") {


### PR DESCRIPTION
Closes #61(PDF 保真部分)· 目标 1.3

分享此前 PDF 只留文字、不嵌原件,医生无法核对 OCR。现内嵌 PDF data-URI + 查看器「下载原件 PDF」下载锚点(download 属性,不碰 CSP)。体积不再是约束(临时分享走联网取密文);仍尊重总上限。

嵌入式查看器 + 托管查看器都改了(后者重算并更新了 CSP sha256 pin,已验证一致 → 合并触发 deploy-viewer 自动上线)。

验证:medme-share 16 测试 + fmt/clippy -D warnings 干净;CSP pin 校验一致。