### PR TITLE
chore(release): bump 1.1.0 → 1.1.1(1.2;iOS TestFlight 已上传)

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MedMe",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.medme.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/mobile/src-tauri/gen/apple/.gitignore
+++ b/apps/mobile/src-tauri/gen/apple/.gitignore
@@ -1,3 +1,4 @@
 xcuserdata/
 build/
 Externals/
+assets/demo-data/

--- a/apps/mobile/src-tauri/gen/apple/ExportManual.plist
+++ b/apps/mobile/src-tauri/gen/apple/ExportManual.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key><string>app-store-connect</string>
+  <key>teamID</key><string>49G34P23QP</string>
+  <key>signingStyle</key><string>manual</string>
+  <key>signingCertificate</key><string>Apple Distribution</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>com.medme.mobile</key><string>MedMe App Store</string>
+  </dict>
+  <key>uploadSymbols</key><true/>
+  <key>destination</key><string>export</string>
+</dict>
+</plist>

--- a/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/medme-mobile_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.0</string>
+	<string>1.1.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MedMe",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.medme.mobile",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
全部 1.2 审计修复已合入 main;iOS 1.1.1 已上传 TestFlight。桌面同步 bump。