### PR TITLE
feat(mobile): P5 iCloud 同步(代码完整;阻断:待分配 iCloud 容器)

### DIFF
--- a/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -695,6 +696,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -721,6 +723,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/apps/mobile_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/mobile_flutter/ios/Runner/AppDelegate.swift
@@ -14,3 +14,47 @@ import UIKit
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }
+
+// MARK: - iCloud ubiquity-container bridge (iOS only)
+//
+// 保险箱「真相」(objects/ + log/)可存进本 App 的 iCloud ubiquity 容器,在用户的
+// 苹果设备间同步;medme.db 留在沙盒本地、从日志重建。这里用 `@_cdecl` 暴露 Rust 需要
+// 的两个系统调用为纯 C-ABI 符号——Runner target 编译本文件、链接 Rust 静态库,Rust
+// 的 `extern "C"`(见 rust/src/icloud.rs)在同一二进制里直接解析到这些符号,无需插件。
+// 从旧 Tauri 版 `apps/mobile/.../ICloud.swift` 逐字移植(机制完全一致)。
+
+/// 解析本 App 的 iCloud ubiquity 容器,返回其 POSIX 路径(malloc 的 C 字符串,调用方
+/// 用 `medme_icloud_free` 释放)。iCloud 不可用/未登录/容器无法配置时返回 null。
+/// `url(forUbiquityContainerIdentifier:)` 是阻塞 I/O,绝不能在主线程跑,故切后台队列
+/// 用信号量等结果(调用方是同步 FFI)。传 nil 选取第一个 ubiquity-container 授权值。
+@_cdecl("medme_icloud_container_path")
+public func medme_icloud_container_path() -> UnsafeMutablePointer<CChar>? {
+  var resolved: String?
+  let sem = DispatchSemaphore(value: 0)
+  DispatchQueue.global(qos: .userInitiated).async {
+    resolved = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.path
+    sem.signal()
+  }
+  sem.wait()
+  guard let path = resolved, !path.isEmpty else { return nil }
+  return path.withCString { strdup($0) }
+}
+
+/// 尽力触发一个被逐出(dataless)的 iCloud 项目下载,好让随后的读取能看到字节。
+/// 返回是否成功发起下载请求(下载本身是异步的)。
+@_cdecl("medme_icloud_ensure_downloaded")
+public func medme_icloud_ensure_downloaded(_ pathC: UnsafePointer<CChar>) -> Bool {
+  let url = URL(fileURLWithPath: String(cString: pathC))
+  do {
+    try FileManager.default.startDownloadingUbiquitousItem(at: url)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/// 释放 `medme_icloud_container_path` 返回的缓冲区(strdup 用 malloc 分配)。
+@_cdecl("medme_icloud_free")
+public func medme_icloud_free(_ ptr: UnsafeMutablePointer<CChar>?) {
+  if let ptr = ptr { free(ptr) }
+}

--- a/apps/mobile_flutter/ios/Runner/Runner.entitlements
+++ b/apps/mobile_flutter/ios/Runner/Runner.entitlements
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- 保险箱真相(objects/ + log/)经本 App 的 iCloud ubiquity 容器在苹果设备间同步。
+	     容器 id 必须与 App ID(Team 49G34P23QP,bundle com.medme.mobile)上启用的一致。
+	     medme.db 不同步——留在沙盒本地、从日志重建。icloud-services=CloudDocuments 是
+	     FileManager.url(forUbiquityContainerIdentifier:) 在真机解析出真实 POSIX 路径所必需。
+	     与旧 Tauri 版 entitlements 完全一致(同一容器 iCloud.com.medme.mobile)。 -->
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.medme.mobile</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.medme.mobile</string>
+	</array>
+</dict>
+</plist>

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -143,14 +143,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ],
           ),
-          _SectionLabel('iCloud 同步'),
+          _SectionLabel('iCloud 同步(实验性)'),
           _SettingsGroup(
             children: [
               _SettingsRow(
-                icon: Icons.cloud_off_outlined,
+                icon: (_icloud?.enabled ?? false)
+                    ? Icons.cloud_done_outlined
+                    : Icons.cloud_outlined,
                 title: 'iCloud 同步',
                 subtitle: _icloudSubtitle(_icloud),
-                trailing: Switch(value: false, onChanged: null),
+                trailing: Switch(
+                  value: _icloud?.enabled ?? false,
+                  onChanged: (_busy || _icloud == null || !_icloud!.available)
+                      ? null
+                      : _toggleIcloud,
+                ),
               ),
             ],
           ),
@@ -176,9 +183,54 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   String _icloudSubtitle(IcloudStatusDto? status) {
     if (status == null) return '正在查询…';
-    if (!status.available) return '此设备暂不可用,后续版本会支持一键开启同步';
-    if (!status.enabled) return '暂未开启,即将在后续版本支持';
-    return '已开启,自动同步到你的苹果设备';
+    if (!status.available) {
+      return '请先在系统「设置」登录 iCloud 并开启 iCloud 云盘,再回来开启同步';
+    }
+    if (!status.enabled) return '开启后病历会同步到你其它苹果设备(实验性,建议先备份)';
+    return '已开启,病历会自动同步到你的苹果设备';
+  }
+
+  Future<void> _toggleIcloud(bool want) async {
+    if (want) {
+      final ok = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('开启 iCloud 同步?'),
+          content: const Text(
+            '会把你的病历(真相数据)搬进本 App 的 iCloud 空间,在你登录同一 Apple ID 的'
+            '苹果设备间自动同步;数据库仍留在本机。\n\n这是实验性功能,建议先用「导出」备份一份。',
+            style: TextStyle(fontSize: 13.5, height: 1.5),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('开启'),
+            ),
+          ],
+        ),
+      );
+      if (ok != true) return;
+    }
+
+    setState(() => _busy = true);
+    try {
+      if (want) {
+        await enableIcloudSync();
+      } else {
+        await disableIcloudSync();
+      }
+      bumpVaultRevision(); // 保险箱已重开,通知档案屏刷新
+      await _refresh();
+      _showSnack(want ? '已开启 iCloud 同步' : '已关闭(本机保留一份副本)');
+    } catch (e) {
+      _showSnack('操作失败:$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
   }
 }
 

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -7,19 +7,19 @@ import '../frb_generated.dart';
 import 'dto.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `doc_summary`, `ingest_one`, `machine_device_id`, `vault_cell`, `with_state_mut`, `with_state`
+// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `doc_summary`, `ingest_one`, `machine_device_id`, `open_resilient_with_fallback`, `resolve_vault_paths`, `vault_cell`, `with_state_mut`, `with_state`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultState`
 
-/// 打开(或新建)保险箱。**P2:先不接 iCloud 真逻辑**——`icloud_enabled` 参数按
-/// 设计文档留着(签名与 `docs/020_Flutter_Mobile_Rewrite.md` 一致),但本阶段一律
-/// 打开本机沙盒保险箱 `<docs_dir>/vault`,与该参数取值无关。真正的「真相根据
-/// iCloud 开关搬进容器」逻辑(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`,
-/// iOS-only 且依赖 Tauri 路径 API,不能直接照搬)留给 P5。
+/// 打开(或新建)保险箱。`icloud_enabled` 参数保留(签名稳定),但「是否用 iCloud
+/// 布局」以持久标记 `<data_dir>/icloud_enabled` 为准(由 `enable_icloud_sync` /
+/// `disable_icloud_sync` 写/删)——好在跨启动时记住用户选择,与旧 Tauri 版一致。
 ///
-/// `docs_dir` 对应 Tauri 版的 `app.path().document_dir()`(沙盒 Documents,
-/// 保险箱 truth 的默认落点);`data_dir` 对应 `app.path().app_data_dir()`
-/// (设备 id + 一次性导入临时文件的落点)。两者都由 Flutter 端解析平台路径后传入
-/// ——FRB crate 本身不含任何路径插件。
+/// 开了 iCloud 且容器可用 → 真相在 iCloud 容器 `<container>/Documents/vault`、派生库
+/// 在沙盒;否则本机 `<docs_dir>/vault`。在解析出的 truth_root 打开失败(如 iCloud
+/// 不可用/未登录)则回退本机沙盒保险箱,绝不因 iCloud 问题而开库失败。
+///
+/// `docs_dir` = 沙盒 Documents(本机保险箱 truth 落点);`data_dir` = App data 目录
+/// (设备 id + iCloud 标记 + 一次性导入临时文件的落点)。两者由 Flutter 端解析后传入。
 Future<void> openVault({
   required String docsDir,
   required String dataDir,
@@ -142,3 +142,17 @@ Future<void> resetVault() => RustLib.instance.api.crateApiVaultResetVault();
 /// (见 `docs/020_Flutter_Mobile_Rewrite.md` 的「同步(iCloud,iOS)」一节)。
 Future<IcloudStatusDto> icloudStatus() =>
     RustLib.instance.api.crateApiVaultIcloudStatus();
+
+/// 开启 iCloud 同步(仅 iOS 真机有效):把保险箱「真相」迁进 iCloud 容器
+/// `<container>/Documents/vault`,派生库留沙盒,写持久标记。迁移用 core-model
+/// `relocate_to`(搬 objects/log/db/VERSION;若容器里已有别的设备建好的 vault 则
+/// adopt+merge)——与旧 Tauri 版 `enable_icloud_sync` 同一套经过验证的安全操作。
+/// iCloud 不可用/未登录返回人性化错误且不改动当前保险箱。幂等。
+Future<void> enableIcloudSync() =>
+    RustLib.instance.api.crateApiVaultEnableIcloudSync();
+
+/// 关闭 iCloud 同步:把真相从容器**复制**回本机 `<docs_dir>/vault`(容器副本保留不动
+/// ——其它苹果设备若仍开着同步不受影响,也留云端备份;用 `copy_to` 只复制不删源),
+/// 本地重开派生库,清标记 + 清沙盒 iCloud 派生库。幂等,失败不改动当前保险箱。
+Future<void> disableIcloudSync() =>
+    RustLib.instance.api.crateApiVaultDisableIcloudSync();

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1829958053;
+  int get rustContentHash => 665745695;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -83,6 +83,10 @@ abstract class RustLibApi extends BaseApi {
   Future<ShareResultDto> crateApiVaultCreateShare({
     required PlatformInt64 expiresDays,
   });
+
+  Future<void> crateApiVaultDisableIcloudSync();
+
+  Future<void> crateApiVaultEnableIcloudSync();
 
   Future<ExportResultDto> crateApiVaultExportTimelineHtml({
     String? fromDate,
@@ -173,6 +177,60 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "create_share", argNames: ["expiresDays"]);
 
   @override
+  Future<void> crateApiVaultDisableIcloudSync() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultDisableIcloudSyncConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultDisableIcloudSyncConstMeta =>
+      const TaskConstMeta(debugName: "disable_icloud_sync", argNames: []);
+
+  @override
+  Future<void> crateApiVaultEnableIcloudSync() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultEnableIcloudSyncConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultEnableIcloudSyncConstMeta =>
+      const TaskConstMeta(debugName: "enable_icloud_sync", argNames: []);
+
+  @override
   Future<ExportResultDto> crateApiVaultExportTimelineHtml({
     String? fromDate,
     String? toDate,
@@ -186,7 +244,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 4,
             port: port_,
           );
         },
@@ -219,7 +277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 5,
             port: port_,
           );
         },
@@ -244,7 +302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -269,7 +327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 7,
             port: port_,
           );
         },
@@ -301,7 +359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 8,
             port: port_,
           );
         },
@@ -331,7 +389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 9,
             port: port_,
           );
         },
@@ -367,7 +425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 10,
             port: port_,
           );
         },
@@ -397,7 +455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 11,
             port: port_,
           );
         },
@@ -424,7 +482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 12,
             port: port_,
           );
         },
@@ -451,7 +509,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 13,
             port: port_,
           );
         },
@@ -485,7 +543,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 14,
             port: port_,
           );
         },
@@ -514,7 +572,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 15,
             port: port_,
           );
         },
@@ -542,7 +600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 16,
             port: port_,
           );
         },
@@ -570,7 +628,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 17,
             port: port_,
           );
         },
@@ -597,7 +655,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 18,
             port: port_,
           );
         },
@@ -625,7 +683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 19,
             port: port_,
           );
         },

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+5
+version: 1.2.0+6
 
 environment:
   sdk: ^3.12.2

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -29,11 +29,14 @@ static DEMO_DATA: include_dir::Dir<'_> = include_dir::include_dir!("$CARGO_MANIF
 /// (镜像 Tauri 版用 `app_cache_dir()` 存一次性导入临时文件的做法)。
 struct VaultState {
     vault: Vault,
-    /// 真相(`objects/` + `log/`)所在目录。P2 阶段恒为本机沙盒
-    /// `<docs_dir>/vault`——iCloud 容器迁移留给 P5(见 `open_vault` doc)。
+    /// 真相(`objects/` + `log/`)所在目录:本机 `<docs_dir>/vault`,或(开了 iCloud
+    /// 同步且容器可用时)iCloud 容器 `<container>/Documents/vault`。
     truth_root: PathBuf,
     db_path: PathBuf,
     device_id: String,
+    /// App 沙盒 Documents 目录;本机保险箱固定为 `<docs_dir>/vault`(关闭 iCloud 时
+    /// 复制回这里,见 `disable_icloud_sync`)。
+    docs_dir: PathBuf,
     data_dir: PathBuf,
 }
 
@@ -92,31 +95,30 @@ fn doc_summary(v: &Vault, d: &core_model::Document) -> DocumentSummaryDto {
     s
 }
 
-/// 打开(或新建)保险箱。**P2:先不接 iCloud 真逻辑**——`icloud_enabled` 参数按
-/// 设计文档留着(签名与 `docs/020_Flutter_Mobile_Rewrite.md` 一致),但本阶段一律
-/// 打开本机沙盒保险箱 `<docs_dir>/vault`,与该参数取值无关。真正的「真相根据
-/// iCloud 开关搬进容器」逻辑(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`,
-/// iOS-only 且依赖 Tauri 路径 API,不能直接照搬)留给 P5。
+/// 打开(或新建)保险箱。`icloud_enabled` 参数保留(签名稳定),但「是否用 iCloud
+/// 布局」以持久标记 `<data_dir>/icloud_enabled` 为准(由 `enable_icloud_sync` /
+/// `disable_icloud_sync` 写/删)——好在跨启动时记住用户选择,与旧 Tauri 版一致。
 ///
-/// `docs_dir` 对应 Tauri 版的 `app.path().document_dir()`(沙盒 Documents,
-/// 保险箱 truth 的默认落点);`data_dir` 对应 `app.path().app_data_dir()`
-/// (设备 id + 一次性导入临时文件的落点)。两者都由 Flutter 端解析平台路径后传入
-/// ——FRB crate 本身不含任何路径插件。
+/// 开了 iCloud 且容器可用 → 真相在 iCloud 容器 `<container>/Documents/vault`、派生库
+/// 在沙盒;否则本机 `<docs_dir>/vault`。在解析出的 truth_root 打开失败(如 iCloud
+/// 不可用/未登录)则回退本机沙盒保险箱,绝不因 iCloud 问题而开库失败。
+///
+/// `docs_dir` = 沙盒 Documents(本机保险箱 truth 落点);`data_dir` = App data 目录
+/// (设备 id + iCloud 标记 + 一次性导入临时文件的落点)。两者由 Flutter 端解析后传入。
 pub fn open_vault(docs_dir: String, data_dir: String, icloud_enabled: bool) -> anyhow::Result<()> {
-    let _ = icloud_enabled; // P2 占位,见上文 doc——iCloud 真迁移留给 P5。
+    let _ = icloud_enabled; // 见 doc——以持久标记为准,参数仅保签名兼容。
     let docs_dir = PathBuf::from(docs_dir);
     let data_dir = PathBuf::from(data_dir);
     std::fs::create_dir_all(&docs_dir)?;
     std::fs::create_dir_all(&data_dir)?;
-
-    let truth_root = docs_dir.join("vault");
-    let db_path = truth_root.join("medme.db");
     let device_id = machine_device_id(&data_dir)?;
 
-    // 韧性打开:派生库损坏(半同步/写坏)不致命,从追加式日志重建而不是打开失败
-    // ——镜像 Tauri 版 `open_vault_with_fallback` 里用的同一个 `open_split_resilient`。
-    let vault = Vault::open_split_resilient(&truth_root, &db_path, &device_id)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let local_vault = docs_dir.join("vault");
+    let local_db = local_vault.join("medme.db");
+    let (truth_root, db_path) = resolve_vault_paths(&docs_dir, &data_dir);
+
+    let (vault, truth_root, db_path) =
+        open_resilient_with_fallback(&truth_root, &db_path, &local_vault, &local_db, &device_id)?;
 
     let mut guard = vault_cell().lock().unwrap_or_else(|p| p.into_inner());
     *guard = Some(VaultState {
@@ -124,9 +126,47 @@ pub fn open_vault(docs_dir: String, data_dir: String, icloud_enabled: bool) -> a
         truth_root,
         db_path,
         device_id,
+        docs_dir,
         data_dir,
     });
     Ok(())
+}
+
+/// 解析保险箱真相/派生库路径。开了 iCloud 标记且容器可用 → 真相在容器
+/// `<container>/Documents/vault`(与旧 Tauri 版路径拼法一致)、派生库在沙盒
+/// `<data_dir>/medme.db`;否则本机 `<docs_dir>/vault`(派生库同目录)。
+/// 开了但容器不可用则回退本机(仅记日志,不致命)。
+fn resolve_vault_paths(docs_dir: &Path, data_dir: &Path) -> (PathBuf, PathBuf) {
+    let local_vault = docs_dir.join("vault");
+    let local_db = local_vault.join("medme.db");
+    if data_dir.join("icloud_enabled").exists() {
+        if let Some(container) = crate::icloud::container_path() {
+            let cv = container.join("Documents").join("vault");
+            let sandbox_db = data_dir.join("medme.db");
+            return (cv, sandbox_db);
+        }
+    }
+    (local_vault, local_db)
+}
+
+/// 在 `truth_root` 用 `open_split_resilient` 打开(派生库损坏可从日志重建);失败且
+/// truth_root 非本机时回退本机沙盒保险箱。返回实际使用的 `(vault, truth_root, db_path)`。
+fn open_resilient_with_fallback(
+    truth_root: &Path,
+    db_path: &Path,
+    local_vault: &Path,
+    local_db: &Path,
+    device_id: &str,
+) -> anyhow::Result<(Vault, PathBuf, PathBuf)> {
+    match Vault::open_split_resilient(truth_root, db_path, device_id) {
+        Ok(v) => Ok((v, truth_root.to_path_buf(), db_path.to_path_buf())),
+        Err(_) if truth_root != local_vault => {
+            let v = Vault::open_split_resilient(local_vault, local_db, device_id)
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+            Ok((v, local_vault.to_path_buf(), local_db.to_path_buf()))
+        }
+        Err(e) => Err(anyhow::anyhow!(e.to_string())),
+    }
 }
 
 /// 健康档案时间线:就诊组 + 独立文档,按日期倒序(无日期最后)。与桌面/Tauri
@@ -214,7 +254,15 @@ pub fn read_source_bytes(id: i64) -> anyhow::Result<Vec<u8>> {
             .source_file_by_id(id)
             .map_err(|e| anyhow::anyhow!(e.to_string()))?
             .ok_or_else(|| anyhow::anyhow!("找不到来源文件 {id}"))?;
-        let bytes = std::fs::read(v.root_join(&sf.storage_path))?;
+        let path = v.root_join(&sf.storage_path);
+        // iOS:从别的设备同步来的 CAS 对象可能被 iCloud 逐出(dataless 占位)以省空间。
+        // 触发下载 + 短暂有界等待,再按 sha256 校验(内容寻址,能证明拿到真字节);
+        // 非 iOS 直接读盘。始终读不到则命令报错(前端提示),不崩溃。与 Tauri 版一致。
+        #[cfg(target_os = "ios")]
+        let bytes = crate::icloud::read_object_ensuring_download(&path, &sf.content_hash)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        #[cfg(not(target_os = "ios"))]
+        let bytes = std::fs::read(&path)?;
         Ok(bytes)
     })
 }
@@ -648,8 +696,67 @@ pub fn reset_vault() -> anyhow::Result<()> {
 /// 不能直接照搬进这个平台无关的 FFI 层,留给 P5 用 Flutter/iOS 原生桥重做
 /// (见 `docs/020_Flutter_Mobile_Rewrite.md` 的「同步(iCloud,iOS)」一节)。
 pub fn icloud_status() -> IcloudStatusDto {
-    IcloudStatusDto {
-        available: false,
-        enabled: false,
-    }
+    // available:容器能否解析(真机登录了 iCloud 且授权就绪);
+    // enabled:本设备是否已写入同步标记。非 iOS 平台 available 恒为 false。
+    let available = crate::icloud::container_path().is_some();
+    let enabled = with_state(|s| Ok(s.data_dir.join("icloud_enabled").exists())).unwrap_or(false);
+    IcloudStatusDto { available, enabled }
+}
+
+/// 开启 iCloud 同步(仅 iOS 真机有效):把保险箱「真相」迁进 iCloud 容器
+/// `<container>/Documents/vault`,派生库留沙盒,写持久标记。迁移用 core-model
+/// `relocate_to`(搬 objects/log/db/VERSION;若容器里已有别的设备建好的 vault 则
+/// adopt+merge)——与旧 Tauri 版 `enable_icloud_sync` 同一套经过验证的安全操作。
+/// iCloud 不可用/未登录返回人性化错误且不改动当前保险箱。幂等。
+pub fn enable_icloud_sync() -> anyhow::Result<()> {
+    let container = crate::icloud::container_path().ok_or_else(|| {
+        anyhow::anyhow!("iCloud 当前不可用:请在系统「设置」里登录 iCloud 并开启 iCloud 云盘后重试")
+    })?;
+    let container_vault = container.join("Documents").join("vault");
+    with_state_mut(|state| {
+        if state.truth_root == container_vault {
+            std::fs::write(state.data_dir.join("icloud_enabled"), "1")?;
+            return Ok(());
+        }
+        let sandbox_db = state.data_dir.join("medme.db");
+        state
+            .vault
+            .relocate_to(&container_vault)
+            .map_err(|e| anyhow::anyhow!(format!("迁移保险箱到 iCloud 失败:{e}")))?;
+        // 数据库不进容器:删掉刚被搬进去的 medme.db,沙盒另开派生库。
+        let _ = std::fs::remove_file(container_vault.join("medme.db"));
+        let fresh = Vault::open_split(&container_vault, &sandbox_db, &state.device_id)
+            .map_err(|e| anyhow::anyhow!(format!("在 iCloud 容器打开保险箱失败:{e}")))?;
+        state.vault = fresh;
+        state.truth_root = container_vault;
+        state.db_path = sandbox_db;
+        std::fs::write(state.data_dir.join("icloud_enabled"), "1")?;
+        Ok(())
+    })
+}
+
+/// 关闭 iCloud 同步:把真相从容器**复制**回本机 `<docs_dir>/vault`(容器副本保留不动
+/// ——其它苹果设备若仍开着同步不受影响,也留云端备份;用 `copy_to` 只复制不删源),
+/// 本地重开派生库,清标记 + 清沙盒 iCloud 派生库。幂等,失败不改动当前保险箱。
+pub fn disable_icloud_sync() -> anyhow::Result<()> {
+    with_state_mut(|state| {
+        let local_vault = state.docs_dir.join("vault");
+        let local_db = local_vault.join("medme.db");
+        if state.truth_root == local_vault {
+            let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+            return Ok(());
+        }
+        state
+            .vault
+            .copy_to(&local_vault)
+            .map_err(|e| anyhow::anyhow!(format!("把保险箱复制回本机失败:{e}")))?;
+        let fresh = Vault::open_split(&local_vault, &local_db, &state.device_id)
+            .map_err(|e| anyhow::anyhow!(format!("在本机打开保险箱失败:{e}")))?;
+        state.vault = fresh;
+        state.truth_root = local_vault;
+        state.db_path = local_db;
+        let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+        let _ = std::fs::remove_file(state.data_dir.join("medme.db"));
+        Ok(())
+    })
 }

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1829958053;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 665745695;
 
 // Section: executor
 
@@ -74,6 +74,74 @@ fn wire__crate__api__vault__create_share_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
                         let output_ok = crate::api::vault::create_share(api_expires_days)?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__disable_icloud_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "disable_icloud_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::disable_icloud_sync()?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__enable_icloud_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "enable_icloud_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::enable_icloud_sync()?;
                         Ok(output_ok)
                     })(),
                 )
@@ -971,23 +1039,25 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__vault__create_share_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
-        8 => {
+        2 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
+        10 => {
             wire__crate__api__vault__ingest_image_with_text_impl(port, ptr, rust_vec_len, data_len)
         }
-        9 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1000,7 +1070,7 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        4 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/apps/mobile_flutter/rust/src/icloud.rs
+++ b/apps/mobile_flutter/rust/src/icloud.rs
@@ -1,0 +1,113 @@
+//! iCloud ubiquity-container 桥(iOS 专用)。
+//!
+//! 保险箱「真相」(`objects/` + `log/`)可存进本 App 的 iCloud ubiquity 容器,
+//! 在用户的苹果设备间同步;`medme.db` 留在沙盒本地、从日志重建(见
+//! `core_model::Vault::open_split` 与 `docs/011_Storage_Sync.md`)。
+//!
+//! ## Swift↔Rust 桥
+//! `ios/Runner/AppDelegate.swift` 里用 `@_cdecl` 暴露三个 C-ABI 符号。Runner
+//! target 编译该 Swift、链接 cargokit 产的 Rust 静态库,故这些 `extern "C"` 在同一
+//! 二进制里直接解析到 Swift 符号——无需插件/CocoaPods/SPM(与旧 Tauri 版机制一致)。
+//!
+//! 非 iOS 平台(安卓):没有 iCloud,`container_path` 恒为 `None`、`ensure_downloaded`
+//! 恒为 no-op,让本模块与调用方在所有平台都能编译,行为上回退到纯本地保险箱。
+
+#[cfg(target_os = "ios")]
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "ios")]
+extern "C" {
+    fn medme_icloud_container_path() -> *mut std::os::raw::c_char;
+    fn medme_icloud_ensure_downloaded(path: *const std::os::raw::c_char) -> bool;
+    fn medme_icloud_free(ptr: *mut std::os::raw::c_char);
+}
+
+/// 本 App 的 iCloud ubiquity 容器路径;iCloud 不可用/未登录/非 iOS 时返回 `None`。
+/// 调用方一律把 `None` 当作「iCloud 不可用」并回退本地保险箱——绝不致命。
+pub fn container_path() -> Option<PathBuf> {
+    #[cfg(target_os = "ios")]
+    {
+        // SAFETY: 返回值要么是 null,要么是 malloc 的 NUL 结尾 C 字符串;拷进
+        // owned String 后用配套的 medme_icloud_free 释放恰好一次,之后不再使用指针。
+        unsafe {
+            let ptr = medme_icloud_container_path();
+            if ptr.is_null() {
+                return None;
+            }
+            let s = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+            medme_icloud_free(ptr);
+            if s.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(s))
+            }
+        }
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        None
+    }
+}
+
+/// 尽力请求 iCloud 下载一个被逐出(dataless 占位)的文件,好让随后读取能看到字节。
+/// 出错(路径含 NUL / OS 拒绝 / 非 iOS)返回 false;调用方据此当「没能触发下载」继续,非致命。
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+pub fn ensure_downloaded(path: &Path) -> bool {
+    let Ok(_c_path) = CString::new(path.to_string_lossy().as_bytes()) else {
+        return false;
+    };
+    #[cfg(target_os = "ios")]
+    {
+        // SAFETY: `_c_path` 是有效的 NUL 结尾字符串,存活到调用结束;Swift 侧只读它、返回 bool。
+        unsafe { medme_icloud_ensure_downloaded(_c_path.as_ptr()) }
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        false
+    }
+}
+
+/// 触发下载后轮询的次数(iCloud 下载是异步的,立即重试看不到字节,故短暂有界轮询
+/// ≈2s——够一个已上传的小对象在联网时落地,又不至于卡住 UI)。
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+const DOWNLOAD_POLLS: u32 = 20;
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// 读取一个可能被逐出(dataless iCloud 占位)的 CAS 对象。快路径:读 + 校验 sha256
+/// (内容寻址,能证明拿到真字节)。失败(缺失/占位/截断)则请求 iCloud 下载并短暂
+/// 轮询等字节落地,每次重校验。尽力而为、非致命:始终没落地则返回最终读取的错误
+/// (或 sha 不匹配错误),由调用方作为命令错误上抛而非崩溃。
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+pub fn read_object_ensuring_download(path: &Path, expected_sha: &str) -> std::io::Result<Vec<u8>> {
+    if let Some(bytes) = try_read_verified(path, expected_sha) {
+        return Ok(bytes);
+    }
+    ensure_downloaded(path);
+    for _ in 0..DOWNLOAD_POLLS {
+        std::thread::sleep(POLL_INTERVAL);
+        if let Some(bytes) = try_read_verified(path, expected_sha) {
+            return Ok(bytes);
+        }
+    }
+    let bytes = std::fs::read(path)?;
+    if core_model::cas::sha256_hex(&bytes) != expected_sha {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "iCloud 对象尚未下载完成或内容校验失败,请联网后重试",
+        ));
+    }
+    Ok(bytes)
+}
+
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+fn try_read_verified(path: &Path, expected_sha: &str) -> Option<Vec<u8>> {
+    let bytes = std::fs::read(path).ok()?;
+    if core_model::cas::sha256_hex(&bytes) == expected_sha {
+        Some(bytes)
+    } else {
+        None
+    }
+}

--- a/apps/mobile_flutter/rust/src/lib.rs
+++ b/apps/mobile_flutter/rust/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
 mod frb_generated;
+mod icloud;


### PR DESCRIPTION
忠实移植旧 Tauri iCloud(Swift C-ABI 桥 + entitlements + icloud.rs + open_vault 标记路径 + enable/disable 用 core-model relocate_to/copy_to + 逐出下载 + 设置开关)。编译/analyze 通过。

**阻断(不能合 main / 出包)**:现有「MedMe App Store」描述文件的 iCloud 容器数组为空(本地 4 个 profile 全是),需在 Apple 后台把容器 `iCloud.com.medme.mobile` 分配给 App ID + 重生成 profile + 更新 CI secret。否则 iOS 签名会因 entitlements 超出 profile 失败。