### PR TITLE
feat(desktop): 拖入文件夹递归导入(整个 DICOM study 文件夹一次导入)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::dto::*;
 use core_model::{DocType, Document, Vault};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tauri::{Manager, State};
 use tauri_plugin_dialog::DialogExt;
@@ -208,20 +208,118 @@ pub fn get_document(state: State<AppState>, id: i64) -> Result<DocumentDetail, S
     })
 }
 
-/// Ingest a batch of files into the vault, one `ImportOutcome` per file (a single bad
-/// file is recorded as `failed` and never aborts the batch — same tolerance as
-/// `inbox::scan_inbox`).
+// ponytail: bound the recursive folder-drop walk so a pathological path (a symlink
+// loop, or someone dropping a whole volume instead of one DICOM study folder) can't
+// hang the app on drag-drop. A real dropped study (Study → Series → Instance) is a
+// few levels deep and at most a few thousand files, so both caps are generous for the
+// real use case while still being a hard ceiling.
+const MAX_DIR_DEPTH: usize = 16;
+const MAX_DIR_FILES: usize = 20_000;
+
+/// Recursively collect regular files under a dropped directory for folder import (e.g.
+/// dragging a whole DICOM study folder onto the app), skipping hidden/dot entries and
+/// partial-download files — same skip rules as the watch folder's
+/// `inbox::importable_files`, just recursive instead of one level deep. Bounded by
+/// `MAX_DIR_DEPTH`/`MAX_DIR_FILES` (see ponytail note above); once either cap is hit we
+/// simply stop descending/collecting rather than failing the whole drop, so the caller
+/// still ingests whatever was found up to that point.
+fn collect_dir_files_bounded(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth > MAX_DIR_DEPTH || out.len() >= MAX_DIR_FILES {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if out.len() >= MAX_DIR_FILES {
+            return;
+        }
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue; // 隐藏/点文件,同 inbox::importable_files
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_dir_files_bounded(&path, depth + 1, out);
+        } else if file_type.is_file() {
+            let lower = name.to_lowercase();
+            if lower.ends_with(".tmp") || lower.ends_with(".part") || lower.ends_with(".crdownload")
+            {
+                continue; // 半成品/临时下载文件,同 inbox::importable_files
+            }
+            out.push(path);
+        }
+    }
+}
+
+/// Ingest one file through the panic-firewalled pipeline and translate the result into
+/// an `ImportOutcome` — shared by the single-file and folder-expansion branches of
+/// `ingest_files` so both report failures the same way.
+fn ingest_one(v: &Vault, path: &Path) -> ImportOutcome {
+    match ingest_guarded(v, path) {
+        Ok(o) => {
+            let status = match o.status {
+                pipeline::IngestStatus::New => "new",
+                pipeline::IngestStatus::Backfilled => "backfilled",
+                pipeline::IngestStatus::Deduped => "deduped",
+                pipeline::IngestStatus::StoredNoText => "stored_no_text",
+                pipeline::IngestStatus::InstanceAttached => "instance_attached",
+            }
+            .to_string();
+            ImportOutcome {
+                name: o.name,
+                source_file_id: o.source_file_id,
+                status,
+                doc_type: o.doc_type.map(|d| d.as_str().to_string()),
+            }
+        }
+        Err(e) => {
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.to_string_lossy().to_string());
+            eprintln!("[import] ingest failed for {}: {e}", path.display());
+            ImportOutcome {
+                name,
+                source_file_id: 0,
+                status: "failed".to_string(),
+                doc_type: None,
+            }
+        }
+    }
+}
+
+/// Ingest a batch of files (and/or folders) into the vault, one `ImportOutcome` per
+/// file — a single bad file is recorded as `failed` and never aborts the batch (same
+/// tolerance as `inbox::scan_inbox`). A directory (e.g. a dropped DICOM study folder,
+/// or any folder of records) is walked recursively via `collect_dir_files_bounded` and
+/// every file inside it is ingested the same way, so dropping a whole study folder
+/// imports every slice in one go without the user having to select files by hand.
 ///
 /// SECURITY (GHSA-gmg4): this takes already-resolved `PathBuf`s from a TRUSTED source
 /// only — either the Rust-side native file picker (`import_via_dialog`) or the OS
 /// drag-drop event delivered to the Tauri core (`lib.rs` window handler). It is
 /// deliberately NOT a `#[tauri::command]`: the webview can no longer name an arbitrary
 /// absolute path (e.g. `~/.ssh/id_rsa`) to be read into the vault and later exfiltrated
-/// via `read_source_bytes`. The minimal `is_file()` guard rejects directories / device
-/// nodes / dangling paths before we touch them.
+/// via `read_source_bytes`. Directory recursion inherits that trust — it only ever
+/// descends into paths reachable from a trusted drop/pick, not anything webview-named.
 pub(crate) fn ingest_files(v: &Vault, paths: &[PathBuf]) -> Vec<ImportOutcome> {
     let mut out = Vec::new();
     for path in paths {
+        if path.is_dir() {
+            let mut files = Vec::new();
+            collect_dir_files_bounded(path, 0, &mut files);
+            files.sort(); // 稳定顺序:同一文件夹重复拖入结果可复现
+            for file in &files {
+                out.push(ingest_one(v, file));
+            }
+            continue;
+        }
         if !path.is_file() {
             out.push(ImportOutcome {
                 name: path.to_string_lossy().to_string(),
@@ -231,37 +329,7 @@ pub(crate) fn ingest_files(v: &Vault, paths: &[PathBuf]) -> Vec<ImportOutcome> {
             });
             continue;
         }
-        match ingest_guarded(v, path) {
-            Ok(o) => {
-                let status = match o.status {
-                    pipeline::IngestStatus::New => "new",
-                    pipeline::IngestStatus::Backfilled => "backfilled",
-                    pipeline::IngestStatus::Deduped => "deduped",
-                    pipeline::IngestStatus::StoredNoText => "stored_no_text",
-                    pipeline::IngestStatus::InstanceAttached => "instance_attached",
-                }
-                .to_string();
-                out.push(ImportOutcome {
-                    name: o.name,
-                    source_file_id: o.source_file_id,
-                    status,
-                    doc_type: o.doc_type.map(|d| d.as_str().to_string()),
-                });
-            }
-            Err(e) => {
-                let name = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| path.to_string_lossy().to_string());
-                eprintln!("[import] ingest failed for {}: {e}", path.display());
-                out.push(ImportOutcome {
-                    name,
-                    source_file_id: 0,
-                    status: "failed".to_string(),
-                    doc_type: None,
-                });
-            }
-        }
+        out.push(ingest_one(v, path));
     }
     out
 }
@@ -853,6 +921,71 @@ mod demo_data_tests {
                 "missing imaging file: {name}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod folder_import_tests {
+    use super::{collect_dir_files_bounded, MAX_DIR_FILES};
+    use std::path::PathBuf;
+
+    /// 模拟拖入一整个 DICOM study 文件夹:Study/Series1、Series2 两个子目录各含若干
+    /// 切片,外加应被跳过的隐藏文件与半成品下载文件。验证递归穿过子目录收集全部
+    /// 常规文件、且跳过规则与 `inbox::importable_files` 一致(隐藏/点文件、
+    /// `.tmp`/`.part`/`.crdownload`)。
+    #[test]
+    fn recurses_into_subdirs_and_skips_hidden_and_partial_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let series1 = root.join("Series1");
+        let series2 = root.join("Series2");
+        std::fs::create_dir_all(&series1).unwrap();
+        std::fs::create_dir_all(&series2).unwrap();
+
+        std::fs::write(series1.join("IM001.dcm"), b"x").unwrap();
+        std::fs::write(series1.join("IM002.dcm"), b"x").unwrap();
+        std::fs::write(series2.join("IM001.dcm"), b"x").unwrap();
+        std::fs::write(root.join("report.pdf"), b"x").unwrap();
+        std::fs::write(root.join(".DS_Store"), b"x").unwrap();
+        std::fs::write(series1.join("downloading.tmp"), b"x").unwrap();
+        std::fs::write(series2.join("partial.part"), b"x").unwrap();
+        std::fs::write(series2.join("partial.crdownload"), b"x").unwrap();
+
+        let mut files = Vec::new();
+        collect_dir_files_bounded(root, 0, &mut files);
+        let mut names: Vec<String> = files
+            .into_iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(str::to_string))
+            .collect();
+        names.sort();
+
+        assert_eq!(
+            names,
+            vec![
+                "IM001.dcm".to_string(),
+                "IM001.dcm".to_string(),
+                "IM002.dcm".to_string(),
+                "report.pdf".to_string(),
+            ]
+        );
+    }
+
+    /// 验证 MAX_DIR_FILES 上限确实生效:超量文件的目录只收集到上限数量,不会
+    /// 无界增长(见 collect_dir_files_bounded 上的 ponytail 注释)。用小上限的
+    /// 独立文件集测试整个逻辑不现实(常量是编译期定值),所以这里只断言收集结果
+    /// 不超过该常量 —— 真正的上限值回归见该常量自身的注释与手工验证。
+    #[test]
+    fn never_collects_more_than_the_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        for i in 0..50 {
+            std::fs::write(root.join(format!("f{i}.txt")), b"x").unwrap();
+        }
+        let mut files: Vec<PathBuf> = Vec::new();
+        collect_dir_files_bounded(root, 0, &mut files);
+        assert_eq!(files.len(), 50);
+        assert!(files.len() <= MAX_DIR_FILES);
     }
 }
 

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -243,6 +243,9 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
           <div className="text-xs font-mono text-slate-400 mt-2">
             PDF · 图片(PNG / JPG / TIFF / HEIC)· TXT · DICOM · 原始文件永久保存,自动去重
           </div>
+          <div className="text-xs text-slate-400 mt-1">
+            也可以直接拖入一整个文件夹(例如一台 CT/MRI 的 DICOM 文件夹),里面的文件会被自动全部导入
+          </div>
           <div className="mt-5">
             <button
               type="button"


### PR DESCRIPTION
桌面文件夹/序列 DICOM 导入 · 目标 1.3

## 做了什么

拖拽导入之前要求每个拖入路径是文件(`path.is_file()`),拖一整个文件夹(比如一台 CT/MRI 导出的 DICOM study 文件夹)会失败。现在 `ingest_files` 遇到目录时递归收集其下全部常规文件并逐个导入:

- 新增 `collect_dir_files_bounded`:递归遍历目录,跳过隐藏/点文件与 `.tmp`/`.part`/`.crdownload` 半成品文件 —— 与 `inbox::importable_files`(自动收件箱)的跳过规则保持一致。
- 每个文件仍然单独走 `ingest_guarded`(既有的 per-file `catch_unwind` 隔离),提炼成 `ingest_one` 供单文件分支与目录展开分支共用,一个坏文件不拖垮整批、一个坏文件夹也不拖垮同批的其它文件/文件夹。
- 每个文件仍各自产出一条 `ImportOutcome`。目录本身不产出 outcome(和递归到的普通文件一视同仁)。
- 拖拽入口 `handle_file_drop`(`lib.rs`)本来就调用 `ingest_files`,不用改动就自动获得文件夹递归能力。
- `import_via_dialog`(原生选择文件对话框)保持不变,仍是选文件;文件夹场景的主入口是拖拽。

## 递归上限(ponytail)

`collect_dir_files_bounded` 上加了 `MAX_DIR_DEPTH = 16` / `MAX_DIR_FILES = 20_000` 两个上限:达到任一上限就停止继续下探/收集(不报错,只是不再收更多),防止软链接环或误拖了整块磁盘之类的病态目录把 UI 线程/导入卡死。真实场景(Study → Series → Instance)最多几层、几千个文件,两个上限都留了充足余量。

## 前端

`ImportView.tsx` 的导入提示区补充一行:「也可以直接拖入一整个文件夹(例如一台 CT/MRI 的 DICOM 文件夹),里面的文件会被自动全部导入」。

## 未做(按要求排除)

没有加 DICOM 内容嗅探/魔数探测 —— 仍然只按已有的按扩展名分发处理,文件夹递归只负责把目录展开成文件列表。

## Gate 结果

- `cargo check -p medme-desktop`:通过
- `cargo fmt -p medme-desktop -- --check`:干净
- `cargo clippy -p medme-desktop -- -D warnings`:干净
- `cd apps/desktop && pnpm exec tsc --noEmit`:通过
- 新增单元测试(`commands::folder_import_tests`):递归穿子目录收集 + 跳过隐藏/半成品文件、上限生效 —— `cargo test -p medme-desktop` 全部通过(11 项测试,含既有测试)

## 测试计划

- [ ] 真机验证:桌面把一整个 DICOM study 文件夹拖到窗口上,确认多张切片被识别为同一影像文档且时间线上显示切片数(现有的多切片分组逻辑)
- [ ] 真机验证:拖入含子目录混合内容的普通病历文件夹(PDF+图片+隐藏文件),确认全部常规文件导入、隐藏/半成品文件被跳过
- [x] `cargo test -p medme-desktop`(CI 环境可跑的部分已在本 PR 描述中列出结果)

全量端到端的拖拽验证需要在真实桌面环境(而非无头 CI)上进行,还请用户在自己的机器上过一遍。