### PR TITLE
feat(mobile): 手机端导出时间线 HTML,交系统分享面板

### DIFF
--- a/apps/mobile/src-tauri/src/commands.rs
+++ b/apps/mobile/src-tauri/src/commands.rs
@@ -572,6 +572,38 @@ pub fn create_share(
     })
 }
 
+/// 导出时间线:复用 `medme_share::export::build_timeline_html`(与桌面
+/// `export_timeline_html` 同一个平台无关函数),把整条时间线渲染成未加密、可打印的
+/// 自包含 HTML 写进沙盒 `shares/` 目录(与加密分享共用同一目录 —— 都是"本机生成、
+/// 交给系统分享 sheet 的临时导出件"),前端据此调起系统「分享」sheet 或用浏览器
+/// 「打印/另存为 PDF」交给医生 / 用于报销留档。导出内容本身**不加密**(区别于
+/// `create_share`),让医生/前台无需口令即可直接打开查看。
+#[tauri::command]
+pub fn export_timeline_html(state: State<AppState>) -> Result<ExportResult, String> {
+    let v = lock(&state)?;
+    // 移动端 Android 构建把 `dicom` 的 C/C++ `codecs` 关掉,进程内解码不含 RCE 面
+    // (GHSA-24px 仅影响链接了 codecs 的桌面),故直接注入进程内渲染器(与
+    // `create_share` 同理)。
+    let (html, record_count) =
+        medme_share::export::build_timeline_html(&v, &medme_share::render_dicom_png_in_process)?;
+    let byte_size = html.len() as i64;
+    let sha256 = core_model::cas::sha256_hex(html.as_bytes());
+
+    let shares_dir = state.vault_dir.join("shares");
+    std::fs::create_dir_all(&shares_dir).map_err(|e| e.to_string())?;
+    let stamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let dest = shares_dir.join(format!("medme-timeline-{stamp}.html"));
+    std::fs::write(&dest, html).map_err(|e| e.to_string())?;
+
+    v.record_export("timeline_html", &sha256, record_count)
+        .map_err(|e| e.to_string())?;
+    Ok(ExportResult {
+        record_count,
+        byte_size,
+        path: dest.to_string_lossy().to_string(),
+    })
+}
+
 /// 一键「载入示例数据」:把随应用打包的张建国示例病历(demo-data/,文本+PDF,
 /// 不含大体积 DICOM —— 详细阅片交给桌面/在线查看器)批量导入保险箱,让测试者
 /// 无需手动选文件就能看到 健康档案。按路径排序保证可复现;pipeline::ingest 去重,

--- a/apps/mobile/src-tauri/src/dto.rs
+++ b/apps/mobile/src-tauri/src/dto.rs
@@ -125,6 +125,16 @@ pub struct ShareResult {
     pub path: String,
 }
 
+/// 时间线导出结果:未加密、可打印的自包含 HTML(与桌面 `ExportSummary` 同构)。
+/// 与 `ShareResult` 不同,没有口令 —— 导出内容不加密,靠系统「分享」sheet 直接
+/// 交给医生 / 存下来打印。
+#[derive(Serialize)]
+pub struct ExportResult {
+    pub record_count: i64,
+    pub byte_size: i64,
+    pub path: String,
+}
+
 #[derive(Serialize)]
 pub struct PatientProfile {
     pub name: Option<String>,

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             commands::read_share_bytes,
             commands::get_patient_profile,
             commands::create_share,
+            commands::export_timeline_html,
             commands::load_demo_data,
             commands::get_vault_path,
             commands::reset_vault,

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -7,6 +7,7 @@ import type {
   TimelineGroup,
   ImportOutcome,
   ShareResult,
+  ExportResult,
   PatientProfile,
   DocumentDetail,
   IcloudStatus,
@@ -93,6 +94,7 @@ export default function App() {
   const [busy, setBusy] = useState<string | null>(null);
   const [lastImport, setLastImport] = useState<ImportOutcome | null>(null);
   const [share, setShare] = useState<ShareResult | null>(null);
+  const [exported, setExported] = useState<ExportResult | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
   const [confirmDisableIcloud, setConfirmDisableIcloud] = useState(false);
   const [version, setVersion] = useState("");
@@ -242,6 +244,21 @@ export default function App() {
       setShare(r);
     } catch (e) {
       alert(`生成分享失败:${e}`);
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  // 导出时间线:未加密的可打印 HTML(与桌面「导出」同一个平台无关渲染函数),
+  // 用于报销 / 给医生留档 —— 区别于上面的「加密分享」(那个要口令,给医生远程查看)。
+  const doExport = useCallback(async () => {
+    setLastImport(null);
+    try {
+      setBusy("正在生成导出文件…");
+      const r = await api.exportTimelineHtml();
+      setExported(r);
+    } catch (e) {
+      alert(`导出失败:${e}`);
     } finally {
       setBusy(null);
     }
@@ -427,6 +444,21 @@ export default function App() {
               <span className="rt">
                 <b>载入示例数据(张建国)</b>
                 <span>导入一份完整的示例病历,先试试看</span>
+              </span>
+              <span className="chev">›</span>
+            </button>
+            <button
+              className="row"
+              onClick={doExport}
+              disabled={!!busy || (profile?.record_count ?? 0) === 0}
+            >
+              <span className="ri"><FileTextIcon /></span>
+              <span className="rt">
+                <b>导出时间线(HTML)</b>
+                <span>
+                  导出可打印的完整时间线,浏览器打开后「打印 / 另存为 PDF」,
+                  用于报销或给医生留档
+                </span>
               </span>
               <span className="chev">›</span>
             </button>
@@ -625,6 +657,8 @@ export default function App() {
 
       {/* 加密分享结果:两步清晰动作 —— 分享文件(系统 sheet)+ 复制口令(另发)。 */}
       {share && <ShareModal share={share} onClose={() => setShare(null)} />}
+      {/* 时间线导出结果:未加密,一步「分享文件」交给系统分享 sheet。 */}
+      {exported && <ExportModal result={exported} onClose={() => setExported(null)} />}
 
       {busy && (
         <div className="toast">
@@ -759,6 +793,82 @@ function ShareModal({ share, onClose }: { share: ShareResult; onClose: () => voi
           <button className="second" onClick={doCopyPass}>
             <CopyIcon />
             {copied ? "已复制" : "复制口令"}
+          </button>
+        </div>
+
+        {msg && <div className="share-msg">{msg}</div>}
+
+        <button className="full" onClick={onClose}>
+          完成
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// 时间线导出结果:未加密的可打印 HTML(与 ShareModal 共用「分享文件」这套系统
+// 分享 sheet 逻辑,内容 File→navigator.share,不支持时回退到 openPath)。
+// 没有口令 —— 导出内容不加密,医生/前台无需口令即可直接打开、打印或另存为 PDF。
+function ExportModal({ result, onClose }: { result: ExportResult; onClose: () => void }) {
+  const [msg, setMsg] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
+
+  const filename = result.path.split("/").pop() || "medme-timeline.html";
+
+  const doShareFile = useCallback(async () => {
+    setMsg(null);
+    setSharing(true);
+    try {
+      const buf = await api.readShareBytes(result.path);
+      const file = new File([buf], filename, { type: "text/html" });
+      const nav = navigator as Navigator & {
+        canShare?: (d?: unknown) => boolean;
+        share?: (d: unknown) => Promise<void>;
+      };
+      if (nav.share) {
+        try {
+          if (!nav.canShare || nav.canShare({ files: [file] })) {
+            await nav.share({ files: [file], title: "MedMe 病历时间线导出" });
+            return;
+          }
+        } catch (e) {
+          if ((e as Error)?.name === "AbortError") return; // 用户在 sheet 里取消
+          // 否则落到下面的回退
+        }
+      }
+      // 回退:用系统默认程序打开文件(iOS 会用 Quick Look,内含「分享」按钮)。
+      const { openPath } = await import("@tauri-apps/plugin-opener");
+      await openPath(result.path);
+    } catch (e) {
+      if ((e as Error)?.name === "AbortError") return;
+      setMsg(`无法调起系统分享。文件已保存在应用内:\n${filename}\n可在「文件」App 的本应用目录中找到后发送。`);
+    } finally {
+      setSharing(false);
+    }
+  }, [result.path, filename]);
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog share" onClick={(e) => e.stopPropagation()}>
+        <div className="share-h">
+          <span className="share-badge"><FileTextIcon /></span>
+          <div>
+            <h3>时间线已导出</h3>
+            <span className="share-sub">{result.record_count} 份记录</span>
+          </div>
+        </div>
+
+        <p className="share-tip">
+          导出的是<b>可打印的完整时间线</b>(浏览器打开该文件后选择「打印 / 另存为 PDF」),
+          用于报销或给医生留档,内容<b>未加密</b>。
+          这里的记录是<b>这台设备</b>保险箱里当前的内容(本机导入的,以及若已开启
+          iCloud 同步则包含的同步数据)。
+        </p>
+
+        <div className="share-acts">
+          <button className="primary" onClick={doShareFile} disabled={sharing}>
+            <ShareIcon />
+            {sharing ? "调起分享…" : "分享文件"}
           </button>
         </div>
 

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -3,6 +3,7 @@ import type {
   TimelineGroup,
   ImportOutcome,
   ShareResult,
+  ExportResult,
   PatientProfile,
   DocumentDetail,
   IcloudStatus,
@@ -24,6 +25,9 @@ export const api = {
   getPatientProfile: () => invoke<PatientProfile>("get_patient_profile"),
   createShare: (expiresDays?: number) =>
     invoke<ShareResult>("create_share", { expiresDays }),
+  // 导出时间线:未加密、可打印的自包含 HTML,写进沙盒 shares/ 目录(与加密分享
+  // 共用同一目录,`read_share_bytes` 的 shares/ 前缀校验对它同样生效)。
+  exportTimelineHtml: () => invoke<ExportResult>("export_timeline_html"),
   loadDemoData: () => invoke<number>("load_demo_data"),
   getVaultPath: () => invoke<string>("get_vault_path"),
   resetVault: () => invoke<void>("reset_vault"),

--- a/apps/mobile/src/types.ts
+++ b/apps/mobile/src/types.ts
@@ -33,6 +33,11 @@ export interface ShareResult {
   byte_size: number;
   path: string;
 }
+export interface ExportResult {
+  record_count: number;
+  byte_size: number;
+  path: string;
+}
 export interface PatientProfile {
   name: string | null;
   gender: string | null;


### PR DESCRIPTION
导出能力平台统一(手机侧) · 目标 1.3

桌面端早已有「导出时间线」(`export_timeline_html` → `medme_share::export::build_timeline_html` → 原生保存对话框),手机端此前只有加密分享,没有对应的「导出未加密可打印 HTML」入口。本 PR 把这项能力补齐到手机端,复用与桌面完全相同的平台无关渲染函数。

## 改动

- 后端(`apps/mobile/src-tauri/src/commands.rs`):新增 `export_timeline_html` 命令。调用 `medme_share::export::build_timeline_html(&v, &medme_share::render_dicom_png_in_process)`(与桌面同一个函数;DICOM 渲染器用进程内版本 —— 移动端 Android 构建关闭了 `dicom` 的 C/C++ `codecs` 特性,没有桌面那条 GHSA-24px RCE 面,这一点与既有 `create_share` 的选择一致),把结果写入沙盒 `shares/` 目录(与既有加密分享共用同一目录 / 同一份 `read_share_bytes` 路径校验),文件名 `medme-timeline-<时间戳>.html`,并调用 `v.record_export("timeline_html", …)` 记入不可篡改的审计日志。返回记录数/字节数/路径(`ExportResult`,`apps/mobile/src-tauri/src/dto.rs`)。已在 `apps/mobile/src-tauri/src/lib.rs` 的 `invoke_handler` 注册。
- 前端(`apps/mobile/src/App.tsx` / `api.ts` / `types.ts`):设置页「数据」分组新增「导出时间线(HTML)」入口。点击后调用新命令,再通过既有的 `read_share_bytes` → `File` → `navigator.share` 路径(与「加密分享」弹层完全同一套逻辑,不支持时回退 `openPath`)把生成文件交给系统分享面板。新增 `ExportModal` 组件呈现结果,文案说明:导出的是可打印的完整时间线(浏览器打开后「打印 / 另存为 PDF」),用于报销或给医生留档;内容是**这台设备**保险箱当前的记录(本机导入的,以及若已开启 iCloud 同步则包含的同步数据),不加密(区别于加密分享),不声称是"跨设备全部数据"。

## 验证

- `cargo check -p medme-mobile` 通过
- `cargo fmt -p medme-mobile -- --check` 无差异
- `cargo clippy -p medme-mobile -- -D warnings` 无警告
- `cd apps/mobile && pnpm exec tsc --noEmit` 通过
- `pnpm run build` 构建成功

未验证:真机上系统「分享」面板的实际弹出效果(`navigator.share` 在 WKWebView/Android WebView 里的行为)需要用户在设备上实测确认,本地只能验证到编译 + 类型检查 + 构建通过。

## Test plan
- [ ] 真机(iOS/Android)点「导出时间线」,确认生成文件、系统分享面板正常弹出
- [ ] 用浏览器打开导出的 HTML,确认「打印 / 另存为 PDF」正常
- [ ] 确认导出内容与当前保险箱记录一致