### PR TITLE
fix(render): 化验单按结构解析成表格(修 pdf-extract 单空格导致的散行)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "node --test",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/apps/desktop/src/components/ReportContent.tsx
+++ b/apps/desktop/src/components/ReportContent.tsx
@@ -4,8 +4,11 @@
 //  - 病理/影像/出院/病历/手术 → 分节 + 行内标签加粗
 // 解析不到结构就退回干净文本 —— 永不比原文更糟(见 memory: content-aware-rendering)。
 
+import { tryParseLabRun, type LabRow } from "../labTable";
+
 type Block =
   | { kind: "table"; header: string[] | null; rows: string[][] }
+  | { kind: "labtable"; rows: LabRow[] }
   | { kind: "section"; text: string }
   | { kind: "para"; text: string };
 
@@ -41,6 +44,14 @@ function parse(text: string): Block[] {
     const trimmed = lines[i].trim();
     if (!trimmed) {
       i++;
+      continue;
+    }
+    // 化验单单空格塌陷场景:先按结构尝试识别连续的化验行(见 labTable.ts),
+    // 命中则优先于下面基于"多空格分列"的通用表格解析。
+    const labRun = tryParseLabRun(lines, i);
+    if (labRun) {
+      blocks.push({ kind: "labtable", rows: labRun.rows });
+      i = labRun.next;
       continue;
     }
     if (isTableHeader(trimmed) || isDataRow(trimmed)) {
@@ -142,6 +153,42 @@ function GenericBlocks({ blocks }: { blocks: Block[] }) {
   return (
     <>
       {blocks.map((b, i) => {
+        if (b.kind === "labtable") {
+          return (
+            <div key={i} className="overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="bg-slate-50 text-slate-500 text-xs">
+                    {["项目", "结果", "单位", "参考范围/提示"].map((h) => (
+                      <th
+                        key={h}
+                        className="text-left font-medium px-3 py-2 border-b border-slate-200 whitespace-nowrap"
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {b.rows.map((r, ri) => (
+                    <tr key={ri} className={`${ri % 2 ? "bg-slate-50/40" : ""} ${statusText(r.flag)}`}>
+                      <td className="px-3 py-1.5 border-b border-slate-100">{r.name}</td>
+                      <td className="px-3 py-1.5 font-mono border-b border-slate-100 whitespace-nowrap">
+                        {r.value}
+                      </td>
+                      <td className="px-3 py-1.5 font-mono border-b border-slate-100 whitespace-nowrap">
+                        {r.unit}
+                      </td>
+                      <td className="px-3 py-1.5 font-mono border-b border-slate-100 whitespace-nowrap">
+                        {r.range}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          );
+        }
         if (b.kind === "table") {
           const cols = Math.max(b.header?.length ?? 0, ...b.rows.map((r) => r.length));
           return (

--- a/apps/desktop/src/labTable.ts
+++ b/apps/desktop/src/labTable.ts
@@ -1,0 +1,97 @@
+// 化验单结构化解析(纯函数,便于单测)。
+//
+// 背景:PDF 文本提取器(pdf-extract)会把所有空白折叠成单个空格,原本靠"两个以上
+// 空格/Tab"分列的化验行(见 ReportContent.tsx 的 splitCells)因此退化成一整行散文本,
+// 无法再按列切分。这里改用"结构"而非"空白宽度"来切列:
+//   值(VALUE) = 第一个独立的数字 token(如 6.05 / 7.1 / 95)
+//   单位(UNIT) = 紧跟在值后面的 token,前提是它不像参考范围的起始(否则视为无单位)
+//   项目名(NAME) = 值之前的所有 token
+//   参考范围/提示(RANGE) = 单位之后的所有 token(如 "< 5.20 ↑" / "3.9 - 6.1 ↑")
+// 对形如 "TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑" 的单空格行同样适用。
+
+export interface LabRow {
+  name: string;
+  value: string;
+  unit: string;
+  range: string;
+  flag: "high" | "low" | "normal" | null;
+}
+
+const NUM_RE = /^-?\d+(\.\d+)?$/;
+const RANGE_START_RE = /^[<>≤≥]/;
+
+function labFlag(range: string): LabRow["flag"] {
+  if (/↑|偏高|升高/.test(range)) return "high";
+  if (/↓|偏低|降低|减低/.test(range)) return "low";
+  if (/正常/.test(range)) return "normal";
+  return null;
+}
+
+// 把一行拆成结构化的化验行;不像化验行(找不到独立数值,或数值前/后缺内容)则返回 null。
+export function parseLabRow(line: string): LabRow | null {
+  const tokens = line.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length < 2) return null;
+
+  const valueIdx = tokens.findIndex((t) => NUM_RE.test(t));
+  if (valueIdx <= 0) return null; // 值前必须有项目名;值本身不能是第一个 token
+
+  const after = tokens.slice(valueIdx + 1);
+  if (after.length === 0) return null; // 值后至少要有单位或参考范围,否则不像化验行
+
+  const name = tokens.slice(0, valueIdx).join(" ");
+  const value = tokens[valueIdx];
+
+  // 判断值后第一个 token 是参考范围的开头(比较符/数字/连字符),还是单位。
+  const nextTok = after[0];
+  const looksLikeRangeStart = RANGE_START_RE.test(nextTok) || NUM_RE.test(nextTok) || nextTok === "-";
+  const unit = looksLikeRangeStart ? "" : nextTok;
+  const rangeTokens = looksLikeRangeStart ? after : after.slice(1);
+  const range = rangeTokens.join(" ");
+
+  return { name, value, unit, range, flag: labFlag(range) };
+}
+
+// 化验表表头行(如"项目缩写 项目名称 结果 单位 参考范围 提示")—— 只用于识别并消费掉
+// 表头,不做数据解析(表头本身不含数字,parseLabRow 对其恒返回 null)。
+export function isLabHeaderLine(line: string): boolean {
+  const keys = ["项目", "结果", "单位", "参考", "提示", "名称", "缩写"];
+  const hits = keys.filter((k) => line.includes(k)).length;
+  return hits >= 2 && !/\d/.test(line);
+}
+
+// 连续 ≥3 行都能解析成化验行,才判定为化验表(避免把偶尔带数字的普通段落误判)。
+const MIN_LAB_ROWS = 3;
+
+export interface LabRun {
+  rows: LabRow[];
+  /** 下一个未消费的行号(含表头在内)。 */
+  next: number;
+}
+
+// 只跳过恰好一行空行(实测 pdf-extract 会在提取出的每一"行"之间都插入一个空行,
+// 见 examples/demo-dataset 的真实血脂血糖报告——不是段落间距,是逐行现象;
+// 连续 ≥2 行空行更像是真正的段落分隔,不再当表格处理)。
+function skipSingleBlank(lines: string[], k: number): number {
+  return k < lines.length && lines[k].trim() === "" ? k + 1 : k;
+}
+
+// 从 lines[i] 开始尝试识别一段连续的化验表:可选的表头行 + ≥3 行连续化验数据行
+// (行间允许被 pdf-extract 逐行插入的单个空行打断,见 skipSingleBlank)。
+// 识别失败(不足 3 行连续化验行)返回 null,调用方应回退到通用解析。
+export function tryParseLabRun(lines: string[], i: number): LabRun | null {
+  const trimmed = lines[i].trim();
+  const start = isLabHeaderLine(trimmed) ? skipSingleBlank(lines, i + 1) : i;
+
+  const rows: LabRow[] = [];
+  let j = start;
+  while (j < lines.length) {
+    const l = lines[j].trim();
+    const row = l ? parseLabRow(l) : null;
+    if (!row) break;
+    rows.push(row);
+    j = skipSingleBlank(lines, j + 1);
+  }
+
+  if (rows.length < MIN_LAB_ROWS) return null;
+  return { rows, next: j };
+}

--- a/apps/desktop/test/labTable.test.ts
+++ b/apps/desktop/test/labTable.test.ts
@@ -1,0 +1,147 @@
+// 化验行结构化解析的单测。喂入 pdf-extract 把所有空白折叠成单空格后的真实行
+// (原始 PDF 里各列靠多空格对齐,提取后退化成单空格分隔的散文本),验证仍能按
+// 结构切出 项目名/结果/单位/参考范围+提示。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isLabHeaderLine, parseLabRow, tryParseLabRun } from "../src/labTable.ts";
+
+// 血脂血糖化验单示例(单空格,来自 pdf-extract 的真实输出形态)。
+const HEADER = "项目缩写 项目名称 结果 单位 参考范围 提示";
+const ROWS = [
+  "TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑",
+  "TG 甘油三酯 Triglyceride 2.35 mmol/L < 1.70 ↑",
+  "HDL-C 高密度脂蛋白胆固醇 0.98 mmol/L > 1.04 ↓",
+  "GLU 空腹血糖 Glucose 7.1 mmol/L 3.9 - 6.1 ↑",
+  "HbA1c 糖化血红蛋白 6.9 % 4.0 - 6.0 ↑",
+  "Cr 肌酐 Creatinine 95 umol/L 57 - 97 正常",
+  "BUN 尿素氮 6.1 mmol/L 3.1 - 8.0 正常",
+];
+
+test("isLabHeaderLine 识别化验表表头,且表头本身不是数据行", () => {
+  assert.equal(isLabHeaderLine(HEADER), true);
+  assert.equal(parseLabRow(HEADER), null);
+});
+
+test("parseLabRow 把单空格行按结构切成 名称/值/单位/范围+提示", () => {
+  assert.deepEqual(parseLabRow(ROWS[0]), {
+    name: "TC 总胆固醇 Cholesterol",
+    value: "6.05",
+    unit: "mmol/L",
+    range: "< 5.20 ↑",
+    flag: "high",
+  });
+  assert.deepEqual(parseLabRow(ROWS[1]), {
+    name: "TG 甘油三酯 Triglyceride",
+    value: "2.35",
+    unit: "mmol/L",
+    range: "< 1.70 ↑",
+    flag: "high",
+  });
+  assert.deepEqual(parseLabRow(ROWS[2]), {
+    name: "HDL-C 高密度脂蛋白胆固醇",
+    value: "0.98",
+    unit: "mmol/L",
+    range: "> 1.04 ↓",
+    flag: "low",
+  });
+  assert.deepEqual(parseLabRow(ROWS[3]), {
+    name: "GLU 空腹血糖 Glucose",
+    value: "7.1",
+    unit: "mmol/L",
+    range: "3.9 - 6.1 ↑",
+    flag: "high",
+  });
+  assert.deepEqual(parseLabRow(ROWS[4]), {
+    name: "HbA1c 糖化血红蛋白",
+    value: "6.9",
+    unit: "%",
+    range: "4.0 - 6.0 ↑",
+    flag: "high",
+  });
+  assert.deepEqual(parseLabRow(ROWS[5]), {
+    name: "Cr 肌酐 Creatinine",
+    value: "95",
+    unit: "umol/L",
+    range: "57 - 97 正常",
+    flag: "normal",
+  });
+  assert.deepEqual(parseLabRow(ROWS[6]), {
+    name: "BUN 尿素氮",
+    value: "6.1",
+    unit: "mmol/L",
+    range: "3.1 - 8.0 正常",
+    flag: "normal",
+  });
+});
+
+test("parseLabRow 对没有单位的行也能优雅处理(值后直接是参考范围)", () => {
+  const row = parseLabRow("WBC 白细胞计数 5.2 3.5 - 9.5 正常");
+  assert.deepEqual(row, {
+    name: "WBC 白细胞计数",
+    value: "5.2",
+    unit: "",
+    range: "3.5 - 9.5 正常",
+    flag: "normal",
+  });
+});
+
+test("parseLabRow 对普通段落(无独立数值,或数值打头)返回 null", () => {
+  assert.equal(parseLabRow("患者近期体检未见明显异常。"), null);
+  assert.equal(parseLabRow("6.05 单独一个数字打头,前面没有项目名"), null);
+  assert.equal(parseLabRow("孤零零一个数字 6.05"), null); // 值后没有任何内容
+});
+
+test("tryParseLabRun 消费表头 + 连续 ≥3 行化验数据,整段判定为化验表", () => {
+  const lines = [HEADER, ...ROWS, "", "备注:空腹采血。"];
+  const run = tryParseLabRun(lines, 0);
+  assert.ok(run);
+  assert.equal(run.rows.length, ROWS.length);
+  assert.equal(run.rows[0].name, "TC 总胆固醇 Cholesterol");
+  assert.equal(lines[run.next].trim(), "备注:空腹采血。"); // 停在化验表之后的下一段落
+});
+
+// 实测发现:pdf_extract 对本 app 打包的真实化验单 PDF(见
+// apps/desktop/src-tauri/demo-data/corpus/*血脂*.pdf)提取出的文本,每一"行"之间
+// 都夹了一个空行(不是只把行内多空格折叠成单空格,连行与行之间也多了空行)。
+// 若不容忍这一个空行,连续行判定会在第 1 行后就被打断,永远凑不够 3 行 —— 复现
+// 这个真实形态,确保修复对线上会遇到的情况真正生效,而不仅仅是对着人工拼的无空行样例。
+test("tryParseLabRun 容忍化验行之间夹杂的单个空行(真实 pdf-extract 输出形态)", () => {
+  const lines = [
+    HEADER,
+    "",
+    ROWS[0],
+    "",
+    ROWS[1],
+    "",
+    ROWS[2],
+    "",
+    ROWS[3],
+    "",
+    "提示:血脂四项异常,建议内分泌科随诊。",
+    "",
+  ];
+  const run = tryParseLabRun(lines, 0);
+  assert.ok(run);
+  assert.equal(run.rows.length, 4);
+  assert.equal(run.rows[0].name, "TC 总胆固醇 Cholesterol");
+  assert.equal(run.rows[3].name, "GLU 空腹血糖 Glucose");
+  assert.equal(lines[run.next].trim(), "提示:血脂四项异常,建议内分泌科随诊。");
+});
+
+test("tryParseLabRun 连续 ≥2 行空行判定为真正的段落分隔,不再当作化验行间隔", () => {
+  const lines = [HEADER, "", ROWS[0], "", "", ROWS[1], ROWS[2]];
+  // TC 后面是两个空行 → 表格在此截断,只拿到 1 行,不足 3 行 → 判定失败
+  assert.equal(tryParseLabRun(lines, 0), null);
+});
+
+test("tryParseLabRun 不足 3 行连续化验行时判定失败,交回通用解析", () => {
+  const lines = [HEADER, ROWS[0], ROWS[1], "以下省略,仅两行数据。"];
+  assert.equal(tryParseLabRun(lines, 0), null);
+});
+
+test("tryParseLabRun 没有表头也能从数据行直接起判(单元测试里另有真实报告场景)", () => {
+  const run = tryParseLabRun(ROWS, 0);
+  assert.ok(run);
+  assert.equal(run.rows.length, ROWS.length);
+  assert.equal(run.next, ROWS.length);
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "node --test",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, ReactNode } from "react";
 import "./App.css";
 import markUrl from "./assets/medme-mark.svg";
 import { api } from "./api";
+import { isLabHeaderLine, parseLabRow } from "./labTable";
 import type {
   TimelineGroup,
   ImportOutcome,
@@ -890,25 +891,8 @@ function ExportModal({ result, onClose }: { result: ExportResult; onClose: () =>
 // 规则:【…】/短标题行 → 小节标题;化验单的「项目 结果 参考范围」行 → 三列对齐
 // (值用等宽 + tabular-nums 对齐,异常↑↓染色);处方的编号药品行 → 药品条目;
 // 其余 → 正常段落(保留换行、舒适行高)。任何行解析失败都安全回退为段落。
-type LabRow = { name: string; value: string; ref: string; flag: "hi" | "lo" | "" };
-
-function parseLabRow(line: string): LabRow | null {
-  const cells = line.trim().split(/\s{2,}/).filter(Boolean);
-  if (cells.length < 2) return null;
-  const idx = cells.findIndex((c) => /^[<>]?\s*-?\d+(\.\d+)?$/.test(c.trim()));
-  if (idx <= 0) return null; // 第一格必须是名称,不能是数值
-  const name = cells.slice(0, idx).join(" ");
-  const value = cells[idx].trim();
-  const rest = cells.slice(idx + 1).join(" ");
-  const tail = line;
-  const flag: LabRow["flag"] = /↑|偏高|升高/.test(tail)
-    ? "hi"
-    : /↓|偏低|降低/.test(tail)
-      ? "lo"
-      : "";
-  const ref = rest.replace(/[↑↓]/g, "").trim();
-  return { name, value, ref, flag };
-}
+// 化验行的结构化解析在 ./labTable.ts(与桌面端同一套修复,按结构而非空白宽度切列,
+// 兼容 pdf-extract 把多空格折叠成单空格的情况)。
 
 function ClinicalText({ text, docType }: { text: string; docType: string }) {
   const raw = text.replace(/\r\n/g, "\n");
@@ -971,11 +955,16 @@ function ClinicalText({ text, docType }: { text: string; docType: string }) {
       );
       return;
     }
-    // 化验单:三列对齐行
+    // 化验单:三列对齐行(名称 | 结果 | 单位+参考范围)
     if (docType === "lab_report") {
+      if (isLabHeaderLine(t)) {
+        flushPara();
+        return; // 表头行(项目/结果/单位/参考范围/提示)—— 消费掉,不当段落展示
+      }
       const row = parseLabRow(line);
       if (row) {
         flushPara();
+        const ref = [row.unit, row.range.replace(/[↑↓]/g, "").trim()].filter(Boolean).join(" ");
         active().push(
           <div className="lab-row" key={`l${seq++}`}>
             <span className="nm">{row.name}</span>
@@ -983,7 +972,7 @@ function ClinicalText({ text, docType }: { text: string; docType: string }) {
               {row.value}
               {row.flag === "hi" ? " ↑" : row.flag === "lo" ? " ↓" : ""}
             </span>
-            <span className="ref">{row.ref}</span>
+            <span className="ref">{ref}</span>
           </div>,
         );
         return;

--- a/apps/mobile/src/labTable.ts
+++ b/apps/mobile/src/labTable.ts
@@ -1,0 +1,59 @@
+// 化验行结构化解析(纯函数,便于单测)。与桌面端 apps/desktop/src/labTable.ts 是
+// 同一处修复的镜像:两端各自独立打包,没有共享的 TS 包,故各自维护一份。
+//
+// 背景:PDF 文本提取器(pdf-extract)会把所有空白折叠成单个空格,原本靠"两个以上
+// 空格"分列的化验行(旧实现 split(/\s{2,}/))因此退化成一整行散文本,无法再按列
+// 切分。这里改用"结构"而非"空白宽度"来切列:
+//   值(VALUE) = 第一个独立的数字 token(如 6.05 / 7.1 / 95)
+//   单位(UNIT) = 紧跟在值后面的 token,前提是它不像参考范围的起始(否则视为无单位)
+//   项目名(NAME) = 值之前的所有 token
+//   参考范围/提示(RANGE) = 单位之后的所有 token(如 "< 5.20 ↑" / "3.9 - 6.1 ↑")
+
+export interface LabRow {
+  name: string;
+  value: string;
+  unit: string;
+  range: string;
+  flag: "hi" | "lo" | "";
+}
+
+const NUM_RE = /^-?\d+(\.\d+)?$/;
+const RANGE_START_RE = /^[<>≤≥]/;
+
+function labFlag(range: string): LabRow["flag"] {
+  if (/↑|偏高|升高/.test(range)) return "hi";
+  if (/↓|偏低|降低/.test(range)) return "lo";
+  return "";
+}
+
+// 把一行拆成结构化的化验行;不像化验行(找不到独立数值,或数值前/后缺内容)则返回 null。
+export function parseLabRow(line: string): LabRow | null {
+  const tokens = line.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length < 2) return null;
+
+  const valueIdx = tokens.findIndex((t) => NUM_RE.test(t));
+  if (valueIdx <= 0) return null; // 值前必须有项目名;值本身不能是第一个 token
+
+  const after = tokens.slice(valueIdx + 1);
+  if (after.length === 0) return null; // 值后至少要有单位或参考范围,否则不像化验行
+
+  const name = tokens.slice(0, valueIdx).join(" ");
+  const value = tokens[valueIdx];
+
+  // 判断值后第一个 token 是参考范围的开头(比较符/数字/连字符),还是单位。
+  const nextTok = after[0];
+  const looksLikeRangeStart = RANGE_START_RE.test(nextTok) || NUM_RE.test(nextTok) || nextTok === "-";
+  const unit = looksLikeRangeStart ? "" : nextTok;
+  const rangeTokens = looksLikeRangeStart ? after : after.slice(1);
+  const range = rangeTokens.join(" ");
+
+  return { name, value, unit, range, flag: labFlag(range) };
+}
+
+// 化验表表头行(如"项目缩写 项目名称 结果 单位 参考范围 提示")—— 识别出来后跳过,
+// 不当作普通段落展示(表头本身不含数字,parseLabRow 对其恒返回 null)。
+export function isLabHeaderLine(line: string): boolean {
+  const keys = ["项目", "结果", "单位", "参考", "提示", "名称", "缩写"];
+  const hits = keys.filter((k) => line.includes(k)).length;
+  return hits >= 2 && !/\d/.test(line);
+}

--- a/apps/mobile/test/labTable.test.ts
+++ b/apps/mobile/test/labTable.test.ts
@@ -1,0 +1,70 @@
+// 化验行结构化解析的单测(移动端镜像,见 apps/desktop/test/labTable.test.ts)。
+// 喂入 pdf-extract 把所有空白折叠成单空格后的真实行,验证仍能按结构切出
+// 项目名/结果/单位/参考范围+提示。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isLabHeaderLine, parseLabRow } from "../src/labTable.ts";
+
+const HEADER = "项目缩写 项目名称 结果 单位 参考范围 提示";
+const ROWS = [
+  "TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑",
+  "TG 甘油三酯 Triglyceride 2.35 mmol/L < 1.70 ↑",
+  "HDL-C 高密度脂蛋白胆固醇 0.98 mmol/L > 1.04 ↓",
+  "GLU 空腹血糖 Glucose 7.1 mmol/L 3.9 - 6.1 ↑",
+  "HbA1c 糖化血红蛋白 6.9 % 4.0 - 6.0 ↑",
+  "Cr 肌酐 Creatinine 95 umol/L 57 - 97 正常",
+  "BUN 尿素氮 6.1 mmol/L 3.1 - 8.0 正常",
+];
+
+test("isLabHeaderLine 识别化验表表头,且表头本身不是数据行", () => {
+  assert.equal(isLabHeaderLine(HEADER), true);
+  assert.equal(parseLabRow(HEADER), null);
+});
+
+test("parseLabRow 把单空格行按结构切成 名称/值/单位/范围+提示", () => {
+  assert.deepEqual(parseLabRow(ROWS[0]), {
+    name: "TC 总胆固醇 Cholesterol",
+    value: "6.05",
+    unit: "mmol/L",
+    range: "< 5.20 ↑",
+    flag: "hi",
+  });
+  assert.deepEqual(parseLabRow(ROWS[2]), {
+    name: "HDL-C 高密度脂蛋白胆固醇",
+    value: "0.98",
+    unit: "mmol/L",
+    range: "> 1.04 ↓",
+    flag: "lo",
+  });
+  assert.deepEqual(parseLabRow(ROWS[3]), {
+    name: "GLU 空腹血糖 Glucose",
+    value: "7.1",
+    unit: "mmol/L",
+    range: "3.9 - 6.1 ↑",
+    flag: "hi",
+  });
+  assert.deepEqual(parseLabRow(ROWS[5]), {
+    name: "Cr 肌酐 Creatinine",
+    value: "95",
+    unit: "umol/L",
+    range: "57 - 97 正常",
+    flag: "",
+  });
+});
+
+test("parseLabRow 对没有单位的行也能优雅处理(值后直接是参考范围)", () => {
+  const row = parseLabRow("WBC 白细胞计数 5.2 3.5 - 9.5 正常");
+  assert.deepEqual(row, {
+    name: "WBC 白细胞计数",
+    value: "5.2",
+    unit: "",
+    range: "3.5 - 9.5 正常",
+    flag: "",
+  });
+});
+
+test("parseLabRow 对普通段落(无独立数值,或数值打头)返回 null", () => {
+  assert.equal(parseLabRow("患者近期体检未见明显异常。"), null);
+  assert.equal(parseLabRow("6.05 单独一个数字打头,前面没有项目名"), null);
+  assert.equal(parseLabRow("孤零零一个数字 6.05"), null);
+});


### PR DESCRIPTION
## 根因

`pdf_extract`(PDF 文本提取器)会把化验行内原本用于对齐的多个空格全部折叠成单空格;
实测还会在每提取出的一行之后额外插入一个空行(见打包的示例 PDF
`apps/desktop/src-tauri/demo-data/corpus/*血脂*.pdf`)。

桌面端 `ReportContent.tsx` 原先靠 `splitCells()` 按"两个以上空格 / Tab"分列来判定
是否是表格行(`isDataRow` 要求 ≥3 个 cell)。单空格塌陷后每行只剩 1 个 cell,判定
失败,整张化验单退化成一行行散乱的纯文本,失去了项目/结果/单位/参考范围的对齐。
移动端 `parseLabRow` 同理依赖 `split(/\s{2,}/)`,同一个根因。

## 修复

新增按**结构**而非空白宽度切列的化验行解析器(`apps/desktop/src/labTable.ts`、
`apps/mobile/src/labTable.ts`,两端各自独立打包,无共享 TS 包,故各维护一份):

- **值(VALUE)** = 第一个独立的数字 token(如 `6.05`)
- **单位(UNIT)** = 值后第一个 token,前提是它不像参考范围的起始(比较符/数字/`-`),
  否则视为无单位,优雅降级
- **项目名(NAME)** = 值之前的所有 token
- **参考范围/提示(RANGE)** = 单位之后的所有 token(如 `< 5.20 ↑`),保留 ↑/↓/正常
  供染色

识别到连续 ≥3 行符合该结构才判定为一段化验表(容忍 pdf-extract 逐行插入的单个
空行;连续 ≥2 行空行则视为真正的段落分隔,不再当表格处理),表头行(`项目缩写
项目名称 结果 单位 参考范围 提示`)被消费掉而不是当作数据行展示。非化验文本的
通用解析路径(原有的双空格表格 / 分节 / 段落)完全不变。

- **桌面端**:渲染成真正的 `<table>`(项目 | 结果 | 单位 | 参考范围/提示 四列),
  按 ↑ 琥珀色 / ↓ 蓝色染色。
- **移动端**:沿用原有的三列对齐布局(名称 | 结果 | 单位+参考范围),同样具备结构化
  解析与表头识别,不引入新的视觉样式。

未改动分享 / 托管查看器(单独关注点,见任务要求)。

## Before / after(实测,单空格塌陷行)

```
TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑
```

- **修复前**:整行原样当作一段纯文本展示,无列对齐。
- **修复后**:解析为 `{ name: "TC 总胆固醇 Cholesterol", value: "6.05", unit: "mmol/L", range: "< 5.20 ↑", flag: "high" }`,
  桌面端渲染为表格一行(琥珀色高亮),移动端渲染为对齐的化验行。

## 验证

用 `pdf_extract` 实际提取了仓库自带的 4 份血脂/血糖示例 PDF(含题述的
"2025-05-06_检验报告_血脂血糖.pdf"),逐行 dump 出真实文本后跑通新解析器:
6 行数据(TC/TG/HDL-C/LDL-C/GLU/HbA1c)全部正确切出项目名/结果/单位/参考范围+
↑↓/正常 标记,报告页眉、患者信息、页脚"提示:"段落仍按普通段落渲染,未被
误判为表格行。

## 测试

- `apps/desktop/test/labTable.test.ts`、`apps/mobile/test/labTable.test.ts`:
  覆盖题述的 7 行血脂血糖单空格样例(TC/TG/HDL-C/GLU/HbA1c/Cr/BUN)、无单位行、
  非化验段落误判防护、表头识别与消费、以及真实 pdf-extract 逐行插空行的输出
  形态(3+ 行连续判定成功 / 2 行空行判定为段落分隔而失败)。
- 用 Node 内置 `node:test` 跑(仓库此前无 JS/TS 测试框架,`package.json` 新增
  `"test": "node --test"` 脚本)。

## Gate

- [x] `apps/desktop`: `pnpm exec tsc --noEmit`
- [x] `apps/desktop`: `pnpm run test`(9 项通过)
- [x] `apps/desktop`: `pnpm run build`
- [x] `apps/mobile`: `pnpm exec tsc --noEmit`
- [x] `apps/mobile`: `pnpm run test`(4 项通过)
- [x] `apps/mobile`: `pnpm run build`