### PR TITLE
fix(mobile): 找回搁浅的 build3 修复(刷新/share/身份卡)

### DIFF
--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -4,6 +4,7 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/screens/document_detail.dart';
+import 'package:mobile_flutter/vault_events.dart';
 
 /// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,按日期倒序,
 /// 点开看详情。与旧 Tauri 移动端 App.tsx 的 archive tab(phead + tl)同一观感,
@@ -122,6 +123,23 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
   late Future<(PatientProfileDto, List<TimelineGroupDto>)> _future = _load();
   // 就诊组在时间线里点开时展开其子文档(可再点开各自详情)。
   final Set<int> _expanded = {};
+
+  @override
+  void initState() {
+    super.initState();
+    // 导入/清空/载入示例后自动重载(本屏在 IndexedStack 里保活,initState 不会重跑)。
+    vaultRevision.addListener(_onVaultChanged);
+  }
+
+  @override
+  void dispose() {
+    vaultRevision.removeListener(_onVaultChanged);
+    super.dispose();
+  }
+
+  void _onVaultChanged() {
+    if (mounted) _refresh();
+  }
 
   Future<(PatientProfileDto, List<TimelineGroupDto>)> _load() async {
     final results = await Future.wait([patientProfile(), loadArchive()]);

--- a/apps/mobile_flutter/lib/screens/import_export_screen.dart
+++ b/apps/mobile_flutter/lib/screens/import_export_screen.dart
@@ -11,6 +11,7 @@ import 'package:mobile_flutter/screens/import_helpers.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/vault_events.dart';
 
 /// 底部导航一级 tab「导入导出」——采集(拍照 / 相册 / 选文件)+
 /// 导出(时间线 HTML)/ 加密分享给医生。保险箱在 `main.dart` 启动时已打开,
@@ -73,6 +74,17 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
   /// 图片先用 ML Kit 中文 OCR 识别文字,再连同字节交给 `ingestImageWithText`;
   /// PDF/TXT 直传字节给 `ingestBytes`(按原始文件名后缀判 MIME)。单份文件
   /// 处理失败不影响其余文件继续导入。
+  /// iOS 的分享面板(尤其 iPad)必须知道从哪个位置弹出(popover 锚点矩形),
+  /// 否则 `SharePlus` 抛 `argument must be set {{0,0},{0,0}} must be non-zero`。
+  /// 用本屏的渲染框作锚点,保证是非零矩形。
+  Rect _shareOrigin() {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box != null && box.hasSize && !box.size.isEmpty) {
+      return box.localToGlobal(Offset.zero) & box.size;
+    }
+    return const Rect.fromLTWH(0, 0, 1, 1);
+  }
+
   Future<void> _importItems(List<PendingImport> items) async {
     setState(() {
       _busy = true;
@@ -110,6 +122,11 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       }
     }
     await recognizer?.close();
+
+    // 有任何一份成功落库(新增或降级存档),通知「健康档案」屏自动刷新看到新记录。
+    if (rows.any((r) => r.kind != ImportRowKind.failed)) {
+      bumpVaultRevision();
+    }
 
     if (!mounted) return;
     setState(() {
@@ -244,7 +261,11 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
         _progress = null;
       });
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(result.path)], subject: 'MedMe 病历时间线导出'),
+        ShareParams(
+          files: [XFile(result.path)],
+          subject: 'MedMe 病历时间线导出',
+          sharePositionOrigin: _shareOrigin(),
+        ),
       );
     } catch (e) {
       if (!mounted) return;
@@ -412,7 +433,11 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
             label: const Text('分享文件'),
             onPressed: () async {
               await SharePlus.instance.share(
-                ShareParams(files: [XFile(result.path)], subject: 'MedMe 加密病历'),
+                ShareParams(
+                  files: [XFile(result.path)],
+                  subject: 'MedMe 加密病历',
+                  sharePositionOrigin: _shareOrigin(),
+                ),
               );
             },
           ),

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/vault_events.dart';
 
 /// 与 `pubspec.yaml` 的 `version:` 字段保持一致。P3 范围内没有为读版本号新增
 /// `package_info_plus` 依赖(约束里明确不加新依赖),手工同步即可——这颗
 /// 版本号本来就只在“关于”里给人看,不参与任何业务逻辑。
-const _appVersion = '1.0.0';
+const _appVersion = '1.2.0';
 
 /// 底部导航一级 tab「设置」—— 载入示例数据 / 清空重置 / iCloud 同步占位 / 关于。
 /// 分组卡片列表,视觉还原自 `apps/mobile/src/App.tsx` 的设置区(sect + group + row)。
@@ -31,6 +32,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void initState() {
     super.initState();
     _refresh();
+    // 导入/清空等在别的 tab 发生时,身份卡的记录数等也要跟着更新(本屏保活)。
+    vaultRevision.addListener(_refresh);
+  }
+
+  @override
+  void dispose() {
+    vaultRevision.removeListener(_refresh);
+    super.dispose();
   }
 
   Future<void> _refresh() async {
@@ -55,6 +64,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _busy = true);
     try {
       final n = await loadDemoData();
+      bumpVaultRevision(); // 通知「健康档案」屏自动重载
       await _refresh();
       _showSnack('已载入 $n 份示例病历,去「健康档案」查看');
     } catch (e) {
@@ -91,6 +101,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _busy = true);
     try {
       await resetVault();
+      bumpVaultRevision(); // 通知「健康档案」屏自动清空重载
       await _refresh();
       _showSnack('已清空');
     } catch (e) {
@@ -107,6 +118,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
         children: [
+          _SectionLabel('当前健康档案'),
+          _ProfileHeader(profile: _profile),
           _SectionLabel('示例数据'),
           _SettingsGroup(
             children: [
@@ -148,11 +161,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: 'MedMe 医我',
                 subtitle: 'v$_appVersion · 本地优先:你的病历只保存在你自己的设备上',
               ),
-              if (_profile != null)
-                _InfoRow(
-                  title: '已保存记录',
-                  subtitle: '${_profile!.recordCount} 份',
-                ),
               const _InfoRow(
                 title: '医疗免责声明',
                 subtitle:
@@ -171,6 +179,73 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (!status.available) return '此设备暂不可用,后续版本会支持一键开启同步';
     if (!status.enabled) return '暂未开启,即将在后续版本支持';
     return '已开启,自动同步到你的苹果设备';
+  }
+}
+
+/// 身份卡:顶部醒目展示「这是谁的健康档案」——姓名 + 性别·年龄 + 记录数。
+/// 让用户清楚当前档案属于谁(为后续家庭多成员/共享方案铺路)。姓名等来自
+/// `patientProfile()`(据已导入病历推断);空库时给友好占位。
+class _ProfileHeader extends StatelessWidget {
+  const _ProfileHeader({required this.profile});
+  final PatientProfileDto? profile;
+
+  @override
+  Widget build(BuildContext context) {
+    final p = profile;
+    final rawName = p?.name;
+    final gender = p?.gender;
+    final age = p?.age;
+    final hasName = rawName != null && rawName.isNotEmpty;
+    final hasRecords = p != null && p.recordCount > 0;
+    final name = hasName ? rawName : (hasRecords ? '未命名档案' : '还没有健康档案');
+    final meta = <String>[
+      if (gender != null && gender.isNotEmpty) gender,
+      if (age != null && age.isNotEmpty) age,
+      if (p != null) '${p.recordCount} 份记录',
+    ].join(' · ');
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 26,
+              backgroundColor: MedMe.tealSoft,
+              child: const Icon(Icons.person, color: MedMe.teal, size: 30),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                      color: MedMe.ink,
+                    ),
+                  ),
+                  if (meta.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      meta,
+                      style: const TextStyle(fontSize: 13, color: MedMe.faint),
+                    ),
+                  ],
+                  const SizedBox(height: 6),
+                  const Text(
+                    '当前设备上的这份档案 · 多成员切换即将支持',
+                    style: TextStyle(fontSize: 11.5, color: MedMe.faint),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile_flutter/lib/vault_events.dart
+++ b/apps/mobile_flutter/lib/vault_events.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+/// 保险箱内容变更的全局信号。导入、清空、载入示例后调用 [bumpVaultRevision]，
+/// 监听者(尤其「健康档案」屏)据此重新加载。
+///
+/// 为什么需要:底部三 tab 用 `IndexedStack` 承载,切走的屏会**保活**(state 不销毁),
+/// 所以在「设置」里清空、或在「导入导出」里导入后,「健康档案」屏的 `initState` 不会
+/// 再跑一次 → 切回去还是旧数据,用户以为没生效。让档案屏监听这个信号即可自动刷新。
+final ValueNotifier<int> vaultRevision = ValueNotifier<int>(0);
+
+/// 保险箱内容变了(导入/清空/载入示例),通知所有监听屏重载。
+void bumpVaultRevision() => vaultRevision.value++;

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+2
+version: 1.2.0+3
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
#99 squash 只合到 build2,build3 三处 iOS 实测修复搁浅。只捡回 mobile_flutter lib+pubspec,不碰桌面(避免冲掉已合的 #86/87/88)。analyze 干净。