### PR TITLE
feat(mobile): Flutter 内容感知渲染 widget(化验表格结构解析移植)

### DIFF
--- a/apps/mobile_flutter/lib/report_content.dart
+++ b/apps/mobile_flutter/lib/report_content.dart
@@ -1,0 +1,140 @@
+// 化验单结构化解析(纯 Dart,便于单测)—— 移植自桌面端
+// apps/desktop/src/labTable.ts,解决同一个根因:文本提取/OCR 会把化验行原本
+// 靠多空格对齐的列全部折叠成单空格,原本靠"两个以上空格/Tab"分列的化验行
+// 退化成一整行散文本,无法再按列切分。这里改用"结构"而非"空白宽度"来切列:
+//   值(value) = 第一个独立的数字 token(如 6.05 / 7.1 / 95)
+//   单位(unit) = 紧跟在值后面的 token,前提是它不像参考范围的起始(否则视为无单位)
+//   项目名(name) = 值之前的所有 token
+//   参考范围/提示(range) = 单位之后的所有 token(如 "< 5.20 ↑" / "3.9 - 6.1 ↑")
+// 对形如 "TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑" 的单空格行同样适用。
+
+/// 化验行的异常提示。
+enum LabFlag { high, low, normal }
+
+/// 一行化验结果:项目名 / 结果值 / 单位 / 参考范围(含提示符号)。
+class LabRow {
+  final String name;
+  final String value;
+  final String unit;
+  final String range;
+  final LabFlag? flag;
+
+  const LabRow({
+    required this.name,
+    required this.value,
+    required this.unit,
+    required this.range,
+    required this.flag,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LabRow &&
+          other.name == name &&
+          other.value == value &&
+          other.unit == unit &&
+          other.range == range &&
+          other.flag == flag);
+
+  @override
+  int get hashCode => Object.hash(name, value, unit, range, flag);
+
+  @override
+  String toString() =>
+      'LabRow(name: $name, value: $value, unit: $unit, range: $range, flag: $flag)';
+}
+
+final RegExp _numRe = RegExp(r'^-?\d+(\.\d+)?$');
+final RegExp _rangeStartRe = RegExp(r'^[<>≤≥]');
+
+LabFlag? _labFlag(String range) {
+  if (RegExp(r'↑|偏高|升高').hasMatch(range)) return LabFlag.high;
+  if (RegExp(r'↓|偏低|降低|减低').hasMatch(range)) return LabFlag.low;
+  if (range.contains('正常')) return LabFlag.normal;
+  return null;
+}
+
+/// 把一行拆成结构化的化验行;不像化验行(找不到独立数值,或数值前/后缺内容)
+/// 则返回 null。
+LabRow? parseLabRow(String line) {
+  final tokens = line.trim().split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+  if (tokens.length < 2) return null;
+
+  final valueIdx = tokens.indexWhere((t) => _numRe.hasMatch(t));
+  if (valueIdx <= 0) return null; // 值前必须有项目名;值本身不能是第一个 token
+
+  final after = tokens.sublist(valueIdx + 1);
+  if (after.isEmpty) return null; // 值后至少要有单位或参考范围,否则不像化验行
+
+  final name = tokens.sublist(0, valueIdx).join(' ');
+  final value = tokens[valueIdx];
+
+  // 判断值后第一个 token 是参考范围的开头(比较符/数字/连字符),还是单位。
+  final nextTok = after[0];
+  final looksLikeRangeStart =
+      _rangeStartRe.hasMatch(nextTok) || _numRe.hasMatch(nextTok) || nextTok == '-';
+  final unit = looksLikeRangeStart ? '' : nextTok;
+  final rangeTokens = looksLikeRangeStart ? after : after.sublist(1);
+  final range = rangeTokens.join(' ');
+
+  return LabRow(name: name, value: value, unit: unit, range: range, flag: _labFlag(range));
+}
+
+/// 化验表表头行(如"项目缩写 项目名称 结果 单位 参考范围 提示")—— 只用于识别
+/// 并消费掉表头,不做数据解析(表头本身不含数字,parseLabRow 对其恒返回 null)。
+bool isLabHeaderLine(String line) {
+  const keys = ['项目', '结果', '单位', '参考', '提示', '名称', '缩写'];
+  final hits = keys.where((k) => line.contains(k)).length;
+  return hits >= 2 && !RegExp(r'\d').hasMatch(line);
+}
+
+/// 连续 ≥3 行都能解析成化验行,才判定为化验表(避免把偶尔带数字的普通段落误判)。
+const int minLabRows = 3;
+
+/// 一段被识别出的连续化验表:解析出的行 + 下一个未消费行号(含表头在内)。
+class LabRun {
+  final List<LabRow> rows;
+
+  /// 下一个未消费的行号(含表头在内)。
+  final int next;
+
+  const LabRun({required this.rows, required this.next});
+}
+
+// 只跳过恰好一行空行(实测文本提取/OCR 会在提取出的每一"行"之间都插入一个
+// 空行——不是段落间距,是逐行现象;连续 ≥2 行空行更像是真正的段落分隔,
+// 不再当表格处理)。
+int _skipSingleBlank(List<String> lines, int k) {
+  return k < lines.length && lines[k].trim().isEmpty ? k + 1 : k;
+}
+
+/// 从 lines[i] 开始尝试识别一段连续的化验表:可选的表头行 + ≥3 行连续化验
+/// 数据行(行间允许被逐行插入的单个空行打断,见 [_skipSingleBlank])。
+/// 识别失败(不足 3 行连续化验行)返回 null,调用方应回退到通用解析。
+LabRun? tryParseLabRun(List<String> lines, int i) {
+  final trimmed = lines[i].trim();
+  final start = isLabHeaderLine(trimmed) ? _skipSingleBlank(lines, i + 1) : i;
+
+  final rows = <LabRow>[];
+  var j = start;
+  while (j < lines.length) {
+    final l = lines[j].trim();
+    final row = l.isNotEmpty ? parseLabRow(l) : null;
+    if (row == null) break;
+    rows.add(row);
+    j = _skipSingleBlank(lines, j + 1);
+  }
+
+  if (rows.length < minLabRows) return null;
+  return LabRun(rows: rows, next: j);
+}
+
+/// 便捷入口:给定一段(疑似)化验行文本,从头按结构解析出所有连续可识别的
+/// 化验行(可选前置表头,行间容忍单个空行);不足 3 行连续则视为不是化验表,
+/// 返回空列表 —— 调用方应回退到通用文本渲染。
+List<LabRow> parseLabRows(List<String> lines) {
+  if (lines.isEmpty) return const [];
+  final run = tryParseLabRun(lines, 0);
+  return run?.rows ?? const [];
+}

--- a/apps/mobile_flutter/lib/widgets/report_content.dart
+++ b/apps/mobile_flutter/lib/widgets/report_content.dart
@@ -1,0 +1,500 @@
+import 'package:flutter/material.dart';
+
+import '../report_content.dart' show LabFlag, LabRow, tryParseLabRun;
+import '../theme.dart';
+
+// 内容感知渲染(维度 B):按文档类型富渲染,移植自桌面端
+// apps/desktop/src/components/ReportContent.tsx。
+//  - 化验 → 表格(指标/结果/单位/参考范围,按 ↑/↓ 着色)
+//  - 处方 → 用药清单卡片
+//  - 病理/影像/出院/病历/手术 → 分节(【…】/结论/诊断 等标题加粗)+ 行内标签加粗
+//  - 其余/解析不到结构 → 退回干净段落 —— 永不比原文更糟(见 memory:
+//    content-aware-rendering)。
+
+/// 档案/文档详情屏复用的富文本渲染;`docType` 为空或未知类型时退回通用分块。
+class ReportContent extends StatelessWidget {
+  final String text;
+  final String? docType;
+
+  const ReportContent({super.key, required this.text, this.docType});
+
+  @override
+  Widget build(BuildContext context) {
+    if (text.trim().isEmpty) {
+      return const Text(
+        '无文本内容。',
+        style: TextStyle(color: MedMe.faint, fontSize: 13),
+      );
+    }
+
+    // 处方 → 用药清单
+    if (docType == 'prescription') {
+      final meds = _parseMeds(text);
+      if (meds != null) {
+        return _MedsView(meds: meds);
+      }
+    }
+
+    // 其余类型(化验表格 / 病理·影像·出院·病历·手术 分节+行内标签 / 通用)
+    final blocks = _parseBlocks(text);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < blocks.length; i++) ...[
+          if (i > 0) const SizedBox(height: 16),
+          _blockView(blocks[i]),
+        ],
+      ],
+    );
+  }
+}
+
+// ── 分块模型(化验表 / 通用多空格表 / 分节标题 / 段落)──
+
+sealed class _Block {}
+
+class _LabTableBlock extends _Block {
+  final List<LabRow> rows;
+  _LabTableBlock(this.rows);
+}
+
+class _TableBlock extends _Block {
+  final List<String>? header;
+  final List<List<String>> rows;
+  _TableBlock(this.header, this.rows);
+}
+
+class _SectionBlock extends _Block {
+  final String text;
+  _SectionBlock(this.text);
+}
+
+class _ParaBlock extends _Block {
+  final String text;
+  _ParaBlock(this.text);
+}
+
+Widget _blockView(_Block b) {
+  return switch (b) {
+    _LabTableBlock(:final rows) => _LabTableView(rows: rows),
+    _TableBlock(:final header, :final rows) => _GenericTableView(header: header, rows: rows),
+    _SectionBlock(:final text) => _SectionView(text: text),
+    _ParaBlock(:final text) => _ParaView(text: text),
+  };
+}
+
+final RegExp _sectionBracketRe = RegExp(r'^[【\[].+[】\]]$');
+final RegExp _shortLabelColonRe = RegExp(r'[:：]$');
+
+List<_Block> _parseBlocks(String text) {
+  final lines = text.split(RegExp(r'\r?\n'));
+  final blocks = <_Block>[];
+  var i = 0;
+  while (i < lines.length) {
+    final trimmed = lines[i].trim();
+    if (trimmed.isEmpty) {
+      i++;
+      continue;
+    }
+
+    // 化验单单空格塌陷场景:先按结构尝试识别连续的化验行(见 ../report_content.dart),
+    // 命中则优先于下面基于"多空格分列"的通用表格解析。
+    final labRun = tryParseLabRun(lines, i);
+    if (labRun != null) {
+      blocks.add(_LabTableBlock(labRun.rows));
+      i = labRun.next;
+      continue;
+    }
+
+    if (_isTableHeader(trimmed) || _isDataRow(trimmed)) {
+      final start = i;
+      final header = _isTableHeader(trimmed) ? _splitCells(trimmed) : null;
+      if (header != null) i++;
+      final rows = <List<String>>[];
+      while (i < lines.length && lines[i].trim().isNotEmpty && _isDataRow(lines[i])) {
+        rows.add(_splitCells(lines[i]));
+        i++;
+      }
+      if (rows.length >= 2) {
+        blocks.add(_TableBlock(header, rows));
+        continue;
+      }
+      i = start;
+    }
+
+    if (_sectionBracketRe.hasMatch(trimmed) ||
+        (trimmed.length <= 14 && _shortLabelColonRe.hasMatch(trimmed))) {
+      blocks.add(_SectionBlock(trimmed));
+    } else {
+      blocks.add(_ParaBlock(lines[i]));
+    }
+    i++;
+  }
+  return blocks;
+}
+
+List<String> _splitCells(String line) {
+  return line.trim().split(RegExp(r'\s{2,}|\t')).where((c) => c.isNotEmpty).toList();
+}
+
+bool _isTableHeader(String line) {
+  const keys = ['项目', '结果', '单位', '参考', '提示', '名称', '缩写'];
+  final hits = keys.where((k) => line.contains(k)).length;
+  return hits >= 2 && _splitCells(line).length >= 3;
+}
+
+bool _isDataRow(String line) {
+  return _splitCells(line).length >= 3 && RegExp(r'\d').hasMatch(line);
+}
+
+LabFlag? _rowStatus(List<String> cells) {
+  final j = cells.join(' ');
+  if (cells.contains('↑') || RegExp(r'↑|偏高|升高').hasMatch(j)) return LabFlag.high;
+  if (cells.contains('↓') || RegExp(r'↓|偏低|降低|减低').hasMatch(j)) return LabFlag.low;
+  if (j.contains('正常')) return LabFlag.normal;
+  return null;
+}
+
+Color _flagColor(LabFlag? flag) {
+  if (flag == LabFlag.high) return const Color(0xFFB45309); // amber-700
+  if (flag == LabFlag.low) return const Color(0xFF1D4ED8); // blue-700
+  return MedMe.ink;
+}
+
+// ── 段落:行内"标签:内容" → 标签加粗(主诉:/病理诊断:/诊断意见:…)──
+
+final RegExp _labelRe = RegExp(r'^([一-龥A-Za-z]{2,10})([:：])(.*)$');
+
+class _ParaView extends StatelessWidget {
+  final String text;
+  const _ParaView({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    const style = TextStyle(fontSize: 15, height: 1.6, color: MedMe.ink);
+    final t = text.trimRight();
+    final m = _labelRe.firstMatch(t);
+    if (m != null && m.group(3)!.trim().isNotEmpty) {
+      return RichText(
+        text: TextSpan(
+          style: style,
+          children: [
+            TextSpan(
+              text: '${m.group(1)}${m.group(2)}',
+              style: const TextStyle(fontWeight: FontWeight.w600, color: MedMe.ink),
+            ),
+            TextSpan(text: m.group(3)),
+          ],
+        ),
+      );
+    }
+    return Text(text, style: style);
+  }
+}
+
+class _SectionView extends StatelessWidget {
+  final String text;
+  const _SectionView({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Text(
+        text,
+        style: const TextStyle(fontWeight: FontWeight.w700, color: MedMe.ink, fontSize: 15),
+      ),
+    );
+  }
+}
+
+// ── 表格:化验表(结构化解析)与通用多空格表共用的外框/单元格样式 ──
+
+class _TableFrame extends StatelessWidget {
+  final Widget child;
+  const _TableFrame({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        decoration: BoxDecoration(border: Border.all(color: MedMe.line)),
+        child: child,
+      ),
+    );
+  }
+}
+
+TableRow _headerRow(List<String> headers) {
+  return TableRow(
+    decoration: const BoxDecoration(color: MedMe.bg),
+    children: [
+      for (final h in headers)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Text(
+            h,
+            style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: MedMe.faint),
+          ),
+        ),
+    ],
+  );
+}
+
+Widget _cell(String text, Color color, {bool mono = false}) {
+  return Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+    child: Text(
+      text,
+      style: TextStyle(fontSize: 13, color: color, fontFamily: mono ? 'monospace' : null),
+    ),
+  );
+}
+
+BoxDecoration? _zebra(int index) =>
+    index.isOdd ? const BoxDecoration(color: Color(0x0A64748B)) : null;
+
+class _LabTableView extends StatelessWidget {
+  final List<LabRow> rows;
+  const _LabTableView({required this.rows});
+
+  static const _headers = ['项目', '结果', '单位', '参考范围/提示'];
+
+  @override
+  Widget build(BuildContext context) {
+    return _TableFrame(
+      child: Table(
+        columnWidths: const {
+          0: FlexColumnWidth(2.2),
+          1: FlexColumnWidth(1),
+          2: FlexColumnWidth(1),
+          3: FlexColumnWidth(1.6),
+        },
+        defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+        children: [
+          _headerRow(_headers),
+          for (var i = 0; i < rows.length; i++) _dataRow(i, rows[i]),
+        ],
+      ),
+    );
+  }
+
+  TableRow _dataRow(int index, LabRow r) {
+    final color = _flagColor(r.flag);
+    return TableRow(
+      decoration: _zebra(index),
+      children: [
+        _cell(r.name, color),
+        _cell(r.value, color, mono: true),
+        _cell(r.unit, color, mono: true),
+        _cell(r.range, color, mono: true),
+      ],
+    );
+  }
+}
+
+class _GenericTableView extends StatelessWidget {
+  final List<String>? header;
+  final List<List<String>> rows;
+  const _GenericTableView({required this.header, required this.rows});
+
+  @override
+  Widget build(BuildContext context) {
+    final cols = [header?.length ?? 0, for (final r in rows) r.length].reduce(
+      (a, b) => a > b ? a : b,
+    );
+
+    return _TableFrame(
+      child: Table(
+        defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+        children: [
+          if (header != null)
+            _headerRow([for (var c = 0; c < cols; c++) c < header!.length ? header![c] : '']),
+          for (var i = 0; i < rows.length; i++) _dataRow(i, rows[i], cols),
+        ],
+      ),
+    );
+  }
+
+  TableRow _dataRow(int index, List<String> r, int cols) {
+    final color = _flagColor(_rowStatus(r));
+    return TableRow(
+      decoration: _zebra(index),
+      children: [
+        for (var c = 0; c < cols; c++) _cell(c < r.length ? r[c] : '', color, mono: true),
+      ],
+    );
+  }
+}
+
+// ── 处方:用药清单(移植自桌面端 ReportContent.tsx 的 parseMeds)──
+
+class _Med {
+  final String name;
+  final List<String> usage;
+  const _Med({required this.name, required this.usage});
+}
+
+class _MedsResult {
+  final List<String> intro;
+  final List<_Med> meds;
+  final List<String> footer;
+  const _MedsResult({required this.intro, required this.meds, required this.footer});
+}
+
+final RegExp _numberedRe = RegExp(r'^(\d+)\s*[.、)]\s*(.+)');
+final RegExp _footerKeywordRe = RegExp(r'^(医师|药师|审核|备注|Rp\.?|处方)');
+final RegExp _rpOnlyRe = RegExp(r'^Rp\.?$');
+
+_MedsResult? _parseMeds(String text) {
+  final lines = text.split(RegExp(r'\r?\n'));
+  final meds = <_Med>[];
+  final intro = <String>[];
+  final footer = <String>[];
+  String? curName;
+  var usage = <String>[];
+  var started = false;
+  var ended = false;
+
+  void pushCur() {
+    if (curName != null) {
+      meds.add(_Med(name: curName!, usage: usage));
+      curName = null;
+      usage = <String>[];
+    }
+  }
+
+  for (final raw in lines) {
+    final line = raw.trim();
+    final numbered = _numberedRe.firstMatch(line);
+    if (numbered != null) {
+      started = true;
+      ended = false;
+      pushCur();
+      curName = numbered.group(2)!.trim();
+      continue;
+    }
+    if (_footerKeywordRe.hasMatch(line)) {
+      pushCur();
+      if (started) ended = true;
+      if (line.isNotEmpty && !_rpOnlyRe.hasMatch(line)) {
+        if (started) {
+          footer.add(line);
+        } else {
+          intro.add(line);
+        }
+      }
+      continue;
+    }
+    if (curName != null && line.isNotEmpty) {
+      usage.add(line);
+      continue;
+    }
+    if (line.isNotEmpty) {
+      if (!started) {
+        intro.add(line);
+      } else if (ended) {
+        footer.add(line);
+      }
+    }
+  }
+  pushCur();
+  return meds.isNotEmpty ? _MedsResult(intro: intro, meds: meds, footer: footer) : null;
+}
+
+class _MedsView extends StatelessWidget {
+  final _MedsResult meds;
+  const _MedsView({required this.meds});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (meds.intro.isNotEmpty) ...[
+          for (final t in meds.intro) _ParaView(text: t),
+          const SizedBox(height: 16),
+        ],
+        const Text(
+          '用药',
+          style: TextStyle(
+            fontSize: 11,
+            letterSpacing: 1.2,
+            color: MedMe.faint,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (var i = 0; i < meds.meds.length; i++) ...[
+          if (i > 0) const SizedBox(height: 8),
+          _MedCard(index: i, med: meds.meds[i]),
+        ],
+        if (meds.footer.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          for (final t in meds.footer) _ParaView(text: t),
+        ],
+      ],
+    );
+  }
+}
+
+class _MedCard extends StatelessWidget {
+  final int index;
+  final _Med med;
+  const _MedCard({required this.index, required this.med});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFECFDF5), // emerald-50/40 近似
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFD1FAE5)), // emerald-100 近似
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 28,
+            height: 28,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: const Color(0xFFD1FAE5),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              '${index + 1}',
+              style: const TextStyle(
+                color: Color(0xFF047857),
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  med.name,
+                  style: const TextStyle(fontWeight: FontWeight.w500, color: MedMe.ink, fontSize: 15),
+                ),
+                for (final u in med.usage)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      u,
+                      style: const TextStyle(fontSize: 13, color: MedMe.faint, height: 1.5),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile_flutter/test/report_content_test.dart
+++ b/apps/mobile_flutter/test/report_content_test.dart
@@ -1,0 +1,189 @@
+// 化验行结构化解析的单测。喂入文本提取/OCR 把所有空白折叠成单空格后的真实行
+// (原始报告里各列靠多空格对齐,提取后退化成单空格分隔的散文本),验证仍能按
+// 结构切出 项目名/结果/单位/参考范围+提示。镜像
+// apps/desktop/test/labTable.test.ts 的断言。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_flutter/report_content.dart';
+
+// 血脂血糖化验单示例(单空格,来自文本提取的真实输出形态)。
+const header = '项目缩写 项目名称 结果 单位 参考范围 提示';
+const rows = [
+  'TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑',
+  'TG 甘油三酯 Triglyceride 2.35 mmol/L < 1.70 ↑',
+  'HDL-C 高密度脂蛋白胆固醇 0.98 mmol/L > 1.04 ↓',
+  'GLU 空腹血糖 Glucose 7.1 mmol/L 3.9 - 6.1 ↑',
+  'HbA1c 糖化血红蛋白 6.9 % 4.0 - 6.0 ↑',
+  'Cr 肌酐 Creatinine 95 umol/L 57 - 97 正常',
+  'BUN 尿素氮 6.1 mmol/L 3.1 - 8.0 正常',
+];
+
+void main() {
+  test('isLabHeaderLine 识别化验表表头,且表头本身不是数据行', () {
+    expect(isLabHeaderLine(header), isTrue);
+    expect(parseLabRow(header), isNull);
+  });
+
+  test('parseLabRow 把单空格行按结构切成 名称/值/单位/范围+提示', () {
+    expect(
+      parseLabRow(rows[0]),
+      const LabRow(
+        name: 'TC 总胆固醇 Cholesterol',
+        value: '6.05',
+        unit: 'mmol/L',
+        range: '< 5.20 ↑',
+        flag: LabFlag.high,
+      ),
+    );
+    expect(
+      parseLabRow(rows[1]),
+      const LabRow(
+        name: 'TG 甘油三酯 Triglyceride',
+        value: '2.35',
+        unit: 'mmol/L',
+        range: '< 1.70 ↑',
+        flag: LabFlag.high,
+      ),
+    );
+    expect(
+      parseLabRow(rows[2]),
+      const LabRow(
+        name: 'HDL-C 高密度脂蛋白胆固醇',
+        value: '0.98',
+        unit: 'mmol/L',
+        range: '> 1.04 ↓',
+        flag: LabFlag.low,
+      ),
+    );
+    expect(
+      parseLabRow(rows[3]),
+      const LabRow(
+        name: 'GLU 空腹血糖 Glucose',
+        value: '7.1',
+        unit: 'mmol/L',
+        range: '3.9 - 6.1 ↑',
+        flag: LabFlag.high,
+      ),
+    );
+    expect(
+      parseLabRow(rows[4]),
+      const LabRow(
+        name: 'HbA1c 糖化血红蛋白',
+        value: '6.9',
+        unit: '%',
+        range: '4.0 - 6.0 ↑',
+        flag: LabFlag.high,
+      ),
+    );
+    expect(
+      parseLabRow(rows[5]),
+      const LabRow(
+        name: 'Cr 肌酐 Creatinine',
+        value: '95',
+        unit: 'umol/L',
+        range: '57 - 97 正常',
+        flag: LabFlag.normal,
+      ),
+    );
+    expect(
+      parseLabRow(rows[6]),
+      const LabRow(
+        name: 'BUN 尿素氮',
+        value: '6.1',
+        unit: 'mmol/L',
+        range: '3.1 - 8.0 正常',
+        flag: LabFlag.normal,
+      ),
+    );
+  });
+
+  test('parseLabRow 对没有单位的行也能优雅处理(值后直接是参考范围)', () {
+    final row = parseLabRow('WBC 白细胞计数 5.2 3.5 - 9.5 正常');
+    expect(
+      row,
+      const LabRow(
+        name: 'WBC 白细胞计数',
+        value: '5.2',
+        unit: '',
+        range: '3.5 - 9.5 正常',
+        flag: LabFlag.normal,
+      ),
+    );
+  });
+
+  test('parseLabRow 对普通段落(无独立数值,或数值打头)返回 null', () {
+    expect(parseLabRow('患者近期体检未见明显异常。'), isNull);
+    expect(parseLabRow('6.05 单独一个数字打头,前面没有项目名'), isNull);
+    expect(parseLabRow('孤零零一个数字 6.05'), isNull); // 值后没有任何内容
+  });
+
+  test('parseLabRow 对患者信息行(数字打头/末尾无内容)不误判为化验行', () {
+    // "45" 是末尾数字 token,值后没有单位/参考范围 —— 不像化验行。
+    expect(parseLabRow('姓名 张三 性别 男 年龄 45'), isNull);
+  });
+
+  test('parseLabRow 对「提示:」类脚注(无独立数值)不误判为化验行', () {
+    expect(parseLabRow('提示:血脂四项异常,建议内分泌科随诊。'), isNull);
+  });
+
+  test('tryParseLabRun 消费表头 + 连续 ≥3 行化验数据,整段判定为化验表', () {
+    final lines = [header, ...rows, '', '备注:空腹采血。'];
+    final run = tryParseLabRun(lines, 0);
+    expect(run, isNotNull);
+    expect(run!.rows.length, rows.length);
+    expect(run.rows[0].name, 'TC 总胆固醇 Cholesterol');
+    expect(lines[run.next].trim(), '备注:空腹采血。'); // 停在化验表之后的下一段落
+  });
+
+  test('tryParseLabRun 容忍化验行之间夹杂的单个空行(真实文本提取输出形态)', () {
+    final lines = [
+      header,
+      '',
+      rows[0],
+      '',
+      rows[1],
+      '',
+      rows[2],
+      '',
+      rows[3],
+      '',
+      '提示:血脂四项异常,建议内分泌科随诊。',
+      '',
+    ];
+    final run = tryParseLabRun(lines, 0);
+    expect(run, isNotNull);
+    expect(run!.rows.length, 4);
+    expect(run.rows[0].name, 'TC 总胆固醇 Cholesterol');
+    expect(run.rows[3].name, 'GLU 空腹血糖 Glucose');
+    expect(lines[run.next].trim(), '提示:血脂四项异常,建议内分泌科随诊。');
+  });
+
+  test('tryParseLabRun 连续 ≥2 行空行判定为真正的段落分隔,不再当作化验行间隔', () {
+    final lines = [header, '', rows[0], '', '', rows[1], rows[2]];
+    // TC 后面是两个空行 → 表格在此截断,只拿到 1 行,不足 3 行 → 判定失败
+    expect(tryParseLabRun(lines, 0), isNull);
+  });
+
+  test('tryParseLabRun 不足 3 行连续化验行时判定失败,交回通用解析', () {
+    final lines = [header, rows[0], rows[1], '以下省略,仅两行数据。'];
+    expect(tryParseLabRun(lines, 0), isNull);
+  });
+
+  test('tryParseLabRun 没有表头也能从数据行直接起判', () {
+    final run = tryParseLabRun(rows, 0);
+    expect(run, isNotNull);
+    expect(run!.rows.length, rows.length);
+    expect(run.next, rows.length);
+  });
+
+  test('parseLabRows 从 表头+连续行 中解析出全部化验行', () {
+    final result = parseLabRows([header, ...rows]);
+    expect(result.length, rows.length);
+    expect(result.first.name, 'TC 总胆固醇 Cholesterol');
+    expect(result.last.name, 'BUN 尿素氮');
+  });
+
+  test('parseLabRows 对不足 3 行连续化验行的输入返回空列表(交回通用解析)', () {
+    final result = parseLabRows([header, rows[0], rows[1], '以下省略,仅两行数据。']);
+    expect(result, isEmpty);
+  });
+}


### PR DESCRIPTION
## 做了什么

把桌面端刚做好的「内容感知渲染」(`apps/desktop/src/labTable.ts` + `apps/desktop/src/components/ReportContent.tsx`,commit b9cf908)移植成纯 Flutter widget,供 Flutter 移动端(`apps/mobile_flutter/`)档案/文档详情屏复用。**纯 UI(文本 → widget),不碰 `rust/`、FFI、`lib/main.dart`、`lib/screens/`、`lib/src/rust/`**,与并行的 P2 (FFI API) 互不干扰。

新增文件:
- `apps/mobile_flutter/lib/report_content.dart` —— 化验行结构化解析的纯 Dart 移植:`LabRow`、`parseLabRow`、`isLabHeaderLine`、`tryParseLabRun`、`parseLabRows`。按“结构”而非“空白宽度”切列(值 = 第一个独立数字 token,单位 = 值后第一个非范围起始 token,项目名 = 值之前的 token,参考范围+提示 = 单位之后的 token),兼容文本提取/OCR 把多空格折叠成单空格、且逐行插入空行的真实输出形态;连续 ≥3 行才判定为化验表。
- `apps/mobile_flutter/lib/widgets/report_content.dart` —— `ReportContent(text, docType)` `StatelessWidget`:
  - 化验 → 真正的 `Table`,列 = 项目/结果/单位/参考范围+提示,按 ↑(高,琥珀)/↓(低,蓝)着色;表头行被消费,不当数据行渲染。
  - 处方 → 用药卡片(移植桌面 `parseMeds` 思路:编号行起始一个药品,后续缩进行为用法,`医师/药师/审核/备注/Rp./处方` 起始的行归入前言或脚注)。
  - 其余(病理/影像/出院/病历/手术) → `【…】`/短标签冒号结尾的分节标题加粗 + 普通段落(行内“标签:内容”中的标签加粗)。
  - 兜底:识别不到结构就退回段落文本 —— 永不比原文更糟。
  - 样式全部取自 `lib/theme.dart` 的 `MedMe` 设计令牌(teal/ink/faint/line/bg)。
- `apps/mobile_flutter/test/report_content_test.dart` —— 镜像 `apps/desktop/test/labTable.test.ts` 的断言,13 个用例。

## Before / After 示例(单空格化验行)

输入(文本提取器把多空格列对齐折叠成单空格后的真实形态):
```
TC 总胆固醇 Cholesterol 6.05 mmol/L < 5.20 ↑
```

**Before**(旧 Flutter 端无此解析器,或按“两个以上空格分列”的通用规则):整行只有 1 个空格分隔出的“列”,无法切出项目/结果/单位/参考范围,只能退化成一整行纯文本段落展示。

**After**(`parseLabRow` 解析结果):
```dart
LabRow(
  name: 'TC 总胆固醇 Cholesterol',
  value: '6.05',
  unit: 'mmol/L',
  range: '< 5.20 ↑',
  flag: LabFlag.high,
)
```
渲染为表格一行:项目=`TC 总胆固醇 Cholesterol`,结果=`6.05`,单位=`mmol/L`,参考范围/提示=`< 5.20 ↑`(琥珀色,因 flag=high)。

## 测试结果

```
$ cd apps/mobile_flutter && flutter analyze lib test
Analyzing 2 items...
No issues found! (ran in 3.6s)

$ flutter test
00:00 +13: All tests passed!
```

注:仓库根目录直接 `flutter analyze`(不限定 `lib test`)会额外报出 66 个既有问题,全部来自 `rust_builder/cargokit/build_tool`(flutter_rust_bridge vendored 的构建工具子包,有独立 `pubspec.yaml` 但从未 `dart pub get` 过,依赖包缺失导致解析失败)。这是本仓库既有状态,与本次改动无关,本 PR 未触碰 `pubspec`/依赖/rust 相关任何文件。

## 测试清单

- [x] `flutter analyze lib test` 无问题
- [x] `flutter test` 全部通过(13/13,覆盖 TC/TG/HDL-C/GLU/HbA1c/Cr/BUN 单空格化验行解析、无单位行、表头识别、单/双空行容忍、患者信息行与「提示:」脚注不被误判为数据行、连续 ≥3 行阈值)
- [ ] 在真机/模拟器里挂到档案详情屏验证视觉效果(留给档案详情屏 P2/P3 集成时一起过一遍)