### PR TITLE
📱[Flutter P3] 三屏落地:导入导出(ML Kit OCR)/ 档案时间线+文档详情 / 设置 + iOS 权限声明

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -94,9 +94,15 @@ jobs:
   # ── iOS release:archive + 导出 IPA(可选上传 TestFlight)。需配签名 secrets(见文末) ──
   ios-release:
     if: github.event_name == 'workflow_dispatch' && (inputs.platform == 'ios' || inputs.platform == 'both')
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: 选最新 Xcode(App Store Connect 要求 iOS 26 SDK / Xcode 26+)
+        run: |
+          XC=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          echo "使用 $XC"
+          sudo xcode-select -s "$XC/Contents/Developer"
+          xcodebuild -version
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,177 @@
+name: Mobile (Flutter)
+
+# 纪律:日常开发在本地跑单平台 debug + `flutter analyze`。
+# 完整 Rust release 跨平台编译是发布流程,只在这里(CI)做,带缓存。
+# - PR:只跑轻量 analyze(不编 Rust release),堵住"移动端无 CI"的缺口。
+# - release:手动 workflow_dispatch 触发,产出安卓全 ABI + iOS archive/TestFlight。
+
+on:
+  pull_request:
+    paths:
+      - "apps/mobile_flutter/**"
+      - ".github/workflows/mobile.yml"
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "要出的包"
+        type: choice
+        options: [android, ios, both]
+        default: both
+      upload_testflight:
+        description: "iOS 是否上传 TestFlight(需已配好 secrets)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: "3.44.6"
+  WORKDIR: apps/mobile_flutter
+
+jobs:
+  # ── 轻量门禁:每个改动移动端的 PR 都跑,只做静态分析 + 单元测试,不编 Rust release ──
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: subosito/flutter-action@v2 # TODO: 按仓库惯例改成 SHA 钉版
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - name: pub get
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter pub get
+      - name: flutter analyze
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter analyze
+      - name: dart 单元测试
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter test
+
+  # ── 安卓 release:全 ABI,产出可安装 APK(debug 签名,内测侧载)+ appbundle 工件 ──
+  android-release:
+    if: github.event_name == 'workflow_dispatch' && (inputs.platform == 'android' || inputs.platform == 'both')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-java@v4 # TODO: SHA 钉版
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+      # 关键:workspaces 指向真实 Rust workspace + 真实 target,否则 cargokit 会在别处重编
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/mobile_flutter/rust -> target
+          shared-key: flutter-rust-android
+      - name: pub get
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter pub get
+      - name: 构建 release APK(全 ABI)
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter build apk --release
+      - name: 构建 appbundle(Play 用)
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter build appbundle --release
+      - uses: actions/upload-artifact@v4 # TODO: SHA 钉版
+        with:
+          name: medme-android
+          path: |
+            ${{ env.WORKDIR }}/build/app/outputs/flutter-apk/app-release.apk
+            ${{ env.WORKDIR }}/build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+
+  # ── iOS release:archive + 导出 IPA(可选上传 TestFlight)。需配签名 secrets(见文末) ──
+  ios-release:
+    if: github.event_name == 'workflow_dispatch' && (inputs.platform == 'ios' || inputs.platform == 'both')
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: aarch64-apple-ios
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/mobile_flutter/rust -> target
+          shared-key: flutter-rust-ios
+      - name: 导入签名证书 + 描述文件
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.IOS_CERT_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.IOS_CERT_P12_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+        run: |
+          CERT=$RUNNER_TEMP/cert.p12
+          PP=$RUNNER_TEMP/pp.mobileprovision
+          KC=$RUNNER_TEMP/signing.keychain-db
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT"
+          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o "$PP"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KC"
+          security set-keychain-settings -lut 21600 "$KC"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KC"
+          security import "$CERT" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KC"
+          security list-keychain -d user -s "$KC"
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP" ~/Library/MobileDevice/Provisioning\ Profiles/
+      - name: 写 ExportOptions.plist
+        run: |
+          cat > $RUNNER_TEMP/ExportOptions.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>teamID</key><string>49G34P23QP</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>provisioningProfiles</key><dict>
+              <key>com.medme.mobile</key><string>MedMe App Store</string>
+            </dict>
+            <key>uploadSymbols</key><true/>
+            <key>destination</key><string>export</string>
+          </dict></plist>
+          PLIST
+      - name: pub get
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter pub get
+      - name: 构建 IPA(release archive + 导出)
+        working-directory: ${{ env.WORKDIR }}
+        run: flutter build ipa --release --export-options-plist=$RUNNER_TEMP/ExportOptions.plist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: medme-ios-ipa
+          path: ${{ env.WORKDIR }}/build/ios/ipa/*.ipa
+          if-no-files-found: error
+      - name: 上传 TestFlight(可选)
+        if: inputs.upload_testflight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$ASC_API_KEY_BASE64" | base64 --decode -o ~/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8
+          xcrun altool --upload-app --type ios \
+            -f "${{ env.WORKDIR }}"/build/ios/ipa/*.ipa \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
+# ── iOS release 需要的 GitHub Secrets(用户在 repo Settings → Secrets → Actions 加)──
+#   IOS_CERT_P12_BASE64            Apple Distribution 证书导出的 .p12,base64(`base64 -i cert.p12`)
+#   IOS_CERT_P12_PASSWORD          导出 .p12 时设的密码
+#   IOS_PROVISIONING_PROFILE_BASE64  "MedMe App Store" 描述文件 .mobileprovision,base64
+#   IOS_KEYCHAIN_PASSWORD          任意临时钥匙串密码(CI 内自建自用)
+#   ASC_KEY_ID / ASC_ISSUER_ID     App Store Connect API key 的 Key ID / Issuer ID
+#   ASC_API_KEY_BASE64             该 API key 的 .p8 文件 base64(勿提交到仓库)

--- a/apps/mobile_flutter/CLAUDE.md
+++ b/apps/mobile_flutter/CLAUDE.md
@@ -28,7 +28,7 @@
 ## 版本纪律
 
 用**最成熟稳定**版本,别用 bleeding-edge:
-- 安卓:AGP 8.7.3 / Gradle 8.11.1 / Kotlin 2.1.0(FRB 模板默认给的 AGP 9 / Gradle 9 不兼容 Flutter Gradle 插件)。
+- 安卓:AGP 8.9.1 / Gradle 8.11.1 / Kotlin 2.1.0(FRB 模板默认给的 AGP 9 / Gradle 9 不兼容 Flutter Gradle 插件)。
 - 插件对齐 win32 版本:file_picker ^8.x 与 share_plus ^11.x(share_plus 13.x 要 win32^6 会把 file_picker 顶回无 namespace 的老版)。
 - iOS 部署目标 15.5(ML Kit 要求);模拟器 `EXCLUDED_ARCHS=arm64`(ML Kit 无模拟器切片)。
 

--- a/apps/mobile_flutter/CLAUDE.md
+++ b/apps/mobile_flutter/CLAUDE.md
@@ -1,0 +1,38 @@
+# MedMe 移动端(Flutter)—— 给 Claude Code 的构建纪律
+
+架构:Flutter UI + 复用现有 Rust core(经 flutter_rust_bridge / cargokit FFI)。
+保险箱格式与桌面 Tauri 版逐字节一致,保证同步兼容。
+
+## Build rules(硬规则,不得违反)
+
+- **Never** run full Flutter release builds during routine development.
+- **Never** build all Rust mobile targets / all ABIs unless explicitly requested.
+- Default to **debug** builds for the **currently selected** simulator/device only
+  (`flutter run` or `flutter run -d <device-id>`)。不要每次同时编译全部 ABI,不要日常用 `--release`。
+- Do **not** run `flutter build ipa`、`flutter build appbundle`、`flutter build apk --release`,
+  或任何多 ABI / release 的 Rust 交叉编译,**除非用户明确许可**。
+- 日常验证只用:`flutter analyze`、`dart test`、Rust 单元测试。这些才是改 UI 后的验证手段。
+- **完整 Rust release 交叉编译是发布流程(CI 的活),不是 Claude Code 的日常验证步骤。**
+- Rust release artifacts / 安装包 / iOS archive / TestFlight / 全 ABI Android release
+  **一律由 GitHub Actions 产出**(见 `.github/workflows/mobile.yml`),带 cargo/target/pub/gradle 缓存。
+- All long-running build commands must use a timeout。
+- **Before invoking any command expected to take more than 5 minutes, STOP and report
+  the exact command to the user instead of running it.**(别擅自触发 30 分钟后台构建。)
+
+## 为什么(踩过的坑)
+
+本地反复跑 `flutter build ipa --release` / release APK 当"验证",每次 30+ 分钟
+(cargokit 每次现场重编 Rust release,不复用缓存),还被环境 kill / flutter temp 崩溃,
+纯浪费时间。release 跨平台编译属于发布流程,搬去 CI 用 `Swatinem/rust-cache` 缓存即可。
+
+## 版本纪律
+
+用**最成熟稳定**版本,别用 bleeding-edge:
+- 安卓:AGP 8.7.3 / Gradle 8.11.1 / Kotlin 2.1.0(FRB 模板默认给的 AGP 9 / Gradle 9 不兼容 Flutter Gradle 插件)。
+- 插件对齐 win32 版本:file_picker ^8.x 与 share_plus ^11.x(share_plus 13.x 要 win32^6 会把 file_picker 顶回无 namespace 的老版)。
+- iOS 部署目标 15.5(ML Kit 要求);模拟器 `EXCLUDED_ARCHS=arm64`(ML Kit 无模拟器切片)。
+
+## 出包(仅发布时,优先 CI)
+
+- iOS bundle id = `com.medme.mobile`(复用现有 App Store app + 「MedMe App Store」描述文件)。
+- 后续:安卓 `applicationId`/`namespace` 从 `com.medme.mobile_flutter` 改齐 `com.medme.mobile`(涉及 kotlin 目录改名,发布前做)。

--- a/apps/mobile_flutter/android/app/build.gradle.kts
+++ b/apps/mobile_flutter/android/app/build.gradle.kts
@@ -27,9 +27,14 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
+            // 内测阶段先用 debug 签名(CI 出可侧载 APK);正式上架前换正式 keystore。
             signingConfig = signingConfigs.getByName("debug")
+            // R8 需要额外规则:ML Kit 文字识别插件把中/日/韩/梵文识别器都声明成
+            // compileOnly(只打包 Latin),我们只加了中文包,其余脚本类缺失需 -dontwarn。
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 }
@@ -42,4 +47,11 @@ kotlin {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // ML Kit 中文文字识别包。插件默认只打包 Latin;MedMe 面向中文病历,必须显式加
+    // 中文识别器,否则中文 OCR 运行时不工作、且 release R8 会因缺类构建失败。
+    // 日/韩/梵文用不到,不加(避免无谓增大 APK),对应缺类在 proguard-rules.pro 里 -dontwarn。
+    implementation("com.google.mlkit:text-recognition-chinese:16.0.1")
 }

--- a/apps/mobile_flutter/android/app/proguard-rules.pro
+++ b/apps/mobile_flutter/android/app/proguard-rules.pro
@@ -1,0 +1,13 @@
+# MedMe 移动端 R8/ProGuard 规则
+
+# ML Kit 文字识别:google_mlkit_text_recognition 插件把中/日/韩/梵文识别器都声明成
+# compileOnly(插件代码里都有引用),但只打包 Latin。我们只额外加了中文识别包
+# (见 build.gradle.kts),日/韩/梵文的识别器类因此在 classpath 缺失。
+# 这些脚本 MedMe 用不到,-dontwarn 让 R8 忽略这些缺类(不影响我们用的中文+Latin)。
+-dontwarn com.google.mlkit.vision.text.devanagari.**
+-dontwarn com.google.mlkit.vision.text.japanese.**
+-dontwarn com.google.mlkit.vision.text.korean.**
+
+# 保留 ML Kit 文字识别相关类(部分经由反射/清单组件加载,避免被 R8 误删)。
+-keep class com.google.mlkit.vision.text.** { *; }
+-keep class com.google.mlkit.vision.text.chinese.** { *; }

--- a/apps/mobile_flutter/android/gradle.properties
+++ b/apps/mobile_flutter/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-# This newDsl flag was added by the Flutter template
-android.newDsl=false
-# This builtInKotlin flag was added by the Flutter template
+# This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/apps/mobile_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/mobile_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/apps/mobile_flutter/android/settings.gradle.kts
+++ b/apps/mobile_flutter/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 

--- a/apps/mobile_flutter/android/settings.gradle.kts
+++ b/apps/mobile_flutter/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.0.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")

--- a/apps/mobile_flutter/integration_test/archive_test.dart
+++ b/apps/mobile_flutter/integration_test/archive_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:mobile_flutter/main.dart' as app;
+import 'package:mobile_flutter/src/rust/frb_generated.dart';
+
+// MedMe Flutter 集成测试(Patrol)——健康档案 tab。
+//   patrol test -t integration_test/archive_test.dart
+//
+// 测试环境是刚打开的空保险箱(没有导入过数据),所以这里验证的是空态引导:
+// 切到「健康档案」tab 后能正常加载(不崩溃/不卡在转圈),患者头卡兜底文案
+// 「我的健康档案」和空态引导文案「还没有病历」都可见。
+
+void main() {
+  patrolTest('健康档案 tab:切换后能加载,空库显示空态引导', ($) async {
+    await RustLib.init();
+    await $.pumpWidgetAndSettle(const app.MedMeApp());
+
+    // 切到「健康档案」tab。
+    await $('健康档案').tap();
+    await $.pumpAndSettle();
+
+    // 患者头卡:空库无姓名时兜底显示「我的健康档案」。
+    expect($('我的健康档案'), findsOneWidget);
+
+    // 空态引导可见,而不是白屏/一直转圈。
+    expect($('还没有病历'), findsOneWidget);
+  });
+}

--- a/apps/mobile_flutter/integration_test/import_export_test.dart
+++ b/apps/mobile_flutter/integration_test/import_export_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:mobile_flutter/main.dart' as app;
+import 'package:mobile_flutter/src/rust/frb_generated.dart';
+
+// 「导入导出」屏(底部第一个一级 tab)集成测试:验证屏能加载、三个采集入口
+// (拍照 / 从相册选 / 选择文件)与两个导出/分享入口(导出时间线 / 加密分享给
+// 医生)都在且可点。采集三项会拉起系统相机 / 相册 / 文件选择器,不在此测试里
+// 真正触发(留给后续端到端流程,见 `app_test.dart` 顶部注释);导出/分享两项
+// 点开的是应用内确认对话框,验证弹窗内容后点「取消」关闭,不依赖真实保险箱
+// 数据、不需要真机权限。
+
+void main() {
+  patrolTest('导入导出屏:入口可见可点,导出/分享弹窗能开能关', ($) async {
+    await RustLib.init();
+    await $.pumpWidgetAndSettle(const app.MedMeApp());
+
+    // 默认停在第一个 tab(导入导出),标题在。
+    expect($('导入 · 导出'), findsOneWidget);
+
+    // 三个采集入口都在(不点——会拉起系统相机/相册/文件选择器)。
+    expect($('拍照'), findsOneWidget);
+    expect($('从相册选'), findsOneWidget);
+    expect($('选择文件'), findsOneWidget);
+
+    // 导出时间线:点开应用内确认对话框,确认文案在,再取消关闭。
+    expect($('导出时间线(HTML)'), findsOneWidget);
+    await $('导出时间线(HTML)').tap();
+    expect($('导出并分享'), findsOneWidget);
+    await $('取消').tap();
+
+    // 加密分享给医生:点开有效期选择对话框,确认文案在,再取消关闭。
+    expect($('加密分享给医生'), findsOneWidget);
+    await $('加密分享给医生').tap();
+    expect($('生成分享'), findsOneWidget);
+    await $('取消').tap();
+  });
+}

--- a/apps/mobile_flutter/integration_test/settings_test.dart
+++ b/apps/mobile_flutter/integration_test/settings_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:mobile_flutter/main.dart' as app;
+import 'package:mobile_flutter/src/rust/frb_generated.dart';
+
+// 「设置」屏集成测试(Patrol)。用户跑:
+//   patrol test -t integration_test/settings_test.dart
+//
+// 覆盖:切到设置 tab 后,示例数据/清空/关于 三个分组都渲染出来;点「清空所有
+// 数据 · 重置保险箱」弹出二次确认对话框(且能取消,不误删)。真正跑一次
+// FFI 清空留给人工在真机/模拟器上验证——这里只验证 UI 流程不会漏掉确认这一步
+// (对应过的反馈:载入示例后清空无法用,首要是要看到确认弹窗且能操作)。
+
+void main() {
+  patrolTest('设置屏:分组可见,清空按钮弹二次确认', ($) async {
+    await RustLib.init();
+    await $.pumpWidgetAndSettle(const app.MedMeApp());
+
+    await $('设置').tap();
+    await $.pumpAndSettle();
+
+    // 三个功能分组的标题行都在。
+    expect($('载入示例数据(张建国)'), findsOneWidget);
+    expect($('清空所有数据 · 重置保险箱'), findsOneWidget);
+    expect($('关于'), findsOneWidget);
+
+    // 点清空 → 弹出二次确认,不直接执行。
+    await $('清空所有数据 · 重置保险箱').tap();
+    await $.pumpAndSettle();
+    expect($('清空保险箱?'), findsOneWidget);
+    expect($('确定清空全部记录?示例数据和已导入的病历都会被删除,此操作不可撤销。'), findsOneWidget);
+
+    // 取消:对话框消失,不触发清空。
+    await $('取消').tap();
+    await $.pumpAndSettle();
+    expect($('清空保险箱?'), findsNothing);
+  });
+}

--- a/apps/mobile_flutter/ios/Podfile
+++ b/apps/mobile_flutter/ios/Podfile
@@ -31,6 +31,12 @@ target 'Runner' do
   use_frameworks!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # ML Kit 文字识别插件默认只带 Latin。MedMe 面向中文病历,必须显式加中文识别包,
+  # 否则请求中文脚本时运行时不工作(iOS 不像安卓有 R8,构建能过但中文识别是坏的)。
+  # 日/韩/梵文用不到,不加。版本对齐插件 podspec 的 GoogleMLKit/TextRecognition ~> 9.0.0。
+  pod 'GoogleMLKit/TextRecognitionChinese', '~> 9.0.0'
+
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -505,13 +505,16 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 49G34P23QP;
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -528,7 +531,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -546,7 +549,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -562,7 +565,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -690,13 +693,16 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 49G34P23QP;
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -713,13 +719,16 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 49G34P23QP;
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobileFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = com.medme.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/mobile_flutter/ios/Runner/Info.plist
+++ b/apps/mobile_flutter/ios/Runner/Info.plist
@@ -66,5 +66,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>MedMe 需要使用相机拍摄你的化验单、处方等病历,识别文字后保存到你自己的健康档案。照片只存在本机,不会上传。</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>MedMe 需要访问相册,导入你已经拍好的病历照片。照片只存在本机,不会上传。</string>
 </dict>
 </plist>

--- a/apps/mobile_flutter/ios/Runner/Info.plist
+++ b/apps/mobile_flutter/ios/Runner/Info.plist
@@ -70,5 +70,12 @@
 	<string>MedMe 需要使用相机拍摄你的化验单、处方等病历,识别文字后保存到你自己的健康档案。照片只存在本机,不会上传。</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>MedMe 需要访问相册,导入你已经拍好的病历照片。照片只存在本机,不会上传。</string>
+	<!-- MedMe 本身不使用定位。此声明仅为满足文字识别组件(ML Kit / GoogleUtilities
+	     传递依赖)引用了系统定位 API 的要求(ITMS-90683);App 不会请求或使用你的位置。 -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>MedMe 不需要你的位置信息,也不会请求定位。</string>
+	<!-- 只用标准/豁免加密(本机端到端分享用的是标准算法),免每次 TestFlight 问出口合规。 -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -1,15 +1,491 @@
 import 'package:flutter/material.dart';
 
-/// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,点开详情。
-/// P3 填充(调 FFI load_archive / get_document + 内容感知渲染);此处占位。
-class ArchiveScreen extends StatelessWidget {
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/screens/document_detail.dart';
+
+/// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,按日期倒序,
+/// 点开看详情。与旧 Tauri 移动端 App.tsx 的 archive tab(phead + tl)同一观感,
+/// 数据来自 FFI `loadArchive` / `patientProfile`(见 lib/src/rust/api/vault.dart)。
+
+// doc_type / encounter kind → 中文标签(与 core-model types.rs、旧 App.tsx 一致)。
+const Map<String, String> _docLabel = {
+  'lab_report': '化验',
+  'imaging_report': '影像',
+  'discharge_summary': '出院小结',
+  'prescription': '处方',
+  'clinical_note': '病历',
+  'pathology': '病理',
+  'surgery': '手术',
+  'other': '其他',
+  'unknown': '待归类',
+};
+const Map<String, String> _kindLabel = {
+  'inpatient': '住院',
+  'outpatient': '门诊',
+  'emergency': '急诊',
+  'exam': '检查',
+};
+
+// 文档类型/就诊类型 → 图标 + 配色(与旧 App.css 的 t-* 徽标一致,只是用 Material
+// 图标替代内联 SVG)。
+const Map<String, IconData> _docIcon = {
+  'lab_report': Icons.science_outlined,
+  'imaging_report': Icons.document_scanner_outlined,
+  'prescription': Icons.medication_outlined,
+  'discharge_summary': Icons.bed_outlined,
+  'clinical_note': Icons.medical_services_outlined,
+  'pathology': Icons.biotech_outlined,
+  'surgery': Icons.content_cut,
+  'other': Icons.description_outlined,
+  'unknown': Icons.help_outline,
+};
+const Map<String, IconData> _kindIcon = {
+  'outpatient': Icons.medical_services_outlined,
+  'inpatient': Icons.bed_outlined,
+};
+const Map<String, Color> _typeColor = {
+  'lab_report': Color(0xFF1D4ED8),
+  'imaging_report': Color(0xFFB45309),
+  'prescription': Color(0xFF047857),
+  'discharge_summary': Color(0xFF4338CA),
+  'clinical_note': Color(0xFF0369A1),
+  'pathology': Color(0xFFBE123C),
+  'surgery': Color(0xFF7E22CE),
+  'other': Color(0xFF475569),
+  'unknown': Color(0xFF475569),
+  'enc': Color(0xFF1D4ED8), // 就诊组统一用蓝(旧 App.css .t-enc)
+};
+
+Color _colorFor(String key) => _typeColor[key] ?? _typeColor['other']!;
+
+IconData _iconForDoc(String docType) =>
+    _docIcon[docType] ?? Icons.description_outlined;
+
+IconData _iconForKind(String kind) =>
+    _kindIcon[kind] ?? Icons.local_hospital_outlined;
+
+String _fmtDate(String? iso) {
+  if (iso == null || iso.isEmpty) return '';
+  final d = DateTime.tryParse(iso);
+  if (d == null) return '';
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+String _groupTitle(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter) =>
+      encounter.provider != null
+          ? '${_kindLabel[encounter.kind] ?? encounter.kind} · ${encounter.provider}'
+          : (_kindLabel[encounter.kind] ?? encounter.kind),
+    TimelineGroupDto_Document(:final doc) =>
+      doc.title ?? _docLabel[doc.docType] ?? '记录',
+  };
+}
+
+String _groupDate(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter) => _fmtDate(
+      encounter.startDate,
+    ),
+    TimelineGroupDto_Document(:final doc) => _fmtDate(doc.docDate),
+  };
+}
+
+String _groupDesc(TimelineGroupDto g) {
+  return switch (g) {
+    TimelineGroupDto_Encounter(:final encounter, :final docs) => () {
+      final kinds = <String>{};
+      for (final d in docs) {
+        kinds.add(_docLabel[d.docType] ?? d.docType);
+      }
+      final parts = ['${encounter.docCount} 份记录', ...kinds.take(3)];
+      if (encounter.transferred) parts.add('转院');
+      return parts.join(' · ');
+    }(),
+    TimelineGroupDto_Document(:final doc) => [
+      _docLabel[doc.docType] ?? doc.docType,
+      if (doc.sliceCount != null) '影像 ${doc.sliceCount} 张',
+    ].join(' · '),
+  };
+}
+
+class ArchiveScreen extends StatefulWidget {
   const ArchiveScreen({super.key});
+
+  @override
+  State<ArchiveScreen> createState() => _ArchiveScreenState();
+}
+
+class _ArchiveScreenState extends State<ArchiveScreen> {
+  late Future<(PatientProfileDto, List<TimelineGroupDto>)> _future = _load();
+  // 就诊组在时间线里点开时展开其子文档(可再点开各自详情)。
+  final Set<int> _expanded = {};
+
+  Future<(PatientProfileDto, List<TimelineGroupDto>)> _load() async {
+    final results = await Future.wait([patientProfile(), loadArchive()]);
+    return (
+      results[0] as PatientProfileDto,
+      results[1] as List<TimelineGroupDto>,
+    );
+  }
+
+  Future<void> _refresh() async {
+    final next = _load();
+    setState(() => _future = next);
+    await next;
+  }
+
+  void _openDoc(int id) {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => DocumentDetailScreen(docId: id)));
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('健康档案')),
-      body: const Center(child: Text('时间线(P3 实现)')),
+      body: FutureBuilder<(PatientProfileDto, List<TimelineGroupDto>)>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError) {
+            return RefreshIndicator(
+              onRefresh: _refresh,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Text(
+                      '加载健康档案失败:\n${snap.error}\n\n下拉可重试。',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: MedMe.faint),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final (profile, groups) = snap.data!;
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            color: MedMe.teal,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+              children: [
+                _PatientHeader(profile: profile),
+                const SizedBox(height: 20),
+                if (groups.isEmpty)
+                  const _EmptyState()
+                else
+                  for (var i = 0; i < groups.length; i++) ...[
+                    if (i > 0) const SizedBox(height: 10),
+                    _TimelineItem(
+                      group: groups[i],
+                      expanded: _expanded.contains(i),
+                      onTap: () {
+                        final g = groups[i];
+                        if (g is TimelineGroupDto_Document) {
+                          _openDoc(g.doc.id);
+                        } else {
+                          setState(() {
+                            if (!_expanded.add(i)) _expanded.remove(i);
+                          });
+                        }
+                      },
+                      onOpenSubDoc: _openDoc,
+                    ),
+                  ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 患者头卡:姓名 / 性别·年龄 / 记录数,字段可空一律优雅缺省。
+class _PatientHeader extends StatelessWidget {
+  final PatientProfileDto profile;
+  const _PatientHeader({required this.profile});
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = (profile.name?.isNotEmpty ?? false)
+        ? profile.name![0]
+        : '我';
+    final subParts = [
+      profile.gender,
+      profile.age,
+    ].whereType<String>().where((s) => s.isNotEmpty).toList();
+    subParts.add('${profile.recordCount} 份记录');
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: MedMe.panel,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: MedMe.line),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 26,
+            backgroundColor: MedMe.tealSoft,
+            child: Text(
+              initial,
+              style: const TextStyle(
+                color: MedMe.teal,
+                fontWeight: FontWeight.w700,
+                fontSize: 18,
+              ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  profile.name ?? '我的健康档案',
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MedMe.ink,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subParts.join(' · '),
+                  style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 空态引导:没有记录时提示去「导入导出」或「设置」载入示例数据。
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 56),
+      child: Column(
+        children: [
+          const Icon(Icons.folder_outlined, size: 48, color: MedMe.faint),
+          const SizedBox(height: 14),
+          const Text(
+            '还没有病历',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: MedMe.ink,
+            ),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '去「导入导出」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 13, color: MedMe.faint, height: 1.6),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 时间线一项:就诊组(可展开子文档)或独立文档。
+class _TimelineItem extends StatelessWidget {
+  final TimelineGroupDto group;
+  final bool expanded;
+  final VoidCallback onTap;
+  final void Function(int docId) onOpenSubDoc;
+
+  const _TimelineItem({
+    required this.group,
+    required this.expanded,
+    required this.onTap,
+    required this.onOpenSubDoc,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isEncounter = group is TimelineGroupDto_Encounter;
+    final colorKey = switch (group) {
+      TimelineGroupDto_Encounter() => 'enc',
+      TimelineGroupDto_Document(:final doc) => doc.docType,
+    };
+    final color = _colorFor(colorKey);
+    final icon = switch (group) {
+      TimelineGroupDto_Encounter(:final encounter) => _iconForKind(
+        encounter.kind,
+      ),
+      TimelineGroupDto_Document(:final doc) => _iconForDoc(doc.docType),
+    };
+
+    return Container(
+      decoration: BoxDecoration(
+        color: MedMe.panel,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: MedMe.line),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          InkWell(
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 36,
+                    height: 36,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Icon(icon, size: 19, color: color),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _groupTitle(group),
+                                style: const TextStyle(
+                                  fontSize: 14.5,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              _groupDate(group),
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: MedMe.faint,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          _groupDesc(group),
+                          style: const TextStyle(
+                            fontSize: 12.5,
+                            color: MedMe.faint,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (isEncounter)
+                    Icon(
+                      expanded ? Icons.expand_less : Icons.expand_more,
+                      size: 20,
+                      color: MedMe.faint,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          if (expanded)
+            switch (group) {
+              TimelineGroupDto_Encounter(:final docs) => _SubDocList(
+                docs: docs,
+                onOpenSubDoc: onOpenSubDoc,
+              ),
+              TimelineGroupDto_Document() => const SizedBox.shrink(),
+            },
+        ],
+      ),
+    );
+  }
+}
+
+class _SubDocList extends StatelessWidget {
+  final List<DocumentSummaryDto> docs;
+  final void Function(int docId) onOpenSubDoc;
+
+  const _SubDocList({required this.docs, required this.onOpenSubDoc});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final d in docs)
+          Container(
+            decoration: const BoxDecoration(
+              border: Border(top: BorderSide(color: MedMe.line)),
+            ),
+            child: InkWell(
+              onTap: () => onOpenSubDoc(d.id),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 26,
+                      height: 26,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: _colorFor(d.docType).withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(
+                        _iconForDoc(d.docType),
+                        size: 14,
+                        color: _colorFor(d.docType),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        d.title ?? _docLabel[d.docType] ?? '记录',
+                        style: const TextStyle(fontSize: 13),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      _fmtDate(d.docDate),
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        color: MedMe.faint,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/apps/mobile_flutter/lib/screens/document_detail.dart
+++ b/apps/mobile_flutter/lib/screens/document_detail.dart
@@ -1,0 +1,424 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/widgets/report_content.dart';
+
+// doc_type → 中文标签,与 archive_screen.dart 保持同一份映射(桌面/旧移动端
+// 同构,来自 core-model types.rs)。
+const Map<String, String> _docLabel = {
+  'lab_report': '化验',
+  'imaging_report': '影像',
+  'discharge_summary': '出院小结',
+  'prescription': '处方',
+  'clinical_note': '病历',
+  'pathology': '病理',
+  'surgery': '手术',
+  'other': '其他',
+  'unknown': '待归类',
+};
+
+String _fmtDate(String? iso) {
+  if (iso == null || iso.isEmpty) return '';
+  final d = DateTime.tryParse(iso);
+  if (d == null) return '';
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+/// 文档详情屏:类型/日期/来源 + 识别文本(复用 ReportContent 内容感知渲染)+
+/// 查看原件(图片/PDF/DICOM 各自渲染,其余格式优雅降级不崩)。
+class DocumentDetailScreen extends StatefulWidget {
+  final int docId;
+  const DocumentDetailScreen({super.key, required this.docId});
+
+  @override
+  State<DocumentDetailScreen> createState() => _DocumentDetailScreenState();
+}
+
+class _DocumentDetailScreenState extends State<DocumentDetailScreen> {
+  late final Future<DocumentDetailDto> _future = getDocument(id: widget.docId);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('文档详情')),
+      body: FutureBuilder<DocumentDetailDto>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  '打开失败:\n${snap.error}',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: MedMe.faint),
+                ),
+              ),
+            );
+          }
+          return _DetailBody(detail: snap.data!);
+        },
+      ),
+    );
+  }
+}
+
+class _DetailBody extends StatelessWidget {
+  final DocumentDetailDto detail;
+  const _DetailBody({required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final doc = detail.document;
+    final sf = detail.sourceFile;
+    final typeLabel = _docLabel[doc.docType] ?? doc.docType;
+
+    // OCR 置信度:换算成患者能看懂的三档,而非裸百分比(与旧 App.tsx 一致)。
+    final conf = detail.ocrConfidence;
+    final confTier = conf == null
+        ? null
+        : conf >= 0.9
+        ? _ConfTier.high
+        : conf >= 0.75
+        ? _ConfTier.mid
+        : _ConfTier.low;
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: MedMe.tealSoft,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(Icons.description_outlined, color: MedMe.teal),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    doc.title ?? typeLabel,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    [
+                      typeLabel,
+                      if (doc.docDate != null) _fmtDate(doc.docDate),
+                    ].join(' · '),
+                    style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+                  ),
+                  Text(
+                    '来源:${sf.originalName}',
+                    style: const TextStyle(fontSize: 12, color: MedMe.faint),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+
+        if (confTier != null) ...[
+          const SizedBox(height: 14),
+          _ConfBadge(tier: confTier),
+        ],
+
+        const SizedBox(height: 14),
+        OutlinedButton.icon(
+          onPressed: () => _openOriginal(context, sf),
+          icon: const Icon(Icons.visibility_outlined, size: 18),
+          label: const Text('查看原件'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: MedMe.teal,
+            side: const BorderSide(color: MedMe.teal),
+            minimumSize: const Size.fromHeight(44),
+          ),
+        ),
+
+        const SizedBox(height: 20),
+        Row(
+          children: [
+            const Icon(Icons.article_outlined, size: 15, color: MedMe.faint),
+            const SizedBox(width: 6),
+            Text(
+              sf.mimeType.startsWith('image/') ? '识别文本' : '文档内容',
+              style: const TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w700,
+                color: MedMe.faint,
+                letterSpacing: 0.4,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        ReportContent(text: detail.ocrText, docType: doc.docType),
+      ],
+    );
+  }
+
+  Future<void> _openOriginal(BuildContext context, SourceFileMetaDto sf) async {
+    final mime = sf.mimeType;
+    if (mime.startsWith('image/')) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _ImageViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    if (mime == 'application/pdf') {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _PdfViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    if (mime == 'application/dicom') {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => _DicomViewerScreen(sourceFileId: sf.id),
+        ),
+      );
+      return;
+    }
+    // 其余格式手机端无法内联预览——如实告知,原件仍安全保存,不静默空白。
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('暂不能预览'),
+        content: Text('此格式($mime)暂不能在手机上预览,原件已安全保存在健康档案里。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('知道了'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+enum _ConfTier { high, mid, low }
+
+/// 识别质量徽标:高/中/低三档,比裸百分比更易懂(与旧 App.tsx .conf 一致)。
+class _ConfBadge extends StatelessWidget {
+  final _ConfTier tier;
+  const _ConfBadge({required this.tier});
+
+  @override
+  Widget build(BuildContext context) {
+    final (bg, fg, icon, text) = switch (tier) {
+      _ConfTier.high => (
+        const Color(0xFFECFDF5),
+        const Color(0xFF047857),
+        Icons.check_circle_outline,
+        '识别质量:高',
+      ),
+      _ConfTier.mid => (
+        const Color(0xFFFFFBEB),
+        const Color(0xFFB45309),
+        Icons.error_outline,
+        '识别质量:中 · 个别字可能有误,可核对原件',
+      ),
+      _ConfTier.low => (
+        const Color(0xFFFDEAEA),
+        const Color(0xFFB42318),
+        Icons.error_outline,
+        '识别质量:低 · 建议重新拍摄',
+      ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 17, color: fg),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(text, style: TextStyle(fontSize: 12.5, color: fg)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 图片原件全屏查看(可缩放),字节来自 `readSourceBytes`。
+class _ImageViewerScreen extends StatelessWidget {
+  final int sourceFileId;
+  const _ImageViewerScreen({required this.sourceFileId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: const Text('原件'),
+      ),
+      body: FutureBuilder<Uint8List>(
+        future: readSourceBytes(id: sourceFileId),
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError || !snap.hasData) {
+            return const _ViewerFallback(message: '原件加载失败,已安全保存在档案里,可稍后重试。');
+          }
+          return PhotoView(
+            imageProvider: MemoryImage(snap.data!),
+            backgroundDecoration: const BoxDecoration(color: Colors.black),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// PDF 原件全屏查看(可翻页),字节来自 `readSourceBytes` → `PdfDocument.openData`。
+class _PdfViewerScreen extends StatefulWidget {
+  final int sourceFileId;
+  const _PdfViewerScreen({required this.sourceFileId});
+
+  @override
+  State<_PdfViewerScreen> createState() => _PdfViewerScreenState();
+}
+
+class _PdfViewerScreenState extends State<_PdfViewerScreen> {
+  PdfController? _controller;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final bytes = await readSourceBytes(id: widget.sourceFileId);
+      if (!mounted) return;
+      setState(() {
+        _controller = PdfController(document: PdfDocument.openData(bytes));
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('原件')),
+      body: _error != null
+          ? const _ViewerFallback(message: '此文件暂不能预览,原件已安全保存在档案里。')
+          : _controller == null
+          ? const Center(child: CircularProgressIndicator(color: MedMe.teal))
+          : PdfView(controller: _controller!, onDocumentError: (_) {}),
+    );
+  }
+}
+
+/// DICOM 原件:渲染锚点切片为 PNG;不支持的压缩格式优雅降级,不崩溃。
+class _DicomViewerScreen extends StatelessWidget {
+  final int sourceFileId;
+  const _DicomViewerScreen({required this.sourceFileId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: const Text('影像原件'),
+      ),
+      body: FutureBuilder<Uint8List>(
+        future: renderDicomPng(id: sourceFileId),
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(color: MedMe.teal),
+            );
+          }
+          if (snap.hasError || !snap.hasData) {
+            return const _ViewerFallback(
+              message: '此 DICOM 格式暂不能预览(可能是不支持的压缩方式),原件已安全保存。',
+              light: false,
+            );
+          }
+          return PhotoView(
+            imageProvider: MemoryImage(snap.data!),
+            backgroundDecoration: const BoxDecoration(color: Colors.black),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 查看原件失败/不支持时的统一降级提示——永远给出如实文案,不留空白。
+class _ViewerFallback extends StatelessWidget {
+  final String message;
+  final bool light;
+  const _ViewerFallback({required this.message, this.light = true});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = light ? MedMe.faint : Colors.white70;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.image_not_supported_outlined, size: 40, color: color),
+            const SizedBox(height: 12),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: color, fontSize: 13.5, height: 1.6),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile_flutter/lib/screens/import_export_screen.dart
+++ b/apps/mobile_flutter/lib/screens/import_export_screen.dart
@@ -1,16 +1,595 @@
-import 'package:flutter/material.dart';
+import 'dart:io';
 
-/// 底部导航一级 tab「导入导出」(用户要求提升为一级,不埋设置)。
-/// 采集/拍照/相册/文件导入 + 导出(时间线,后续带日期区间筛选)。
-/// P3/P4/P6 填充实现;此处为占位骨架。
-class ImportExportScreen extends StatelessWidget {
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:share_plus/share_plus.dart';
+
+import 'package:mobile_flutter/screens/import_helpers.dart';
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
+
+/// 底部导航一级 tab「导入导出」——采集(拍照 / 相册 / 选文件)+
+/// 导出(时间线 HTML)/ 加密分享给医生。保险箱在 `main.dart` 启动时已打开,
+/// 这里直接调 FFI;不重写任何医疗判断逻辑,识别/归类/加密全部落在 Rust core。
+class ImportExportScreen extends StatefulWidget {
   const ImportExportScreen({super.key});
+
+  @override
+  State<ImportExportScreen> createState() => _ImportExportScreenState();
+}
+
+class _ImportExportScreenState extends State<ImportExportScreen> {
+  bool _busy = false;
+  String? _progress;
+
+  // ---------------------------------------------------------------------
+  // 采集入口:拍照 / 相册 / 文件选择器,三者最终都汇入 _importItems。
+  // ---------------------------------------------------------------------
+
+  Future<void> _pickFromCamera() async {
+    final XFile? file = await ImagePicker().pickImage(
+      source: ImageSource.camera,
+    );
+    if (file == null) return; // 用户取消
+    await _importItems([
+      PendingImport(name: file.name, path: file.path, isImage: true),
+    ]);
+  }
+
+  Future<void> _pickFromGallery() async {
+    final files = await ImagePicker().pickMultiImage();
+    if (files.isEmpty) return; // 用户取消
+    await _importItems([
+      for (final f in files)
+        PendingImport(name: f.name, path: f.path, isImage: true),
+    ]);
+  }
+
+  Future<void> _pickFiles() async {
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      type: FileType.custom,
+      allowedExtensions: ['pdf', 'txt', 'png', 'jpg', 'jpeg', 'tiff', 'heic'],
+    );
+    if (result == null) return; // 用户取消
+    final items = <PendingImport>[
+      for (final f in result.files)
+        if (f.path != null)
+          PendingImport(
+            name: f.name,
+            path: f.path!,
+            isImage: isImageName(f.name),
+          ),
+    ];
+    if (items.isEmpty) return;
+    await _importItems(items);
+  }
+
+  /// 逐个采集 → 落库,期间刷新「正在导入 i/n…」进度;结束后弹汇总对话框。
+  /// 图片先用 ML Kit 中文 OCR 识别文字,再连同字节交给 `ingestImageWithText`;
+  /// PDF/TXT 直传字节给 `ingestBytes`(按原始文件名后缀判 MIME)。单份文件
+  /// 处理失败不影响其余文件继续导入。
+  Future<void> _importItems(List<PendingImport> items) async {
+    setState(() {
+      _busy = true;
+      _progress = '正在导入 1/${items.length}…';
+    });
+
+    TextRecognizer? recognizer;
+    final rows = <ImportResultRow>[];
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      if (i > 0) {
+        setState(() => _progress = '正在导入 ${i + 1}/${items.length}…');
+      }
+      try {
+        final ImportOutcomeDto outcome;
+        if (item.isImage) {
+          recognizer ??= TextRecognizer(script: TextRecognitionScript.chinese);
+          final recognized = await recognizer.processImage(
+            InputImage.fromFilePath(item.path),
+          );
+          final bytes = await File(item.path).readAsBytes();
+          outcome = await ingestImageWithText(
+            name: item.name,
+            bytes: bytes,
+            ocrText: recognized.text,
+            confidence: averageMlkitConfidence(recognized),
+          );
+        } else {
+          final bytes = await File(item.path).readAsBytes();
+          outcome = await ingestBytes(filename: item.name, data: bytes);
+        }
+        rows.add(rowFromOutcome(outcome));
+      } catch (e) {
+        rows.add(rowFromError(item.name, e));
+      }
+    }
+    await recognizer?.close();
+
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      _progress = null;
+    });
+    await _showImportSummary(rows);
+  }
+
+  Future<void> _showImportSummary(List<ImportResultRow> rows) async {
+    final success = rows.where((r) => r.kind == ImportRowKind.success).length;
+    final duplicate = rows
+        .where((r) => r.kind == ImportRowKind.duplicate)
+        .length;
+    final storedNoText = rows
+        .where((r) => r.kind == ImportRowKind.storedNoText)
+        .length;
+    final failed = rows.where((r) => r.kind == ImportRowKind.failed).length;
+
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(failed == rows.length ? '导入未成功' : '导入完成'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (success > 0)
+                _summaryLine(
+                  Icons.check_circle,
+                  MedMe.teal,
+                  '成功识别入库 $success 份',
+                ),
+              if (duplicate > 0)
+                _summaryLine(
+                  Icons.content_copy,
+                  MedMe.faint,
+                  '重复,已跳过 $duplicate 份',
+                ),
+              if (storedNoText > 0)
+                _summaryLine(
+                  Icons.warning_amber_rounded,
+                  Colors.orange,
+                  '仅存原件(未识别到文字)$storedNoText 份',
+                ),
+              if (failed > 0)
+                _summaryLine(
+                  Icons.error_outline,
+                  MedMe.danger,
+                  '未能处理 $failed 份',
+                ),
+              const SizedBox(height: 12),
+              const Divider(height: 1, color: MedMe.line),
+              const SizedBox(height: 8),
+              for (final row in rows)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 3),
+                  child: Text(
+                    '${row.name} —— ${row.statusLabel}',
+                    style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('知道了'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _summaryLine(IconData icon, Color color, String text) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    child: Row(
+      children: [
+        Icon(icon, color: color, size: 20),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+          ),
+        ),
+      ],
+    ),
+  );
+
+  // ---------------------------------------------------------------------
+  // 导出时间线(未加密 HTML)。P6 才做日期区间筛选——FFI 目前无日期参数,
+  // 这里如实全量导出,并在说明里提前告知,不做假的日期选择器。
+  // ---------------------------------------------------------------------
+
+  Future<void> _exportTimeline() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('导出时间线'),
+        content: const Text(
+          '导出完整病历时间线为可打印文件(HTML),未加密,用浏览器打开后可直接打印或另存为 PDF,'
+          '适合报销或给医生留档。\n\n当前导出的是全部记录;按时间段筛选导出即将支持。',
+          style: TextStyle(fontSize: 13.5, height: 1.5),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('导出并分享'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      _busy = true;
+      _progress = '正在生成导出文件…';
+    });
+    try {
+      final result = await exportTimelineHtml();
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _progress = null;
+      });
+      await SharePlus.instance.share(
+        ShareParams(files: [XFile(result.path)], subject: 'MedMe 病历时间线导出'),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _progress = null;
+      });
+      await _showError('导出失败', '$e');
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // 加密分享给医生:先选有效期,再生成——口令与文件分开告知(口令另发)。
+  // ---------------------------------------------------------------------
+
+  Future<void> _startEncryptedShare() async {
+    var selectedDays = 7;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: const Text('加密分享给医生'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '生成一份端到端加密文件和一串口令;对方需要口令才能打开,全程不经过任何服务器。',
+                style: TextStyle(
+                  fontSize: 13.5,
+                  color: MedMe.faint,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                '有效期',
+                style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 8),
+              SegmentedButton<int>(
+                segments: const [
+                  ButtonSegment(value: 7, label: Text('7 天')),
+                  ButtonSegment(value: 30, label: Text('30 天')),
+                  ButtonSegment(value: 90, label: Text('90 天')),
+                ],
+                selected: {selectedDays},
+                onSelectionChanged: (s) =>
+                    setDialogState(() => selectedDays = s.first),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('生成分享'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      _busy = true;
+      _progress = '正在生成端到端加密分享…';
+    });
+    try {
+      final result = await createShare(expiresDays: selectedDays);
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _progress = null;
+      });
+      await _showShareResult(result);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _progress = null;
+      });
+      await _showError('生成分享失败', '$e');
+    }
+  }
+
+  Future<void> _showShareResult(ShareResultDto result) async {
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('加密分享已生成'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '共 ${result.recordCount} 份记录,已打包为端到端加密文件。',
+              style: const TextStyle(fontSize: 13.5, color: MedMe.faint),
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              '把文件发给医生,口令请用不同渠道另发(比如短信、电话告知);'
+              '对方打开文件、输入口令即可查看,数据始终端到端加密。',
+              style: TextStyle(fontSize: 13.5, color: MedMe.faint, height: 1.5),
+            ),
+            const SizedBox(height: 14),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                color: MedMe.bg,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: MedMe.line),
+              ),
+              child: Row(
+                children: [
+                  const Text(
+                    '口令',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: MedMe.faint,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      result.passphrase,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '复制口令',
+                    icon: const Icon(Icons.copy, size: 18),
+                    onPressed: () async {
+                      await Clipboard.setData(
+                        ClipboardData(text: result.passphrase),
+                      );
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(
+                          context,
+                        ).showSnackBar(const SnackBar(content: Text('口令已复制')));
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('关闭'),
+          ),
+          FilledButton.icon(
+            icon: const Icon(Icons.ios_share),
+            label: const Text('分享文件'),
+            onPressed: () async {
+              await SharePlus.instance.share(
+                ShareParams(files: [XFile(result.path)], subject: 'MedMe 加密病历'),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showError(String title, String message) => showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('知道了'),
+        ),
+      ],
+    ),
+  );
+
+  // ---------------------------------------------------------------------
+  // 界面
+  // ---------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('导入 · 导出')),
-      body: const Center(child: Text('导入导出(P3/P4 实现)')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          if (_progress != null) _progressBanner(_progress!),
+          _sectionTitle('添加记录'),
+          const SizedBox(height: 8),
+          _actionGroup([
+            _actionRow(
+              icon: Icons.camera_alt_outlined,
+              title: '拍照',
+              subtitle: '用相机拍摄病历、化验单、报告',
+              onTap: _busy ? null : _pickFromCamera,
+            ),
+            _actionRow(
+              icon: Icons.photo_library_outlined,
+              title: '从相册选',
+              subtitle: '从手机相册选择已有照片,可多选',
+              onTap: _busy ? null : _pickFromGallery,
+            ),
+            _actionRow(
+              icon: Icons.folder_open_outlined,
+              title: '选择文件',
+              subtitle: 'PDF、TXT 或图片文件,可多选',
+              onTap: _busy ? null : _pickFiles,
+            ),
+          ]),
+          const SizedBox(height: 24),
+          _sectionTitle('导出与分享'),
+          const SizedBox(height: 8),
+          _actionGroup([
+            _actionRow(
+              icon: Icons.description_outlined,
+              title: '导出时间线(HTML)',
+              subtitle: '完整病历时间线,未加密,可打印或自存',
+              onTap: _busy ? null : _exportTimeline,
+            ),
+            _actionRow(
+              icon: Icons.lock_outline,
+              title: '加密分享给医生',
+              subtitle: '生成加密文件与口令,凭口令查看',
+              onTap: _busy ? null : _startEncryptedShare,
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+
+  Widget _progressBanner(String text) => Container(
+    margin: const EdgeInsets.only(bottom: 16),
+    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+    decoration: BoxDecoration(
+      color: MedMe.tealSoft,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Row(
+      children: [
+        const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2.4, color: MedMe.teal),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: MedMe.tealDark,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+
+  Widget _sectionTitle(String text) => Padding(
+    padding: const EdgeInsets.only(left: 4, bottom: 4),
+    child: Text(
+      text,
+      style: const TextStyle(
+        fontSize: 13,
+        fontWeight: FontWeight.w700,
+        color: MedMe.faint,
+        letterSpacing: 0.4,
+      ),
+    ),
+  );
+
+  Widget _actionGroup(List<Widget> rows) => Card(
+    child: Column(
+      children: [
+        for (var i = 0; i < rows.length; i++) ...[
+          rows[i],
+          if (i != rows.length - 1) const Divider(height: 1, color: MedMe.line),
+        ],
+      ],
+    ),
+  );
+
+  Widget _actionRow({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback? onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: MedMe.tealSoft,
+                borderRadius: BorderRadius.circular(11),
+              ),
+              child: Icon(icon, color: MedMe.teal, size: 22),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: MedMe.ink,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(fontSize: 13, color: MedMe.faint),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: MedMe.faint),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile_flutter/lib/screens/import_helpers.dart
+++ b/apps/mobile_flutter/lib/screens/import_helpers.dart
@@ -1,0 +1,120 @@
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+
+/// 「导入导出」屏的纯逻辑小工具:与 Widget 树无关,方便单独看清楚。
+/// 文档类型中文标签,与桌面 / 旧 Tauri 移动端 `DOC_LABEL` 保持一致
+/// (见 `apps/mobile/src/App.tsx`),汇总弹窗里「归类为」文案用它。
+const Map<String, String> kDocTypeLabel = {
+  'lab_report': '化验',
+  'imaging_report': '影像',
+  'discharge_summary': '出院小结',
+  'prescription': '处方',
+  'clinical_note': '病历',
+  'pathology': '病理',
+  'surgery': '手术',
+  'other': '其他',
+  'unknown': '待归类',
+};
+
+/// 图片扩展名:拍照 / 相册天然是图片;「选择文件」里靠这些后缀判断是否也走
+/// OCR 通道(与 Rust 端 `pipeline::mime_for` 按扩展名判 MIME 的思路一致)。
+const Set<String> kImageExtensions = {'png', 'jpg', 'jpeg', 'tiff', 'heic'};
+
+/// 按文件名后缀判断是否为图片(大小写不敏感)。
+bool isImageName(String name) {
+  final dot = name.lastIndexOf('.');
+  if (dot < 0 || dot == name.length - 1) return false;
+  return kImageExtensions.contains(name.substring(dot + 1).toLowerCase());
+}
+
+/// 一份待导入项:统一拍照 / 相册 / 文件选择器三种来源——三者在设备上都有
+/// 真实文件路径(仅移动端,不考虑 web),据此读字节、跑 OCR。
+class PendingImport {
+  final String name;
+  final String path;
+  final bool isImage;
+
+  const PendingImport({
+    required this.name,
+    required this.path,
+    required this.isImage,
+  });
+}
+
+/// 单份文件导入结果的展示态:区分「FFI 落库但状态非全新成功」与
+/// 「处理过程中直接抛异常」,汇总弹窗按此分类计数。
+enum ImportRowKind { success, duplicate, storedNoText, failed }
+
+class ImportResultRow {
+  final String name;
+  final String statusLabel;
+  final ImportRowKind kind;
+
+  const ImportResultRow({
+    required this.name,
+    required this.statusLabel,
+    required this.kind,
+  });
+}
+
+/// 把 `ImportOutcomeDto.status`(见 rust/src/api/dto.rs 注释:
+/// new|backfilled|deduped|stored_no_text|instance_attached|failed)映射成
+/// 老人能看懂的一行结果。
+ImportResultRow rowFromOutcome(ImportOutcomeDto outcome) {
+  final typeLabel = outcome.docType == null
+      ? null
+      : (kDocTypeLabel[outcome.docType] ?? outcome.docType);
+  switch (outcome.status) {
+    case 'new':
+    case 'backfilled':
+    case 'instance_attached':
+      return ImportResultRow(
+        name: outcome.name,
+        statusLabel: typeLabel != null ? '已识别入库 · $typeLabel' : '已识别入库',
+        kind: ImportRowKind.success,
+      );
+    case 'deduped':
+      return ImportResultRow(
+        name: outcome.name,
+        statusLabel: '重复,已跳过',
+        kind: ImportRowKind.duplicate,
+      );
+    case 'stored_no_text':
+      return ImportResultRow(
+        name: outcome.name,
+        statusLabel: '仅存原件(未识别到文字)',
+        kind: ImportRowKind.storedNoText,
+      );
+    default:
+      return ImportResultRow(
+        name: outcome.name,
+        statusLabel: '未能处理',
+        kind: ImportRowKind.failed,
+      );
+  }
+}
+
+/// 单份文件处理过程中直接抛异常(读文件失败、FFI 报错等),同样归入失败展示行,
+/// 不让一份文件的问题中断整个批次。
+ImportResultRow rowFromError(String name, Object error) => ImportResultRow(
+  name: name,
+  statusLabel: '导入失败:$error',
+  kind: ImportRowKind.failed,
+);
+
+/// 一张图片识别结果的平均置信度:遍历 blocks→lines→elements,取所有有值的
+/// `element.confidence` 求平均。iOS 端 ML Kit 不提供置信度(全为 null),
+/// 这时回退到一个合理默认值,让「导入」流程照常继续、不因缺置信度而中断。
+double averageMlkitConfidence(RecognizedText recognized) {
+  final values = <double>[];
+  for (final block in recognized.blocks) {
+    for (final line in block.lines) {
+      for (final element in line.elements) {
+        final c = element.confidence;
+        if (c != null) values.add(c);
+      }
+    }
+  }
+  if (values.isEmpty) return 0.9; // iOS 无置信度回退值
+  return values.reduce((a, b) => a + b) / values.length;
+}

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -1,15 +1,271 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_flutter/src/rust/api/dto.dart';
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/theme.dart';
 
-/// 底部导航一级 tab「设置」—— 载入示例数据 / 清空重置 / iCloud 同步 / 加密分享入口 / 关于。
-/// (导出已移到「导入导出」tab,不再放这里。)P3/P5 填充;此处占位。
-class SettingsScreen extends StatelessWidget {
+/// 与 `pubspec.yaml` 的 `version:` 字段保持一致。P3 范围内没有为读版本号新增
+/// `package_info_plus` 依赖(约束里明确不加新依赖),手工同步即可——这颗
+/// 版本号本来就只在“关于”里给人看,不参与任何业务逻辑。
+const _appVersion = '1.0.0';
+
+/// 底部导航一级 tab「设置」—— 载入示例数据 / 清空重置 / iCloud 同步占位 / 关于。
+/// 分组卡片列表,视觉还原自 `apps/mobile/src/App.tsx` 的设置区(sect + group + row)。
+/// 保险箱在 `main.dart` 启动时已打开,这里直接调 FFI,不重复任何 Rust 侧逻辑。
+class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  IcloudStatusDto? _icloud;
+  PatientProfileDto? _profile;
+
+  /// 载入示例 / 清空时置真,禁用所有操作按钮,防止重复点击(尤其清空——
+  /// 用户反馈过「载入示例后清空点了没反应」,这里确保按钮忙时不可再点,
+  /// 而不是悄悄丢弃点击)。
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    try {
+      final results = await Future.wait([icloudStatus(), patientProfile()]);
+      if (!mounted) return;
+      setState(() {
+        _icloud = results[0] as IcloudStatusDto;
+        _profile = results[1] as PatientProfileDto;
+      });
+    } catch (_) {
+      // 状态读取失败不影响本屏其它功能(载入示例/清空仍可用),静默忽略即可。
+    }
+  }
+
+  void _showSnack(String text) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+  }
+
+  Future<void> _loadDemoData() async {
+    setState(() => _busy = true);
+    try {
+      final n = await loadDemoData();
+      await _refresh();
+      _showSnack('已载入 $n 份示例病历,去「健康档案」查看');
+    } catch (e) {
+      _showSnack('载入示例数据失败:$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _confirmAndResetVault() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('清空保险箱?'),
+        content: const Text(
+          '确定清空全部记录?示例数据和已导入的病历都会被删除,'
+          '此操作不可撤销。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: TextButton.styleFrom(foregroundColor: MedMe.danger),
+            child: const Text('清空'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() => _busy = true);
+    try {
+      await resetVault();
+      await _refresh();
+      _showSnack('已清空');
+    } catch (e) {
+      _showSnack('清空失败:$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('设置')),
-      body: const Center(child: Text('设置(P3/P5 实现)')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        children: [
+          _SectionLabel('示例数据'),
+          _SettingsGroup(
+            children: [
+              _SettingsRow(
+                icon: Icons.download_outlined,
+                title: '载入示例数据(张建国)',
+                subtitle: '一键导入一份完整的示例病历,方便你先看看效果、再决定怎么用',
+                onTap: _busy ? null : _loadDemoData,
+              ),
+            ],
+          ),
+          _SectionLabel('数据管理'),
+          _SettingsGroup(
+            children: [
+              _SettingsRow(
+                icon: Icons.delete_outline,
+                title: '清空所有数据 · 重置保险箱',
+                subtitle: '删除全部记录,回到初始空状态',
+                danger: true,
+                onTap: _busy ? null : _confirmAndResetVault,
+              ),
+            ],
+          ),
+          _SectionLabel('iCloud 同步'),
+          _SettingsGroup(
+            children: [
+              _SettingsRow(
+                icon: Icons.cloud_off_outlined,
+                title: 'iCloud 同步',
+                subtitle: _icloudSubtitle(_icloud),
+                trailing: Switch(value: false, onChanged: null),
+              ),
+            ],
+          ),
+          _SectionLabel('关于'),
+          _SettingsGroup(
+            children: [
+              _InfoRow(
+                title: 'MedMe 医我',
+                subtitle: 'v$_appVersion · 本地优先:你的病历只保存在你自己的设备上',
+              ),
+              if (_profile != null)
+                _InfoRow(
+                  title: '已保存记录',
+                  subtitle: '${_profile!.recordCount} 份',
+                ),
+              const _InfoRow(
+                title: '医疗免责声明',
+                subtitle:
+                    'MedMe 是个人病历整理工具,不是医疗器械,不提供诊断或治疗建议;'
+                    '一切以原始医疗文件为准,请遵医嘱。',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _icloudSubtitle(IcloudStatusDto? status) {
+    if (status == null) return '正在查询…';
+    if (!status.available) return '此设备暂不可用,后续版本会支持一键开启同步';
+    if (!status.enabled) return '暂未开启,即将在后续版本支持';
+    return '已开启,自动同步到你的苹果设备';
+  }
+}
+
+/// 分组标题(灰色小字),对应旧版 `App.css` 里的 `.sect`。
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 16, 4, 8),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+          color: MedMe.faint,
+        ),
+      ),
+    );
+  }
+}
+
+/// 白色圆角卡片,内部若干行,行间用分隔线隔开——对应旧版 `.group`。
+class _SettingsGroup extends StatelessWidget {
+  const _SettingsGroup({required this.children});
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: [
+          for (var i = 0; i < children.length; i++) ...[
+            if (i > 0) const Divider(height: 1, color: MedMe.line),
+            children[i],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// 可点击的一行:图标 + 标题 + 说明 + 尾部箭头(或自定义 trailing)。
+/// 对应旧版 `.row`;`danger` 对应 `.row.danger`(清空按钮用 `MedMe.danger`)。
+class _SettingsRow extends StatelessWidget {
+  const _SettingsRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.onTap,
+    this.trailing,
+    this.danger = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+  final bool danger;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = danger ? MedMe.danger : MedMe.ink;
+    return ListTile(
+      leading: Icon(icon, color: danger ? MedMe.danger : MedMe.teal),
+      title: Text(
+        title,
+        style: TextStyle(fontWeight: FontWeight.w600, color: color),
+      ),
+      subtitle: Text(subtitle, style: const TextStyle(color: MedMe.faint)),
+      trailing:
+          trailing ??
+          (onTap != null
+              ? const Icon(Icons.chevron_right, color: MedMe.faint)
+              : null),
+      onTap: onTap,
+      enabled: onTap != null || trailing != null,
+    );
+  }
+}
+
+/// 纯展示的一行(无点击),用于「关于」里的静态信息。
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.title, required this.subtitle});
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+      subtitle: Text(subtitle, style: const TextStyle(color: MedMe.faint)),
     );
   }
 }

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -217,14 +217,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  ffi_leak_tracker:
-    dependency: transitive
-    description:
-      name: ffi_leak_tracker
-      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -237,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: f9245fc33aeba9e0b938d7f3785f10b7a7230e05b8fc40f5a6a8342d7899e391
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "8.3.7"
   file_selector_linux:
     dependency: transitive
     description:
@@ -762,18 +754,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8"
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.0"
+    version: "11.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "6.1.0"
   shelf:
     dependency: transitive
     description:
@@ -991,10 +983,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -40,11 +40,11 @@ dependencies:
   path_provider: ^2.1.6
   freezed_annotation: ^3.1.0
   image_picker: ^1.2.3
-  file_picker: ^3.0.4
+  file_picker: ^8.0.0
   google_mlkit_text_recognition: ^0.16.0
   photo_view: ^0.15.0
   pdfx: ^2.9.2
-  share_plus: ^13.2.0
+  share_plus: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.2.0+1
 
 environment:
   sdk: ^3.12.2
@@ -72,7 +72,7 @@ patrol:
   android:
     package_name: com.medme.mobile_flutter
   ios:
-    bundle_id: com.medme.mobileFlutter
+    bundle_id: com.medme.mobile
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+1
+version: 1.2.0+2
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
Flutter 移动端 P3:三个一级屏全部实现(由三个并行 subagent 在各自 worktree 开发,文件互不相交),合入本集成分支并做集成构建验证。**功能/设计对齐旧 Tauri 移动端,复用同一套 Rust core(经 FRB)**。

## 三屏(原始拆分 PR:#96 设置 / #97 档案+详情 / #98 导入导出,均已并入本分支,可关掉)

### 导入导出屏 `import_export_screen.dart` + `import_helpers.dart`
- 三入口:拍照(image_picker 相机)/ 从相册选(pickMultiImage)/ 选文件(file_picker,pdf·txt·png·jpg·jpeg·tiff·heic)
- 按类型分流:图片→**ML Kit 中文 OCR**(TextRecognizer chinese)→ `ingestImageWithText`;PDF/TXT→`ingestBytes`
- 批量导入进度「i/n」+ 容错 + 按 `ImportOutcomeDto.status` 分类汇总弹窗
- 导出时间线 HTML(`exportTimelineHtml`→系统分享)+ 加密分享给医生(`createShare`,选 7/30/90 天→口令弹窗可复制→分享)

### 档案屏 `archive_screen.dart` + 详情 `document_detail.dart`
- 患者头卡(缺省优雅兜底)+ 时间线(sealed `TimelineGroupDto` 穷尽 pattern matching:就诊组/独立文档)+ 下拉刷新 + 空态引导
- 详情:复用已有 `ReportContent` 渲染识别文本(化验单成表);查看原件按 mimeType 分流 —— 图片(photo_view)/ PDF(pdfx)/ DICOM(renderDicomPng→PNG);不支持格式优雅降级不崩

### 设置屏 `settings_screen.dart`
- 载入示例数据(张建国)/ 清空重置(danger 色 + 二次确认,修好「载入后清不掉」)/ iCloud 只读占位(不做假开关,P5 接)/ 关于

## 我补的共享配置
- **iOS 相机/相册用途声明**(`NSCameraUsageDescription`/`NSPhotoLibraryUsageDescription`)—— 缺了 iOS 点拍照会硬崩,这是真机 blocker。安卓 image_picker/file_picker 走系统 photo picker+SAF,现代安卓无需 manifest 权限。
- 插件地基已先行合入 main(#95):image_picker/file_picker/google_mlkit_text_recognition/photo_view/pdfx/share_plus + iOS 部署目标 15.5 + 模拟器排除 arm64(ML Kit 无模拟器切片)。

## 验证状态(诚实标注)
- ✅ **iOS 模拟器集成构建通过**(三屏 + 全插件 + Rust core 一起链接,本地实测)
- ✅ `flutter analyze` 三屏 + 集成测试 **0 issue**;`dart format` 已跑;`report_content_test.dart` 仍绿
- ⏳ **安卓构建未本地验证**(本机无 Android SDK)—— 待 CI / 真机;Rust core 安卓交叉编译地基 P2 已通
- ⏳ **Patrol 集成测试已写未跑**(`integration_test/{import_export,archive,settings}_test.dart`)—— 需设备/模拟器,由你跑 `patrol test`
- ⚠️ 待办(不阻断本 PR,后续 P4-P7):安卓 HEIC→ML Kit OCR 真机验证;导出按日期区间筛选(P6);iCloud 真同步(P5);出包 + 删旧 Tauri + 改 bundle id com.medme.mobile(P7)

面向不懂电脑的老人:各屏清晰单动作、友好中文、危险操作强确认。