### PR TITLE
feat(mobile): 启动打开保险箱(open_vault 引导)

### DIFF
--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:mobile_flutter/src/rust/frb_generated.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/screens/import_export_screen.dart';
 import 'package:mobile_flutter/screens/archive_screen.dart';
@@ -8,8 +10,6 @@ import 'package:mobile_flutter/screens/settings_screen.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
-  // 保险箱在 P2 的 open_vault 落地后于此初始化(在真实沙盒/iCloud 目录打开);
-  // 骨架阶段先不调,避免依赖尚未合并的 FFI。
   runApp(const MedMeApp());
 }
 
@@ -21,7 +21,68 @@ class MedMeApp extends StatelessWidget {
       title: 'MedMe 医我',
       theme: MedMe.theme(),
       debugShowCheckedModeBanner: false,
-      home: const HomeShell(),
+      home: const VaultBootstrap(),
+    );
+  }
+}
+
+/// 启动引导:先在真实沙盒目录打开保险箱(FFI `open_vault`),再进主界面。
+/// 打开是可韧性的(损坏的派生 db 会从 log 重建);目录取自 path_provider。
+/// iCloud 暂关(P5 接);打开失败给人性化提示而非白屏。
+class VaultBootstrap extends StatefulWidget {
+  const VaultBootstrap({super.key});
+  @override
+  State<VaultBootstrap> createState() => _VaultBootstrapState();
+}
+
+class _VaultBootstrapState extends State<VaultBootstrap> {
+  late final Future<void> _open = _openVault();
+
+  Future<void> _openVault() async {
+    final docs = await getApplicationDocumentsDirectory();
+    final support = await getApplicationSupportDirectory();
+    await openVault(
+      docsDir: docs.path,
+      dataDir: support.path,
+      icloudEnabled: false, // P5 接 iCloud
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _open,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.health_and_safety, size: 56, color: MedMe.teal),
+                  SizedBox(height: 16),
+                  CircularProgressIndicator(color: MedMe.teal),
+                ],
+              ),
+            ),
+          );
+        }
+        if (snap.hasError) {
+          return Scaffold(
+            body: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  '无法打开你的健康档案:\n${snap.error}\n\n请重启 App 再试。',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 15),
+                ),
+              ),
+            ),
+          );
+        }
+        return const HomeShell();
+      },
     );
   }
 }


### PR DESCRIPTION
main.dart 启动时 open_vault(沙盒目录),加载/错误态。屏幕 fan-out 前置。