### PR TITLE
feat(mobile): P6 导出按日期区间筛选

### DIFF
--- a/apps/mobile_flutter/lib/screens/import_export_screen.dart
+++ b/apps/mobile_flutter/lib/screens/import_export_screen.dart
@@ -221,30 +221,102 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
   );
 
   // ---------------------------------------------------------------------
-  // 导出时间线(未加密 HTML)。P6 才做日期区间筛选——FFI 目前无日期参数,
-  // 这里如实全量导出,并在说明里提前告知,不做假的日期选择器。
+  // 导出时间线(未加密 HTML),支持可选的日期区间筛选(留空=全部记录)。
   // ---------------------------------------------------------------------
 
+  static String _ymd(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
   Future<void> _exportTimeline() async {
+    DateTime? from;
+    DateTime? to;
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('导出时间线'),
-        content: const Text(
-          '导出完整病历时间线为可打印文件(HTML),未加密,用浏览器打开后可直接打印或另存为 PDF,'
-          '适合报销或给医生留档。\n\n当前导出的是全部记录;按时间段筛选导出即将支持。',
-          style: TextStyle(fontSize: 13.5, height: 1.5),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('取消'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('导出并分享'),
-          ),
-        ],
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialog) {
+          Future<void> pickDate(bool isFrom) async {
+            final now = DateTime.now();
+            final picked = await showDatePicker(
+              context: context,
+              initialDate: (isFrom ? from : to) ?? now,
+              firstDate: DateTime(1970),
+              lastDate: DateTime(now.year + 1),
+            );
+            if (picked != null) {
+              setDialog(() => isFrom ? from = picked : to = picked);
+            }
+          }
+
+          return AlertDialog(
+            title: const Text('导出时间线'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '导出病历时间线为可打印文件(HTML),未加密,用浏览器打开后可直接打印或另存为 PDF,适合报销或给医生留档。',
+                  style: TextStyle(
+                    fontSize: 13.5,
+                    height: 1.5,
+                    color: MedMe.faint,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '时间范围(可选,留空即导出全部)',
+                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => pickDate(true),
+                        child: Text('从:${from == null ? '不限' : _ymd(from!)}'),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => pickDate(false),
+                        child: Text('到:${to == null ? '不限' : _ymd(to!)}'),
+                      ),
+                    ),
+                  ],
+                ),
+                if (from != null || to != null)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () => setDialog(() {
+                        from = null;
+                        to = null;
+                      }),
+                      child: const Text('清除范围'),
+                    ),
+                  ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('取消'),
+              ),
+              FilledButton(
+                onPressed: () {
+                  if (from != null && to != null && from!.isAfter(to!)) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('起始日期不能晚于结束日期')),
+                    );
+                    return;
+                  }
+                  Navigator.of(context).pop(true);
+                },
+                child: const Text('导出并分享'),
+              ),
+            ],
+          );
+        },
       ),
     );
     if (confirmed != true) return;
@@ -254,7 +326,10 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       _progress = '正在生成导出文件…';
     });
     try {
-      final result = await exportTimelineHtml();
+      final result = await exportTimelineHtml(
+        fromDate: from == null ? null : _ymd(from!),
+        toDate: to == null ? null : _ymd(to!),
+      );
       if (!mounted) return;
       setState(() {
         _busy = false;

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -104,13 +104,20 @@ Future<ImportOutcomeDto> ingestImageWithText({
 Future<ShareResultDto> createShare({required PlatformInt64 expiresDays}) =>
     RustLib.instance.api.crateApiVaultCreateShare(expiresDays: expiresDays);
 
-/// 导出时间线:复用 `medme_share::export::build_timeline_html`,把整条时间线
+/// 导出时间线:复用 `medme_share::export::build_timeline_html_ranged`,把时间线
 /// 渲染成未加密、可打印的自包含 HTML 写进保险箱 `shares/` 目录(与加密分享共用
-/// 同一目录——都是本机生成、交给系统分享 sheet 的临时导出件)。**日期区间筛选
-/// 留给 P6**——本阶段全量导出,与当前 `medme_share::export::build_timeline_html`
-/// 的签名(无日期参数)一致。
-Future<ExportResultDto> exportTimelineHtml() =>
-    RustLib.instance.api.crateApiVaultExportTimelineHtml();
+/// 同一目录——都是本机生成、交给系统分享 sheet 的临时导出件)。
+///
+/// `from_date` / `to_date` 为可选的 `YYYY-MM-DD`(前端日期选择器传入);任一为空
+/// 表示该侧不限,两者都为空即全量导出。`from` 取当天 00:00、`to` 取当天 23:59:59
+/// (含端点)。无 `doc_date` 的记录仅在完全不筛选时纳入(见共享 crate 的说明)。
+Future<ExportResultDto> exportTimelineHtml({
+  String? fromDate,
+  String? toDate,
+}) => RustLib.instance.api.crateApiVaultExportTimelineHtml(
+  fromDate: fromDate,
+  toDate: toDate,
+);
 
 /// 一键「载入示例数据」:把编译进本 crate 的张建国示例病历(见 `DEMO_DATA`)
 /// 批量导入保险箱,让测试者无需手动选文件就能看到 健康档案。按路径排序保证

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -84,7 +84,10 @@ abstract class RustLibApi extends BaseApi {
     required PlatformInt64 expiresDays,
   });
 
-  Future<ExportResultDto> crateApiVaultExportTimelineHtml();
+  Future<ExportResultDto> crateApiVaultExportTimelineHtml({
+    String? fromDate,
+    String? toDate,
+  });
 
   Future<DocumentDetailDto> crateApiVaultGetDocument({
     required PlatformInt64 id,
@@ -170,11 +173,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "create_share", argNames: ["expiresDays"]);
 
   @override
-  Future<ExportResultDto> crateApiVaultExportTimelineHtml() {
+  Future<ExportResultDto> crateApiVaultExportTimelineHtml({
+    String? fromDate,
+    String? toDate,
+  }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_opt_String(fromDate, serializer);
+          sse_encode_opt_String(toDate, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -187,14 +195,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiVaultExportTimelineHtmlConstMeta,
-        argValues: [],
+        argValues: [fromDate, toDate],
         apiImpl: this,
       ),
     );
   }
 
   TaskConstMeta get kCrateApiVaultExportTimelineHtmlConstMeta =>
-      const TaskConstMeta(debugName: "export_timeline_html", argNames: []);
+      const TaskConstMeta(
+        debugName: "export_timeline_html",
+        argNames: ["fromDate", "toDate"],
+      );
 
   @override
   Future<DocumentDetailDto> crateApiVaultGetDocument({

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+3
+version: 1.2.0+4
 
 environment:
   sdk: ^3.12.2

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -134,7 +134,8 @@ pub fn open_vault(docs_dir: String, data_dir: String, icloud_enabled: bool) -> a
 pub fn load_archive() -> anyhow::Result<Vec<TimelineGroupDto>> {
     with_state(|state| {
         let v = &state.vault;
-        v.rebuild_encounters().map_err(|e| anyhow::anyhow!(e.to_string()))?; // 幂等
+        v.rebuild_encounters()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?; // 幂等
         let mut groups: Vec<(Option<String>, TimelineGroupDto)> = Vec::new();
         for (enc, docs) in v
             .encounters_with_docs()
@@ -307,7 +308,8 @@ pub fn ingest_file(path: String) -> anyhow::Result<ImportOutcomeDto> {
     with_state(|state| {
         let v = &state.vault;
         let outcome = ingest_one(v, Path::new(&path));
-        v.rebuild_encounters().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        v.rebuild_encounters()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(outcome)
     })
 }
@@ -340,17 +342,15 @@ pub fn ingest_bytes(filename: String, data: Vec<u8>) -> anyhow::Result<ImportOut
 
     with_state(|state| {
         let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S%f");
-        let tmp_dir = state
-            .data_dir
-            .join("medme-ingest")
-            .join(stamp.to_string());
+        let tmp_dir = state.data_dir.join("medme-ingest").join(stamp.to_string());
         std::fs::create_dir_all(&tmp_dir)?;
         let tmp_path = tmp_dir.join(&safe_name);
         std::fs::write(&tmp_path, &data)?;
 
         let v = &state.vault;
         let outcome = ingest_one(v, &tmp_path);
-        v.rebuild_encounters().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        v.rebuild_encounters()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let _ = std::fs::remove_dir_all(&tmp_dir); // 尽力清理,失败无妨
         Ok(outcome)
     })
@@ -399,7 +399,8 @@ pub fn ingest_image_with_text(
         let sid = imp.source_file.id;
 
         let outcome = if imp.deduped
-            && v.has_document(sid).map_err(|e| anyhow::anyhow!(e.to_string()))?
+            && v.has_document(sid)
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?
         {
             ImportOutcomeDto {
                 name: safe_name.clone(),
@@ -460,7 +461,8 @@ pub fn ingest_image_with_text(
                 }
             }
         };
-        v.rebuild_encounters().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        v.rebuild_encounters()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(outcome)
     })
 }
@@ -503,17 +505,45 @@ pub fn create_share(expires_days: i64) -> anyhow::Result<ShareResultDto> {
     })
 }
 
-/// 导出时间线:复用 `medme_share::export::build_timeline_html`,把整条时间线
+/// 导出时间线:复用 `medme_share::export::build_timeline_html_ranged`,把时间线
 /// 渲染成未加密、可打印的自包含 HTML 写进保险箱 `shares/` 目录(与加密分享共用
-/// 同一目录——都是本机生成、交给系统分享 sheet 的临时导出件)。**日期区间筛选
-/// 留给 P6**——本阶段全量导出,与当前 `medme_share::export::build_timeline_html`
-/// 的签名(无日期参数)一致。
-pub fn export_timeline_html() -> anyhow::Result<ExportResultDto> {
+/// 同一目录——都是本机生成、交给系统分享 sheet 的临时导出件)。
+///
+/// `from_date` / `to_date` 为可选的 `YYYY-MM-DD`(前端日期选择器传入);任一为空
+/// 表示该侧不限,两者都为空即全量导出。`from` 取当天 00:00、`to` 取当天 23:59:59
+/// (含端点)。无 `doc_date` 的记录仅在完全不筛选时纳入(见共享 crate 的说明)。
+pub fn export_timeline_html(
+    from_date: Option<String>,
+    to_date: Option<String>,
+) -> anyhow::Result<ExportResultDto> {
+    let parse = |s: &str, end_of_day: bool| -> anyhow::Result<chrono::DateTime<chrono::Utc>> {
+        let d = chrono::NaiveDate::parse_from_str(s.trim(), "%Y-%m-%d")
+            .map_err(|e| anyhow::anyhow!("日期格式应为 YYYY-MM-DD:{e}"))?;
+        let t = if end_of_day {
+            d.and_hms_opt(23, 59, 59)
+        } else {
+            d.and_hms_opt(0, 0, 0)
+        }
+        .ok_or_else(|| anyhow::anyhow!("无效日期"))?;
+        Ok(t.and_utc())
+    };
+    let from = from_date
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| parse(s, false))
+        .transpose()?;
+    let to = to_date
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| parse(s, true))
+        .transpose()?;
     with_state(|state| {
         let v = &state.vault;
-        let (html, record_count) = medme_share::export::build_timeline_html(
+        let (html, record_count) = medme_share::export::build_timeline_html_ranged(
             v,
             &medme_share::render_dicom_png_in_process,
+            from,
+            to,
         )
         .map_err(|e| anyhow::anyhow!(e))?;
         let byte_size = html.len() as i64;
@@ -536,10 +566,7 @@ pub fn export_timeline_html() -> anyhow::Result<ExportResultDto> {
 }
 
 /// 递归收集 `include_dir!` 打进二进制的示例数据集里的全部文件。
-fn collect_demo_files<'a>(
-    dir: &'a include_dir::Dir<'a>,
-    out: &mut Vec<&'a include_dir::File<'a>>,
-) {
+fn collect_demo_files<'a>(dir: &'a include_dir::Dir<'a>, out: &mut Vec<&'a include_dir::File<'a>>) {
     out.extend(dir.files());
     for sub in dir.dirs() {
         collect_demo_files(sub, out);
@@ -577,7 +604,9 @@ pub fn load_demo_data() -> anyhow::Result<i64> {
             }));
             match result {
                 Ok(Ok(_)) => count += 1,
-                Ok(Err(e)) => eprintln!("[demo-data] ingest failed for {}: {e}", tmp_path.display()),
+                Ok(Err(e)) => {
+                    eprintln!("[demo-data] ingest failed for {}: {e}", tmp_path.display())
+                }
                 Err(_) => eprintln!(
                     "[demo-data] ingest panicked (isolated) for {}",
                     tmp_path.display()
@@ -585,7 +614,8 @@ pub fn load_demo_data() -> anyhow::Result<i64> {
             }
         }
         let _ = std::fs::remove_dir_all(&tmp_root); // 尽力清理,失败无妨
-        v.rebuild_encounters().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        v.rebuild_encounters()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(count)
     })
 }
@@ -605,8 +635,9 @@ pub fn reset_vault() -> anyhow::Result<()> {
         if state.db_path.exists() && !state.db_path.starts_with(&state.truth_root) {
             std::fs::remove_file(&state.db_path)?;
         }
-        let fresh = Vault::open_split_resilient(&state.truth_root, &state.db_path, &state.device_id)
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let fresh =
+            Vault::open_split_resilient(&state.truth_root, &state.db_path, &state.device_id)
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         state.vault = fresh; // 旧 Vault(连接/日志句柄)在此被 drop
         Ok(())
     })

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -103,11 +103,14 @@ fn wire__crate__api__vault__export_timeline_html_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_from_date = <Option<String>>::sse_decode(&mut deserializer);
+            let api_to_date = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::vault::export_timeline_html()?;
+                        let output_ok =
+                            crate::api::vault::export_timeline_html(api_from_date, api_to_date)?;
                         Ok(output_ok)
                     })(),
                 )

--- a/packages/share/src/export.rs
+++ b/packages/share/src/export.rs
@@ -156,7 +156,26 @@ pub fn build_timeline_html(
     vault: &Vault,
     render_dicom_png: crate::DicomPngRenderer,
 ) -> Result<(String, i64), String> {
-    let records = gather_records(vault)?;
+    build_timeline_html_ranged(vault, render_dicom_png, None, None)
+}
+
+/// 与 [`build_timeline_html`] 相同,但只导出 `doc_date` 落在 `[from, to]`(含端点)
+/// 区间内的记录。`from`/`to` 任一为 `None` 表示该侧不限;两者都为 `None` 即全量
+/// (等价于 [`build_timeline_html`])。**无 `doc_date` 的记录仅在完全不筛选时纳入**
+/// ——一旦指定了任一端点,无日期记录无法归入区间,予以排除(行为可预期)。
+pub fn build_timeline_html_ranged(
+    vault: &Vault,
+    render_dicom_png: crate::DicomPngRenderer,
+    from: Option<chrono::DateTime<chrono::Utc>>,
+    to: Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<(String, i64), String> {
+    let records: Vec<GatheredRecord> = gather_records(vault)?
+        .into_iter()
+        .filter(|rec| match rec.doc.doc_date {
+            Some(d) => from.is_none_or(|f| d >= f) && to.is_none_or(|t| d <= t),
+            None => from.is_none() && to.is_none(),
+        })
+        .collect();
     let profile = pipeline::patient_profile(vault).map_err(|e| e.to_string())?;
 
     let mut body = String::new();
@@ -306,6 +325,49 @@ mod tests {
         assert!(html.contains("化验")); // 类型徽标
         assert!(html.contains("本导出由 MedMe 生成"));
         assert!(html.starts_with("<!doctype html>"));
+    }
+
+    #[test]
+    fn ranged_export_filters_by_doc_date() {
+        use chrono::TimeZone;
+        let dir = tempfile::tempdir().unwrap();
+        let vault = Vault::open(dir.path()).unwrap();
+        let mk = |name: &str, date: Option<chrono::DateTime<chrono::Utc>>| {
+            let imp = vault.import(name, "text/plain", name.as_bytes()).unwrap();
+            vault
+                .add_document(NewDocument {
+                    source_file_id: imp.source_file.id,
+                    doc_type: DocType::LabReport,
+                    doc_date: date,
+                    doc_date_end: None,
+                    title: Some(name.into()),
+                    language: None,
+                    page_count: 1,
+                })
+                .unwrap();
+        };
+        let d = |y, m, day| chrono::Utc.with_ymd_and_hms(y, m, day, 12, 0, 0).unwrap();
+        mk("old.txt", Some(d(2020, 1, 1)));
+        mk("mid.txt", Some(d(2023, 6, 15)));
+        mk("new.txt", Some(d(2025, 1, 1)));
+        mk("nodate.txt", None);
+
+        let r = &crate::render_dicom_png_in_process;
+        // 全量(不筛选):4 份,含无日期
+        let (_, all) = build_timeline_html_ranged(&vault, r, None, None).unwrap();
+        assert_eq!(all, 4);
+        // 区间 [2023-01-01, 2024-01-01]:只 mid 命中;无日期记录被排除
+        let (html, n) =
+            build_timeline_html_ranged(&vault, r, Some(d(2023, 1, 1)), Some(d(2024, 1, 1)))
+                .unwrap();
+        assert_eq!(n, 1);
+        assert!(html.contains("mid.txt"));
+        assert!(!html.contains("old.txt"));
+        assert!(!html.contains("nodate.txt"));
+        // 只给起点 2024-01-01:仅 new 命中
+        let (_, from_only) =
+            build_timeline_html_ranged(&vault, r, Some(d(2024, 1, 1)), None).unwrap();
+        assert_eq!(from_only, 1);
     }
 
     #[test]


### PR DESCRIPTION
共享 crate 加 ranged 变体(旧函数委托,桌面零影响)+ FFI 日期参数 + 导出对话框日期选择器 + 单元测试。cargo test/clippy/fmt + flutter analyze 全过。