### PR TITLE
feat(desktop): 清空保险箱 · 重置(格式化)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -851,6 +851,39 @@ pub async fn set_vault_path(
     Ok(guard.root().to_string_lossy().to_string())
 }
 
+/// 「清空保险箱 · 重置(格式化)」:抹掉保险箱当前内容并在原位置重建一个空保险箱,
+/// 镜像 mobile 的同名命令(见 apps/mobile/src-tauri/src/commands.rs::reset_vault)。
+/// 让「加载示例数据(张建国)→ 试用 → 清空 → 正式使用」可逆;也给了用户一个在开启
+/// 云盘同步前清掉示例数据的机会 —— 否则示例数据会被同步进云盘。
+///
+/// 与 mobile 不同:desktop 的保险箱目录可以被 `set_vault_path` 换到用户任选的、
+/// 名字任意的目录(例如某个 iCloud/坚果云同步目录),那个目录里除了保险箱本身还可能
+/// 放着用户自己的其它文件 —— `relocate_to` 的 `move_into` 就只搬 4 个具名条目
+/// (`objects`/`log`/`medme.db`/`VERSION`)进去,从不碰目标已有的其它内容(见
+/// core-model::relocate)。所以这里同样只删这 4 个具名条目,绝不对整个保险箱目录
+/// `remove_dir_all` —— 否则若保险箱目录是用户挪过去的、还装着别的文件的文件夹,
+/// 一次重置会把那些无关文件也一并删掉。
+#[tauri::command]
+pub fn reset_vault(app: tauri::AppHandle, state: State<AppState>) -> Result<(), String> {
+    let vault_dir = crate::vault_loc::read_vault_location(&app);
+    let mut guard = lock(&state)?;
+    for dir in ["objects", "log"] {
+        let p = vault_dir.join(dir);
+        if p.exists() {
+            std::fs::remove_dir_all(&p).map_err(|e| format!("清空保险箱失败:{e}"))?;
+        }
+    }
+    for file in ["medme.db", "VERSION"] {
+        let p = vault_dir.join(file);
+        if p.exists() {
+            std::fs::remove_file(&p).map_err(|e| format!("清空保险箱失败:{e}"))?;
+        }
+    }
+    *guard = Vault::open_with_device_id_resilient(&vault_dir, &state.device_id)
+        .map_err(|e| format!("重建保险箱失败:{e}"))?;
+    Ok(())
+}
+
 /// 隐藏的「审计/管理员」视图数据源:所有导入/导出/分享事件,最新在前,含
 /// 内容 sha256(见 core-model::audit —— 不可变事件日志,可核验、防篡改)。
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -147,6 +147,7 @@ pub fn run() {
             commands::open_url,
             commands::get_vault_path,
             commands::set_vault_path,
+            commands::reset_vault,
             commands::get_audit_log,
             commands::export_audit_csv,
         ])

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -96,7 +96,7 @@ export default function App() {
             ) : tab === "about" ? (
               <AboutView onNav={nav} />
             ) : tab === "settings" ? (
-              <SettingsView onNav={nav} />
+              <SettingsView onNav={nav} onReset={afterImport} />
             ) : tab === "audit" ? (
               <AuditView onNav={nav} />
             ) : (

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -47,6 +47,9 @@ export const api = {  listTimelineGrouped: () => invoke<TimelineGroup[]>("list_t
   // 更换保险箱位置:Rust 侧弹原生「选择文件夹」对话框,把现有病历搬到所选目录
   //(指向云同步文件夹即可多设备同步),返回新路径(取消则返回原路径)。
   setVaultPath: () => invoke<string>("set_vault_path"),
+  // 清空保险箱 · 重置(格式化):删掉当前保险箱内容并重建一个空的,用于清掉示例数据
+  // 或让用户从头开始——尤其应在开启云盘同步前做,否则示例数据会被同步进云盘。
+  resetVault: () => invoke<void>("reset_vault"),
   getAuditLog: () => invoke<AuditEntry[]>("get_audit_log"),
   // 导出审计清单 CSV:内容由前端按审计条目生成,后端写入固定导出目录并返回写入路径。
   exportAuditCsv: (contents: string) =>

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -201,7 +201,9 @@ export default function ImportView({ onImported }: { onImported: () => void }) {
             还没有自己的病历?加载内置的<b className="text-slate-800">张建国</b>示例数据集
             (含检验报告、门诊病历、处方、影像检查等),立即体验完整的生命时间线。
             <br />
-            <span className="text-xs text-slate-400">示例数据,可随时删除保险箱重来。</span>
+            <span className="text-xs text-slate-400">
+              示例数据,可随时到「设置 → 清空保险箱」删除重来。
+            </span>
           </div>
           <button
             type="button"

--- a/apps/desktop/src/components/SettingsView.tsx
+++ b/apps/desktop/src/components/SettingsView.tsx
@@ -8,10 +8,20 @@ import {
   Info,
   CloudCog,
   Lock,
+  AlertTriangle,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 import { api } from "../api";
 
-export default function SettingsView({ onNav }: { onNav: (id: string) => void }) {
+export default function SettingsView({
+  onNav,
+  onReset,
+}: {
+  onNav: (id: string) => void;
+  /** 清空保险箱成功后调用,让 App 层刷新时间线 + 病人 banner(见 App.tsx 的 afterImport)。 */
+  onReset: () => void;
+}) {
   const [vaultPath, setVaultPath] = useState<string | null>(null);
   const [inboxPath, setInboxPath] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -35,6 +45,29 @@ export default function SettingsView({ onNav }: { onNav: (id: string) => void })
       setError(String(e));
     } finally {
       setRelocating(false);
+    }
+  }
+
+  // 清空保险箱 · 重置(格式化):让示例数据/已导入内容可逆(载入 → 试用 → 清空 → 正式使用),
+  // 尤其应在开启上方「云文件夹设置」之前做——否则示例数据会被同步进云盘。
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetMsg, setResetMsg] = useState<
+    { kind: "ok"; text: string } | { kind: "err"; text: string } | null
+  >(null);
+
+  async function doResetVault() {
+    setResetting(true);
+    setResetMsg(null);
+    try {
+      await api.resetVault();
+      onReset();
+      setConfirmReset(false);
+      setResetMsg({ kind: "ok", text: "保险箱已清空,可以开始正式使用了。" });
+    } catch (e) {
+      setResetMsg({ kind: "err", text: `清空失败:${String(e)}` });
+    } finally {
+      setResetting(false);
     }
   }
 
@@ -179,6 +212,40 @@ export default function SettingsView({ onNav }: { onNav: (id: string) => void })
           </div>
         </div>
 
+        {/* 危险操作:清空保险箱 · 重置(格式化)——桌面此前没有这个入口,示例数据/试用内容
+            没法清掉;镜像 mobile 已有的同名功能(见 apps/mobile/src/App.tsx::resetVault)。 */}
+        <div className="bg-white rounded-2xl border border-rose-200 p-5 shadow-sm">
+          <div className="flex items-center gap-2 text-rose-700 font-medium mb-2">
+            <AlertTriangle className="w-5 h-5" /> 危险操作
+          </div>
+          <div className="text-sm text-slate-600 leading-relaxed mb-3">
+            <b className="text-rose-700">清空保险箱</b>会永久删除保险箱里的<b>全部记录</b>
+            (包括示例数据「张建国」和你已导入的所有病历),<b className="text-rose-700">此操作不可撤销</b>。
+            <br />
+            如果你之前用示例数据试用过 MedMe,请在正式使用前先清空一次——
+            <b className="text-rose-700">尤其要在开启上方「云文件夹设置」之前</b>,
+            否则示例数据会被同步进你的云盘。
+          </div>
+          <button
+            type="button"
+            onClick={() => setConfirmReset(true)}
+            className="flex items-center gap-2 text-sm font-medium text-rose-700 bg-rose-50 hover:bg-rose-100 rounded-xl px-4 py-2.5 transition-colors cursor-pointer"
+          >
+            <Trash2 className="w-4 h-4" /> 清空保险箱 · 重置(格式化)
+          </button>
+          {resetMsg && (
+            <div
+              className={`mt-3 rounded-xl px-4 py-2.5 text-sm leading-relaxed break-all ${
+                resetMsg.kind === "ok"
+                  ? "bg-emerald-50 text-emerald-700"
+                  : "bg-rose-50 text-rose-700"
+              }`}
+            >
+              {resetMsg.text}
+            </div>
+          )}
+        </div>
+
         {/* 关于 · 声明 */}
         <div className="bg-white rounded-2xl border border-slate-200 p-5 shadow-sm">
           <div className="flex items-center justify-between gap-3">
@@ -197,6 +264,50 @@ export default function SettingsView({ onNav }: { onNav: (id: string) => void })
 
         <div className="text-xs font-mono text-slate-400 text-center">版本 v1.0</div>
       </div>
+
+      {/* 清空确认:破坏性操作,二次确认(镜像 mobile 的 confirmReset 弹层) */}
+      {confirmReset && (
+        <div
+          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+          onClick={() => !resetting && setConfirmReset(false)}
+        >
+          <div
+            className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 text-rose-700 font-semibold text-lg mb-3">
+              <AlertTriangle className="w-5 h-5" /> 确定清空保险箱?
+            </div>
+            <div className="text-sm text-slate-600 leading-relaxed mb-5">
+              这会<b className="text-rose-700">永久删除</b>保险箱里的全部记录
+              (含示例数据和你已导入的病历),<b className="text-rose-700">此操作不可撤销</b>。
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmReset(false)}
+                disabled={resetting}
+                className="text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:opacity-50 rounded-lg px-4 py-2 transition-colors cursor-pointer"
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={doResetVault}
+                disabled={resetting}
+                className="flex items-center gap-2 text-sm font-medium text-white bg-rose-600 hover:bg-rose-700 disabled:opacity-50 disabled:cursor-wait rounded-lg px-4 py-2 transition-colors cursor-pointer"
+              >
+                {resetting ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Trash2 className="w-4 h-4" />
+                )}
+                {resetting ? "正在清空…" : "确定清空"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

桌面端此前没有清空/重置保险箱的入口:用户加载过内置示例数据(张建国)试用后，
想正式使用，或想在开启云文件夹同步前先清掉示例数据，都无路可走 —— 移动端已经
有同名的 `reset_vault` 功能，桌面端一直缺失，这个 PR 补上。

- **后端**（`apps/desktop/src-tauri/src/commands.rs`）：新增 `reset_vault` 命令，
  锁定 vault、经 `vault_loc::read_vault_location` 拿到当前保险箱目录，删掉
  `objects/`、`log/`、`medme.db`、`VERSION` 这四个具名条目，再用
  `Vault::open_with_device_id_resilient` 在原位置重建空保险箱，替换 `AppState`
  里的 `Mutex<Vault>`。已在 `lib.rs` 的 `invoke_handler` 注册，并加了
  `api.ts` 的 `resetVault` 绑定。

  **与 mobile 版本的一处刻意差异**：mobile 的 `reset_vault` 用「目录名必须叫
  `vault`」做安全兜底后直接 `remove_dir_all` 整个目录，这在 mobile 上是安全的，
  因为那个目录始终是 App 沙盒/容器专属、从不与用户其它文件共享。但桌面端的保险箱
  目录可以被 `set_vault_path` 换到用户任选的、名字任意的目录（例如指向一个
  iCloud/坚果云同步文件夹），而 `relocate_to` 的 `move_into` 只会把
  `objects`/`log`/`medme.db`/`VERSION` 这四个具名条目搬进去，从不碰目标目录里
  已有的其它内容（见 `core-model::relocate`）。如果直接照搬 mobile 那套
  `remove_dir_all` 整个目录的做法，一旦用户把保险箱指向了一个还装着自己其它文件
  的文件夹，重置就会把那些无关文件也一起删掉。所以桌面端改为只删这四个具名条目，
  不删整个目录 —— 更贴合桌面端「保险箱目录可以是任意用户文件夹」这个实际情况。

- **前端**（`apps/desktop/src/components/SettingsView.tsx`）：新增「危险操作」
  卡片，红色警示样式，`清空保险箱 · 重置(格式化)` 按钮 + 二次确认弹层。文案明确
  写清楚：
  - 永久删除保险箱里的**全部记录**（含示例数据「张建国」和已导入的所有病历）
  - **此操作不可撤销**
  - 如果之前用示例数据试用过，请在正式使用前先清空一次，**尤其要在开启上方
    「云文件夹设置」之前** —— 否则示例数据会被同步进云盘

  清空成功后调用 `onReset`（= `App.tsx` 里的 `afterImport`）刷新时间线和病人
  banner，让界面立刻显示为空。

- `ImportView.tsx` 里"加载示例数据"按钮旁原本一句模糊的提示（"可随时删除保险箱
  重来"）改为明确指向 `设置 → 清空保险箱`，让用户知道去哪清、示例数据是可逆的。

## Test plan

Gate（提交前已全部跑过，均通过）：
- [x] `cargo check -p medme-desktop`
- [x] `cargo fmt -p medme-desktop -- --check`
- [x] `cargo clippy -p medme-desktop -- -D warnings`
- [x] `cd apps/desktop && pnpm exec tsc --noEmit`

**尚未做的验证**：实际在跑起来的桌面 app 里点一遍"加载示例数据 → 设置 → 清空
保险箱 → 确认清空 → 时间线变空"这条完整路径，需要在用户的桌面环境里手动跑一遍
（此 sandbox 里跑不了打包后的 Tauri app）。