### PR TITLE
feat(mobile): Flutter 健康档案时间线 + 文档详情屏

### DIFF
--- a/apps/mobile_flutter/integration_test/archive_test.dart
+++ b/apps/mobile_flutter/integration_test/archive_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:mobile_flutter/main.dart' as app;
+import 'package:mobile_flutter/src/rust/frb_generated.dart';
+
+// MedMe Flutter 集成测试(Patrol)——健康档案 tab。
+//   patrol test -t integration_test/archive_test.dart
+//
+// 测试环境是刚打开的空保险箱(没有导入过数据),所以这里验证的是空态引导:
+// 切到「健康档案」tab 后能正常加载(不崩溃/不卡在转圈),患者头卡兜底文案
+// 「我的健康档案」和空态引导文案「还没有病历」都可见。
+
+void main() {
+  patrolTest('健康档案 tab:切换后能加载,空库显示空态引导', ($) async {
+    await RustLib.init();
+    await $.pumpWidgetAndSettle(const app.MedMeApp());
+
+    // 切到「健康档案」tab。
+    await $('健康档案').tap();
+    await $.pumpAndSettle();
+
+    // 患者头卡:空库无姓名时兜底显示「我的健康档案」。
+    expect($('我的健康档案'), findsOneWidget);
+
+    // 空态引导可见,而不是白屏/一直转圈。
+    expect($('还没有病历'), findsOneWidget);
+  });
+}

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -1,15 +1,491 @@
 import 'package:flutter/material.dart';
 
-/// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,点开详情。
-/// P3 填充(调 FFI load_archive / get_document + 内容感知渲染);此处占位。
-class ArchiveScreen extends StatelessWidget {
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/screens/document_detail.dart';
+
+/// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,按日期倒序,
+/// 点开看详情。与旧 Tauri 移动端 App.tsx 的 archive tab(phead + tl)同一观感,
+/// 数据来自 FFI `loadArchive` / `patientProfile`(见 lib/src/rust/api/vault.dart)。
+
+// doc_type / encounter kind → 中文标签(与 core-model types.rs、旧 App.tsx 一致)。
+const Map<String, String> _docLabel = {
+  'lab_report': '化验',
+  'imaging_report': '影像',
+  'discharge_summary': '出院小结',
+  'prescription': '处方',
+  'clinical_note': '病历',
+  'pathology': '病理',
+  'surgery': '手术',
+  'other': '其他',
+  'unknown': '待归类',
+};
+const Map<String, String> _kindLabel = {
+  'inpatient': '住院',
+  'outpatient': '门诊',
+  'emergency': '急诊',
+  'exam': '检查',
+};
+
+// 文档类型/就诊类型 → 图标 + 配色(与旧 App.css 的 t-* 徽标一致,只是用 Material
+// 图标替代内联 SVG)。
+const Map<String, IconData> _docIcon = {
+  'lab_report': Icons.science_outlined,
+  'imaging_report': Icons.document_scanner_outlined,
+  'prescription': Icons.medication_outlined,
+  'discharge_summary': Icons.bed_outlined,
+  'clinical_note': Icons.medical_services_outlined,
+  'pathology': Icons.biotech_outlined,
+  'surgery': Icons.content_cut,
+  'other': Icons.description_outlined,
+  'unknown': Icons.help_outline,
+};
+const Map<String, IconData> _kindIcon = {
+  'outpatient': Icons.medical_services_outlined,
+  'inpatient': Icons.bed_outlined,
+};
+const Map<String, Color> _typeColor = {
+  'lab_report': Color(0xFF1D4ED8),
+  'imaging_report': Color(0xFFB45309),
+  'prescription': Color(0xFF047857),
+  'discharge_summary': Color(0xFF4338CA),
+  'clinical_note': Color(0xFF0369A1),
+  'pathology': Color(0xFFBE123C),
+  'surgery': Color(0xFF7E22CE),
+  'other': Color(0xFF475569),
+  'unknown': Color(0xFF475569),
+  'enc': Color(0xFF1D4ED8), // 就诊组统一用蓝(旧 App.css .t-enc)
+};
+
+Color _colorFor(String key) => _typeColor[key] ?? _typeColor['other']!;
+
+IconData _iconForDoc(String docType) =>
+    _docIcon[docType] ?? Icons.description_outlined;
+
+IconData _iconForKind(String kind) =>
+    _kindIcon[kind] ?? Icons.local_hospital_outlined;
+
+String _fmtDate(String? iso) {
+  if (iso == null || iso.isEmpty) return '';
+  final d = DateTime.tryParse(iso);
+  if (d == null) return '';
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+String _groupTitle(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter) =>
+      encounter.provider != null
+          ? '${_kindLabel[encounter.kind] ?? encounter.kind} · ${encounter.provider}'
+          : (_kindLabel[encounter.kind] ?? encounter.kind),
+    TimelineGroupDto_Document(:final doc) =>
+      doc.title ?? _docLabel[doc.docType] ?? '记录',
+  };
+}
+
+String _groupDate(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter) => _fmtDate(
+      encounter.startDate,
+    ),
+    TimelineGroupDto_Document(:final doc) => _fmtDate(doc.docDate),
+  };
+}
+
+String _groupDesc(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter, :final docs) => () {
+      final kinds = <String>{};
+      for (final d in docs) {
+        kinds.add(_docLabel[d.docType] ?? d.docType);
+      }
+      final parts = ['${encounter.docCount} 份记录', ...kinds.take(3)];
+      if (encounter.transferred) parts.add('转院');
+      return parts.join(' · ');
+    }(),
+    TimelineGroupDto_Document(:final doc) => [
+      _docLabel[doc.docType] ?? doc.docType,
+      if (doc.sliceCount != null) '影像 ${doc.sliceCount} 张',
+    ].join(' · '),
+  };
+}
+
+class ArchiveScreen extends StatefulWidget {
   const ArchiveScreen({super.key});
+
+  @override
+  State<ArchiveScreen> createState() => _ArchiveScreenState();
+}
+
+class _ArchiveScreenState extends State<ArchiveScreen> {
+  late Future<(PatientProfileDto, List<TimelineGroupDto>)> _future = _load();
+  // 就诊组在时间线里点开时展开其子文档(可再点开各自详情)。
+  final Set<int> _expanded = {};
+
+  Future<(PatientProfileDto, List<TimelineGroupDto>)> _load() async {
+    final results = await Future.wait([patientProfile(), loadArchive()]);
+    return (
+      results[0] as PatientProfileDto,
+      results[1] as List<TimelineGroupDto>,
+    );
+  }
+
+  Future<void> _refresh() async {
+    final next = _load();
+    setState(() => _future = next);
+    await next;
+  }
+
+  void _openDoc(int id) {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => DocumentDetailScreen(docId: id)));
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('健康档案')),
-      body: const Center(child: Text('时间线(P3 实现)')),
+      body: FutureBuilder<(PatientProfileDto, List<TimelineGroupDto>)>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError) {
+            return RefreshIndicator(
+              onRefresh: _refresh,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Text(
+                      '加载健康档案失败:\n${snap.error}\n\n下拉可重试。',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: MedMe.faint),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final (profile, groups) = snap.data!;
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            color: MedMe.teal,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+              children: [
+                _PatientHeader(profile: profile),
+                const SizedBox(height: 20),
+                if (groups.isEmpty)
+                  const _EmptyState()
+                else
+                  for (var i = 0; i < groups.length; i++) ...[
+                    if (i > 0) const SizedBox(height: 10),
+                    _TimelineItem(
+                      group: groups[i],
+                      expanded: _expanded.contains(i),
+                      onTap: () {
+                        final g = groups[i];
+                        if (g is TimelineGroupDto_Document) {
+                          _openDoc(g.doc.id);
+                        } else {
+                          setState(() {
+                            if (!_expanded.add(i)) _expanded.remove(i);
+                          });
+                        }
+                      },
+                      onOpenSubDoc: _openDoc,
+                    ),
+                  ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 患者头卡:姓名 / 性别·年龄 / 记录数,字段可空一律优雅缺省。
+class _PatientHeader extends StatelessWidget {
+  final PatientProfileDto profile;
+  const _PatientHeader({required this.profile});
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = (profile.name?.isNotEmpty ?? false)
+        ? profile.name![0]
+        : '我';
+    final subParts = [
+      profile.gender,
+      profile.age,
+    ].whereType<String>().where((s) => s.isNotEmpty).toList();
+    subParts.add('${profile.recordCount} 份记录');
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: MedMe.panel,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: MedMe.line),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 26,
+            backgroundColor: MedMe.tealSoft,
+            child: Text(
+              initial,
+              style: const TextStyle(
+                color: MedMe.teal,
+                fontWeight: FontWeight.w700,
+                fontSize: 18,
+              ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  profile.name ?? '我的健康档案',
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MedMe.ink,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subParts.join(' · '),
+                  style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 空态引导:没有记录时提示去「导入导出」或「设置」载入示例数据。
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 56),
+      child: Column(
+        children: [
+          const Icon(Icons.folder_outlined, size: 48, color: MedMe.faint),
+          const SizedBox(height: 14),
+          const Text(
+            '还没有病历',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: MedMe.ink,
+            ),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '去「导入导出」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 13, color: MedMe.faint, height: 1.6),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 时间线一项:就诊组(可展开子文档)或独立文档。
+class _TimelineItem extends StatelessWidget {
+  final TimelineGroupDto group;
+  final bool expanded;
+  final VoidCallback onTap;
+  final void Function(int docId) onOpenSubDoc;
+
+  const _TimelineItem({
+    required this.group,
+    required this.expanded,
+    required this.onTap,
+    required this.onOpenSubDoc,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isEncounter = group is TimelineGroupDto_Encounter;
+    final colorKey = switch (group) {
+      TimelineGroupDto_Encounter() => 'enc',
+      TimelineGroupDto_Document(:final doc) => doc.docType,
+    };
+    final color = _colorFor(colorKey);
+    final icon = switch (group) {
+      TimelineGroupDto_Encounter(:final encounter) => _iconForKind(
+        encounter.kind,
+      ),
+      TimelineGroupDto_Document(:final doc) => _iconForDoc(doc.docType),
+    };
+
+    return Container(
+      decoration: BoxDecoration(
+        color: MedMe.panel,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: MedMe.line),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          InkWell(
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 36,
+                    height: 36,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Icon(icon, size: 19, color: color),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _groupTitle(group),
+                                style: const TextStyle(
+                                  fontSize: 14.5,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              _groupDate(group),
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: MedMe.faint,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          _groupDesc(group),
+                          style: const TextStyle(
+                            fontSize: 12.5,
+                            color: MedMe.faint,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (isEncounter)
+                    Icon(
+                      expanded ? Icons.expand_less : Icons.expand_more,
+                      size: 20,
+                      color: MedMe.faint,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          if (expanded)
+            switch (group) {
+              TimelineGroupDto_Encounter(:final docs) => _SubDocList(
+                docs: docs,
+                onOpenSubDoc: onOpenSubDoc,
+              ),
+              TimelineGroupDto_Document() => const SizedBox.shrink(),
+            },
+        ],
+      ),
+    );
+  }
+}
+
+class _SubDocList extends StatelessWidget {
+  final List<DocumentSummaryDto> docs;
+  final void Function(int docId) onOpenSubDoc;
+
+  const _SubDocList({required this.docs, required this.onOpenSubDoc});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final d in docs)
+          Container(
+            decoration: const BoxDecoration(
+              border: Border(top: BorderSide(color: MedMe.line)),
+            ),
+            child: InkWell(
+              onTap: () => onOpenSubDoc(d.id),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 26,
+                      height: 26,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: _colorFor(d.docType).withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(
+                        _iconForDoc(d.docType),
+                        size: 14,
+                        color: _colorFor(d.docType),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        d.title ?? _docLabel[d.docType] ?? '记录',
+                        style: const TextStyle(fontSize: 13),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      _fmtDate(d.docDate),
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        color: MedMe.faint,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/apps/mobile_flutter/lib/screens/document_detail.dart
+++ b/apps/mobile_flutter/lib/screens/document_detail.dart
@@ -1,0 +1,424 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/widgets/report_content.dart';
+
+// doc_type → 中文标签,与 archive_screen.dart 保持同一份映射(桌面/旧移动端
+// 同构,来自 core-model types.rs)。
+const Map<String, String> _docLabel = {
+  'lab_report': '化验',
+  'imaging_report': '影像',
+  'discharge_summary': '出院小结',
+  'prescription': '处方',
+  'clinical_note': '病历',
+  'pathology': '病理',
+  'surgery': '手术',
+  'other': '其他',
+  'unknown': '待归类',
+};
+
+String _fmtDate(String? iso) {
+  if (iso == null || iso.isEmpty) return '';
+  final d = DateTime.tryParse(iso);
+  if (d == null) return '';
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+/// 文档详情屏:类型/日期/来源 + 识别文本(复用 ReportContent 内容感知渲染)+
+/// 查看原件(图片/PDF/DICOM 各自渲染,其余格式优雅降级不崩)。
+class DocumentDetailScreen extends StatefulWidget {
+  final int docId;
+  const DocumentDetailScreen({super.key, required this.docId});
+
+  @override
+  State<DocumentDetailScreen> createState() => _DocumentDetailScreenState();
+}
+
+class _DocumentDetailScreenState extends State<DocumentDetailScreen> {
+  late final Future<DocumentDetailDto> _future = getDocument(id: widget.docId);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('文档详情')),
+      body: FutureBuilder<DocumentDetailDto>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  '打开失败:\n${snap.error}',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: MedMe.faint),
+                ),
+              ),
+            );
+          }
+          return _DetailBody(detail: snap.data!);
+        },
+      ),
+    );
+  }
+}
+
+class _DetailBody extends StatelessWidget {
+  final DocumentDetailDto detail;
+  const _DetailBody({required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final doc = detail.document;
+    final sf = detail.sourceFile;
+    final typeLabel = _docLabel[doc.docType] ?? doc.docType;
+
+    // OCR 置信度:换算成患者能看懂的三档,而非裸百分比(与旧 App.tsx 一致)。
+    final conf = detail.ocrConfidence;
+    final confTier = conf == null
+        ? null
+        : conf >= 0.9
+        ? _ConfTier.high
+        : conf >= 0.75
+        ? _ConfTier.mid
+        : _ConfTier.low;
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: MedMe.tealSoft,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(Icons.description_outlined, color: MedMe.teal),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    doc.title ?? typeLabel,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    [
+                      typeLabel,
+                      if (doc.docDate != null) _fmtDate(doc.docDate),
+                    ].join(' · '),
+                    style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+                  ),
+                  Text(
+                    '来源:${sf.originalName}',
+                    style: const TextStyle(fontSize: 12, color: MedMe.faint),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+
+        if (confTier != null) ...[
+          const SizedBox(height: 14),
+          _ConfBadge(tier: confTier),
+        ],
+
+        const SizedBox(height: 14),
+        OutlinedButton.icon(
+          onPressed: () => _openOriginal(context, sf),
+          icon: const Icon(Icons.visibility_outlined, size: 18),
+          label: const Text('查看原件'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: MedMe.teal,
+            side: const BorderSide(color: MedMe.teal),
+            minimumSize: const Size.fromHeight(44),
+          ),
+        ),
+
+        const SizedBox(height: 20),
+        Row(
+          children: [
+            const Icon(Icons.article_outlined, size: 15, color: MedMe.faint),
+            const SizedBox(width: 6),
+            Text(
+              sf.mimeType.startsWith('image/') ? '识别文本' : '文档内容',
+              style: const TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w700,
+                color: MedMe.faint,
+                letterSpacing: 0.4,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        ReportContent(text: detail.ocrText, docType: doc.docType),
+      ],
+    );
+  }
+
+  Future<void> _openOriginal(BuildContext context, SourceFileMetaDto sf) async {
+    final mime = sf.mimeType;
+    if (mime.startsWith('image/')) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _ImageViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    if (mime == 'application/pdf') {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _PdfViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    if (mime == 'application/dicom') {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _DicomViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    // 其余格式手机端无法内联预览——如实告知,原件仍安全保存,不静默空白。
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('暂不能预览'),
+        content: Text('此格式($mime)暂不能在手机上预览,原件已安全保存在健康档案里。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('知道了'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+enum _ConfTier { high, mid, low }
+
+/// 识别质量徽标:高/中/低三档,比裸百分比更易懂(与旧 App.tsx .conf 一致)。
+class _ConfBadge extends StatelessWidget {
+  final _ConfTier tier;
+  const _ConfBadge({required this.tier});
+
+  @override
+  Widget build(BuildContext context) {
+    final (bg, fg, icon, text) = switch (tier) {
+      _ConfTier.high => (
+        const Color(0xFFECFDF5),
+        const Color(0xFF047857),
+        Icons.check_circle_outline,
+        '识别质量:高',
+      ),
+      _ConfTier.mid => (
+        const Color(0xFFFFFBEB),
+        const Color(0xFFB45309),
+        Icons.error_outline,
+        '识别质量:中 · 个别字可能有误,可核对原件',
+      ),
+      _ConfTier.low => (
+        const Color(0xFFFDEAEA),
+        const Color(0xFFB42318),
+        Icons.error_outline,
+        '识别质量:低 · 建议重新拍摄',
+      ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 17, color: fg),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(text, style: TextStyle(fontSize: 12.5, color: fg)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 图片原件全屏查看(可缩放),字节来自 `readSourceBytes`。
+class _ImageViewerScreen extends StatelessWidget {
+  final int sourceFileId;
+  const _ImageViewerScreen({required this.sourceFileId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: const Text('原件'),
+      ),
+      body: FutureBuilder<Uint8List>(
+        future: readSourceBytes(id: sourceFileId),
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError || !snap.hasData) {
+            return const _ViewerFallback(message: '原件加载失败,已安全保存在档案里,可稍后重试。');
+          }
+          return PhotoView(
+            imageProvider: MemoryImage(snap.data!),
+            backgroundDecoration: const BoxDecoration(color: Colors.black),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// PDF 原件全屏查看(可翻页),字节来自 `readSourceBytes` → `PdfDocument.openData`。
+class _PdfViewerScreen extends StatefulWidget {
+  final int sourceFileId;
+  const _PdfViewerScreen({required this.sourceFileId});
+
+  @override
+  State<_PdfViewerScreen> createState() => _PdfViewerScreenState();
+}
+
+class _PdfViewerScreenState extends State<_PdfViewerScreen> {
+  PdfController? _controller;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final bytes = await readSourceBytes(id: widget.sourceFileId);
+      if (!mounted) return;
+      setState(() {
+        _controller = PdfController(document: PdfDocument.openData(bytes));
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('原件')),
+      body: _error != null
+          ? const _ViewerFallback(message: '此文件暂不能预览,原件已安全保存在档案里。')
+          : _controller == null
+          ? const Center(child: CircularProgressIndicator(color: MedMe.teal))
+          : PdfView(controller: _controller!, onDocumentError: (_) {}),
+    );
+  }
+}
+
+/// DICOM 原件:渲染锚点切片为 PNG;不支持的压缩格式优雅降级,不崩溃。
+class _DicomViewerScreen extends StatelessWidget {
+  final int sourceFileId;
+  const _DicomViewerScreen({required this.sourceFileId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: const Text('影像原件'),
+      ),
+      body: FutureBuilder<Uint8List>(
+        future: renderDicomPng(id: sourceFileId),
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError || !snap.hasData) {
+            return const _ViewerFallback(
+              message: '此 DICOM 格式暂不能预览(可能是不支持的压缩方式),原件已安全保存。',
+              light: false,
+            );
+          }
+          return PhotoView(
+            imageProvider: MemoryImage(snap.data!),
+            backgroundDecoration: const BoxDecoration(color: Colors.black),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 查看原件失败/不支持时的统一降级提示——永远给出如实文案,不留空白。
+class _ViewerFallback extends StatelessWidget {
+  final String message;
+  final bool light;
+  const _ViewerFallback({required this.message, this.light = true});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = light ? MedMe.faint : Colors.white70;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.image_not_supported_outlined, size: 40, color: color),
+            const SizedBox(height: 12),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: color, fontSize: 13.5, height: 1.6),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概述
- 实现「健康档案」时间线屏(第二个底部 tab)+ 文档详情屏
- 数据全部来自现有 FFI(`loadArchive` / `patientProfile` / `getDocument` / `readSourceBytes` / `renderDicomPng`),未改动 Rust core / FRB 生成码

## 改动
- `apps/mobile_flutter/lib/screens/archive_screen.dart`:患者头卡(姓名/性别·年龄/记录数,字段可空优雅缺省)+ 时间线列表(就诊组可展开子文档、独立文档单卡),下拉刷新,空态引导
- `apps/mobile_flutter/lib/screens/document_detail.dart`(新建):文档详情——类型/日期/来源文件名/OCR 置信度三档徽标;识别文本复用已有 `ReportContent` 组件;查看原件按 mimeType 分流(图片 photo_view、PDF pdfx、DICOM renderDicomPng),不支持格式优雅降级不崩溃
- `apps/mobile_flutter/integration_test/archive_test.dart`(新建):Patrol 集成测试,验证空库下切到健康档案 tab 能加载并显示空态引导

## 测试计划
- [x] `flutter analyze` 0 issue
- [x] `dart format` 已跑
- [x] 现有 `flutter test test/report_content_test.dart` 仍全绿
- [ ] `patrol test -t integration_test/archive_test.dart`(用户本地/真机跑)