### PR TITLE
feat(mobile): P5 iCloud 同步 MethodChannel 重做

### DIFF
--- a/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -695,6 +696,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -721,6 +723,7 @@
 				DEVELOPMENT_TEAM = 49G34P23QP;
 				CODE_SIGN_STYLE = Manual;
 				PROVISIONING_PROFILE_SPECIFIER = "MedMe App Store";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/apps/mobile_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/mobile_flutter/ios/Runner/AppDelegate.swift
@@ -12,5 +12,31 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    registerICloudChannel(engineBridge.pluginRegistry)
+  }
+
+  // MARK: - iCloud MethodChannel(iOS-only)
+  //
+  // Dart 侧经此 channel 解析 iCloud ubiquity 容器路径,再作参数传给 Rust FFI
+  // (open_vault / enable_icloud_sync)。放在 app target 里当 MethodChannel handler,
+  // 不像之前的 @_cdecl C-ABI 那样要被 Rust 独立框架反向链接(Flutter 插件框架不允许,
+  // 会 archive linker 失败)。保险箱真相(objects/+log/)存进容器同步,medme.db 留本地。
+  private func registerICloudChannel(_ registry: FlutterPluginRegistry) {
+    guard let registrar = registry.registrar(forPlugin: "MedMeICloud") else { return }
+    let channel = FlutterMethodChannel(
+      name: "medme/icloud", binaryMessenger: registrar.messenger())
+    channel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "containerPath":
+        // url(forUbiquityContainerIdentifier:) 是阻塞 I/O,切后台线程;传 nil 取第一个
+        // ubiquity-container 授权值。返回容器根路径,不可用/未登录返回 nil。
+        DispatchQueue.global(qos: .userInitiated).async {
+          let path = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.path
+          DispatchQueue.main.async { result(path) }
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
   }
 }

--- a/apps/mobile_flutter/ios/Runner/Runner.entitlements
+++ b/apps/mobile_flutter/ios/Runner/Runner.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.medme.mobile</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.medme.mobile</string>
+	</array>
+</dict>
+</plist>

--- a/apps/mobile_flutter/lib/icloud_bridge.dart
+++ b/apps/mobile_flutter/lib/icloud_bridge.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/services.dart';
+
+/// iCloud 原生桥(iOS-only,MethodChannel `medme/icloud`)。解析 ubiquity 容器路径,
+/// 由 Dart 拿到后作参数传给 Rust FFI(`openVault` / `enableIcloudSync`)。
+///
+/// 为什么走 channel 而不是 Rust 直接调 Swift:FRB/cargokit 把 Rust 编成独立
+/// framework,框架不能反向链接 app target 里的 Swift `@_cdecl` 符号(archive linker
+/// 会失败)。MethodChannel handler 住在 app target(AppDelegate),没有这个限制。
+class IcloudBridge {
+  static const _channel = MethodChannel('medme/icloud');
+
+  /// iCloud 容器根路径;iCloud 不可用/未登录/非 iOS 返回 `null`。安卓等平台上 channel
+  /// 没有 handler,`invokeMethod` 抛 `MissingPluginException`,这里捕获成 `null`。
+  static Future<String?> containerPath() async {
+    try {
+      final path = await _channel.invokeMethod<String>('containerPath');
+      return (path != null && path.isNotEmpty) ? path : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// iCloud 是否可用(容器能解析)。
+  static Future<bool> available() async => (await containerPath()) != null;
+}

--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/screens/archive_screen.dart';
 import 'package:mobile_flutter/screens/export_screen.dart';
 import 'package:mobile_flutter/screens/settings_screen.dart';
+import 'package:mobile_flutter/icloud_bridge.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -41,10 +42,13 @@ class _VaultBootstrapState extends State<VaultBootstrap> {
   Future<void> _openVault() async {
     final docs = await getApplicationDocumentsDirectory();
     final support = await getApplicationSupportDirectory();
+    // iCloud 容器路径由原生 channel 解析(iOS 且登录了 iCloud 才非空),传给 Rust:
+    // 若之前开过同步(<data>/icloud_enabled 标记在)且容器可用,保险箱真相就开在容器里。
+    final container = await IcloudBridge.containerPath();
     await openVault(
       docsDir: docs.path,
       dataDir: support.path,
-      icloudEnabled: false, // P5 接 iCloud
+      icloudContainerDir: container,
     );
   }
 

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
+import 'package:mobile_flutter/icloud_bridge.dart';
 
 /// 与 `pubspec.yaml` 的 `version:` 字段保持一致。P3 范围内没有为读版本号新增
 /// `package_info_plus` 依赖(约束里明确不加新依赖),手工同步即可——这颗
@@ -22,6 +23,8 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   IcloudStatusDto? _icloud;
   PatientProfileDto? _profile;
+  // iCloud 容器是否可用(登录了 iCloud):Rust 拿不到,由原生 channel 判断。
+  bool _icloudAvailable = false;
 
   /// 载入示例 / 清空时置真,禁用所有操作按钮,防止重复点击(尤其清空——
   /// 用户反馈过「载入示例后清空点了没反应」,这里确保按钮忙时不可再点,
@@ -45,10 +48,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _refresh() async {
     try {
       final results = await Future.wait([icloudStatus(), patientProfile()]);
+      final available = await IcloudBridge.available(); // 原生判断容器是否可用
       if (!mounted) return;
       setState(() {
         _icloud = results[0] as IcloudStatusDto;
         _profile = results[1] as PatientProfileDto;
+        _icloudAvailable = available;
       });
     } catch (_) {
       // 状态读取失败不影响本屏其它功能(载入示例/清空仍可用),静默忽略即可。
@@ -143,14 +148,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ],
           ),
-          _SectionLabel('iCloud 同步'),
+          _SectionLabel('iCloud 同步(实验性)'),
           _SettingsGroup(
             children: [
               _SettingsRow(
-                icon: Icons.cloud_off_outlined,
+                icon: (_icloud?.enabled ?? false)
+                    ? Icons.cloud_done_outlined
+                    : Icons.cloud_outlined,
                 title: 'iCloud 同步',
-                subtitle: _icloudSubtitle(_icloud),
-                trailing: Switch(value: false, onChanged: null),
+                subtitle: _icloudSubtitle(),
+                trailing: Switch(
+                  value: _icloud?.enabled ?? false,
+                  onChanged: (_busy || !_icloudAvailable)
+                      ? null
+                      : _toggleIcloud,
+                ),
               ),
             ],
           ),
@@ -174,11 +186,60 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
-  String _icloudSubtitle(IcloudStatusDto? status) {
-    if (status == null) return '正在查询…';
-    if (!status.available) return '此设备暂不可用,后续版本会支持一键开启同步';
-    if (!status.enabled) return '暂未开启,即将在后续版本支持';
-    return '已开启,自动同步到你的苹果设备';
+  String _icloudSubtitle() {
+    if (_icloud == null) return '正在查询…';
+    if (!_icloudAvailable) {
+      return '请先在系统「设置」登录 iCloud 并开启 iCloud 云盘,再回来开启同步';
+    }
+    if (!_icloud!.enabled) return '开启后病历会同步到你其它苹果设备(实验性,建议先备份)';
+    return '已开启,病历会自动同步到你的苹果设备';
+  }
+
+  Future<void> _toggleIcloud(bool want) async {
+    if (want) {
+      final ok = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('开启 iCloud 同步?'),
+          content: const Text(
+            '会把你的病历(真相数据)搬进本 App 的 iCloud 空间,在你登录同一 Apple ID 的'
+            '苹果设备间自动同步;数据库仍留在本机。\n\n这是实验性功能,建议先用「导出」备份一份。',
+            style: TextStyle(fontSize: 13.5, height: 1.5),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('开启'),
+            ),
+          ],
+        ),
+      );
+      if (ok != true) return;
+    }
+
+    setState(() => _busy = true);
+    try {
+      if (want) {
+        final container = await IcloudBridge.containerPath();
+        if (container == null) {
+          throw 'iCloud 当前不可用,请确认已登录 iCloud 并开启 iCloud 云盘';
+        }
+        await enableIcloudSync(containerDir: container);
+      } else {
+        await disableIcloudSync();
+      }
+      bumpVaultRevision(); // 保险箱已重开,通知档案屏刷新
+      await _refresh();
+      _showSnack(want ? '已开启 iCloud 同步' : '已关闭(本机保留一份副本)');
+    } catch (e) {
+      _showSnack('操作失败:$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
   }
 }
 

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -7,27 +7,24 @@ import '../frb_generated.dart';
 import 'dto.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `doc_summary`, `ingest_one`, `machine_device_id`, `vault_cell`, `with_state_mut`, `with_state`
+// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `doc_summary`, `ingest_one`, `machine_device_id`, `open_resilient_with_fallback`, `resolve_vault_paths`, `vault_cell`, `with_state_mut`, `with_state`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultState`
 
-/// 打开(或新建)保险箱。**P2:先不接 iCloud 真逻辑**——`icloud_enabled` 参数按
-/// 设计文档留着(签名与 `docs/020_Flutter_Mobile_Rewrite.md` 一致),但本阶段一律
-/// 打开本机沙盒保险箱 `<docs_dir>/vault`,与该参数取值无关。真正的「真相根据
-/// iCloud 开关搬进容器」逻辑(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`,
-/// iOS-only 且依赖 Tauri 路径 API,不能直接照搬)留给 P5。
+/// 打开(或新建)保险箱。iCloud 容器路径由 **Dart 侧经 MethodChannel 解析后传入**
+/// (`icloud_container_dir`,容器根目录;不可用/非 iOS 传 `None`)——避免 Rust 框架
+/// 反向链接 app target 的 Swift 符号(Flutter 插件框架不允许,会 archive linker 失败)。
 ///
-/// `docs_dir` 对应 Tauri 版的 `app.path().document_dir()`(沙盒 Documents,
-/// 保险箱 truth 的默认落点);`data_dir` 对应 `app.path().app_data_dir()`
-/// (设备 id + 一次性导入临时文件的落点)。两者都由 Flutter 端解析平台路径后传入
-/// ——FRB crate 本身不含任何路径插件。
+/// 是否用 iCloud 布局以持久标记 `<data_dir>/icloud_enabled` 为准(enable/disable 写/删)。
+/// 开了标记且传入了容器 → 真相在 `<container>/Documents/vault`、派生库在沙盒;否则本机
+/// `<docs_dir>/vault`。在解析出的 truth_root 打开失败则回退本机,绝不因 iCloud 问题崩。
 Future<void> openVault({
   required String docsDir,
   required String dataDir,
-  required bool icloudEnabled,
+  String? icloudContainerDir,
 }) => RustLib.instance.api.crateApiVaultOpenVault(
   docsDir: docsDir,
   dataDir: dataDir,
-  icloudEnabled: icloudEnabled,
+  icloudContainerDir: icloudContainerDir,
 );
 
 /// 健康档案时间线:就诊组 + 独立文档,按日期倒序(无日期最后)。与桌面/Tauri
@@ -140,5 +137,21 @@ Future<void> resetVault() => RustLib.instance.api.crateApiVaultResetVault();
 /// 是 iOS-only 且依赖 Tauri 路径 API(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`),
 /// 不能直接照搬进这个平台无关的 FFI 层,留给 P5 用 Flutter/iOS 原生桥重做
 /// (见 `docs/020_Flutter_Mobile_Rewrite.md` 的「同步(iCloud,iOS)」一节)。
+/// iCloud 同步是否已在本设备开启(读持久标记)。`available`(容器是否可解析)由
+/// Dart 侧经 MethodChannel 判断——Rust 拿不到容器,恒返回 false,Dart 覆盖。
 Future<IcloudStatusDto> icloudStatus() =>
     RustLib.instance.api.crateApiVaultIcloudStatus();
+
+/// 开启 iCloud 同步:把保险箱真相迁进 iCloud 容器 `<container_dir>/Documents/vault`,
+/// 派生库留沙盒,写持久标记。容器路径由 Dart 经 MethodChannel 解析后传入。迁移用
+/// core-model `relocate_to`(搬 objects/log/db/VERSION;容器里已有别设备的 vault 则
+/// adopt+merge)——与已验证的 Tauri #38 同一套安全操作。幂等。
+Future<void> enableIcloudSync({required String containerDir}) => RustLib
+    .instance
+    .api
+    .crateApiVaultEnableIcloudSync(containerDir: containerDir);
+
+/// 关闭 iCloud 同步:把真相从容器**复制**回本机 `<docs_dir>/vault`(容器副本保留),
+/// 本地重开派生库,清标记 + 沙盒 iCloud 派生库。用 `copy_to` 只复制不删源。幂等。
+Future<void> disableIcloudSync() =>
+    RustLib.instance.api.crateApiVaultDisableIcloudSync();

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1829958053;
+  int get rustContentHash => 665745695;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -83,6 +83,10 @@ abstract class RustLibApi extends BaseApi {
   Future<ShareResultDto> crateApiVaultCreateShare({
     required PlatformInt64 expiresDays,
   });
+
+  Future<void> crateApiVaultDisableIcloudSync();
+
+  Future<void> crateApiVaultEnableIcloudSync({required String containerDir});
 
   Future<ExportResultDto> crateApiVaultExportTimelineHtml({
     String? fromDate,
@@ -120,7 +124,7 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiVaultOpenVault({
     required String docsDir,
     required String dataDir,
-    required bool icloudEnabled,
+    String? icloudContainerDir,
   });
 
   Future<PatientProfileDto> crateApiVaultPatientProfile();
@@ -173,6 +177,64 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "create_share", argNames: ["expiresDays"]);
 
   @override
+  Future<void> crateApiVaultDisableIcloudSync() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultDisableIcloudSyncConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultDisableIcloudSyncConstMeta =>
+      const TaskConstMeta(debugName: "disable_icloud_sync", argNames: []);
+
+  @override
+  Future<void> crateApiVaultEnableIcloudSync({required String containerDir}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(containerDir, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultEnableIcloudSyncConstMeta,
+        argValues: [containerDir],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultEnableIcloudSyncConstMeta =>
+      const TaskConstMeta(
+        debugName: "enable_icloud_sync",
+        argNames: ["containerDir"],
+      );
+
+  @override
   Future<ExportResultDto> crateApiVaultExportTimelineHtml({
     String? fromDate,
     String? toDate,
@@ -186,7 +248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 4,
             port: port_,
           );
         },
@@ -219,7 +281,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 5,
             port: port_,
           );
         },
@@ -244,7 +306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -269,7 +331,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 7,
             port: port_,
           );
         },
@@ -301,7 +363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 8,
             port: port_,
           );
         },
@@ -331,7 +393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 9,
             port: port_,
           );
         },
@@ -367,7 +429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 10,
             port: port_,
           );
         },
@@ -397,7 +459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 11,
             port: port_,
           );
         },
@@ -424,7 +486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 12,
             port: port_,
           );
         },
@@ -451,7 +513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 13,
             port: port_,
           );
         },
@@ -473,7 +535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<void> crateApiVaultOpenVault({
     required String docsDir,
     required String dataDir,
-    required bool icloudEnabled,
+    String? icloudContainerDir,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -481,11 +543,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(docsDir, serializer);
           sse_encode_String(dataDir, serializer);
-          sse_encode_bool(icloudEnabled, serializer);
+          sse_encode_opt_String(icloudContainerDir, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 14,
             port: port_,
           );
         },
@@ -494,7 +556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiVaultOpenVaultConstMeta,
-        argValues: [docsDir, dataDir, icloudEnabled],
+        argValues: [docsDir, dataDir, icloudContainerDir],
         apiImpl: this,
       ),
     );
@@ -502,7 +564,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiVaultOpenVaultConstMeta => const TaskConstMeta(
     debugName: "open_vault",
-    argNames: ["docsDir", "dataDir", "icloudEnabled"],
+    argNames: ["docsDir", "dataDir", "icloudContainerDir"],
   );
 
   @override
@@ -514,7 +576,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 15,
             port: port_,
           );
         },
@@ -542,7 +604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 16,
             port: port_,
           );
         },
@@ -570,7 +632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 17,
             port: port_,
           );
         },
@@ -597,7 +659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 18,
             port: port_,
           );
         },
@@ -625,7 +687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 19,
             port: port_,
           );
         },

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+8
+version: 1.2.0+9
 
 environment:
   sdk: ^3.12.2

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -29,11 +29,13 @@ static DEMO_DATA: include_dir::Dir<'_> = include_dir::include_dir!("$CARGO_MANIF
 /// (镜像 Tauri 版用 `app_cache_dir()` 存一次性导入临时文件的做法)。
 struct VaultState {
     vault: Vault,
-    /// 真相(`objects/` + `log/`)所在目录。P2 阶段恒为本机沙盒
-    /// `<docs_dir>/vault`——iCloud 容器迁移留给 P5(见 `open_vault` doc)。
+    /// 真相(`objects/` + `log/`)所在目录:本机 `<docs_dir>/vault`,或(开了 iCloud
+    /// 同步且容器可用时)iCloud 容器 `<container>/Documents/vault`。
     truth_root: PathBuf,
     db_path: PathBuf,
     device_id: String,
+    /// App 沙盒 Documents 目录;本机保险箱固定 `<docs_dir>/vault`(关 iCloud 时复制回这)。
+    docs_dir: PathBuf,
     data_dir: PathBuf,
 }
 
@@ -92,31 +94,31 @@ fn doc_summary(v: &Vault, d: &core_model::Document) -> DocumentSummaryDto {
     s
 }
 
-/// 打开(或新建)保险箱。**P2:先不接 iCloud 真逻辑**——`icloud_enabled` 参数按
-/// 设计文档留着(签名与 `docs/020_Flutter_Mobile_Rewrite.md` 一致),但本阶段一律
-/// 打开本机沙盒保险箱 `<docs_dir>/vault`,与该参数取值无关。真正的「真相根据
-/// iCloud 开关搬进容器」逻辑(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`,
-/// iOS-only 且依赖 Tauri 路径 API,不能直接照搬)留给 P5。
+/// 打开(或新建)保险箱。iCloud 容器路径由 **Dart 侧经 MethodChannel 解析后传入**
+/// (`icloud_container_dir`,容器根目录;不可用/非 iOS 传 `None`)——避免 Rust 框架
+/// 反向链接 app target 的 Swift 符号(Flutter 插件框架不允许,会 archive linker 失败)。
 ///
-/// `docs_dir` 对应 Tauri 版的 `app.path().document_dir()`(沙盒 Documents,
-/// 保险箱 truth 的默认落点);`data_dir` 对应 `app.path().app_data_dir()`
-/// (设备 id + 一次性导入临时文件的落点)。两者都由 Flutter 端解析平台路径后传入
-/// ——FRB crate 本身不含任何路径插件。
-pub fn open_vault(docs_dir: String, data_dir: String, icloud_enabled: bool) -> anyhow::Result<()> {
-    let _ = icloud_enabled; // P2 占位,见上文 doc——iCloud 真迁移留给 P5。
+/// 是否用 iCloud 布局以持久标记 `<data_dir>/icloud_enabled` 为准(enable/disable 写/删)。
+/// 开了标记且传入了容器 → 真相在 `<container>/Documents/vault`、派生库在沙盒;否则本机
+/// `<docs_dir>/vault`。在解析出的 truth_root 打开失败则回退本机,绝不因 iCloud 问题崩。
+pub fn open_vault(
+    docs_dir: String,
+    data_dir: String,
+    icloud_container_dir: Option<String>,
+) -> anyhow::Result<()> {
     let docs_dir = PathBuf::from(docs_dir);
     let data_dir = PathBuf::from(data_dir);
     std::fs::create_dir_all(&docs_dir)?;
     std::fs::create_dir_all(&data_dir)?;
-
-    let truth_root = docs_dir.join("vault");
-    let db_path = truth_root.join("medme.db");
     let device_id = machine_device_id(&data_dir)?;
 
-    // 韧性打开:派生库损坏(半同步/写坏)不致命,从追加式日志重建而不是打开失败
-    // ——镜像 Tauri 版 `open_vault_with_fallback` 里用的同一个 `open_split_resilient`。
-    let vault = Vault::open_split_resilient(&truth_root, &db_path, &device_id)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let local_vault = docs_dir.join("vault");
+    let local_db = local_vault.join("medme.db");
+    let (truth_root, db_path) =
+        resolve_vault_paths(&docs_dir, &data_dir, icloud_container_dir.as_deref());
+
+    let (vault, truth_root, db_path) =
+        open_resilient_with_fallback(&truth_root, &db_path, &local_vault, &local_db, &device_id)?;
 
     let mut guard = vault_cell().lock().unwrap_or_else(|p| p.into_inner());
     *guard = Some(VaultState {
@@ -124,9 +126,49 @@ pub fn open_vault(docs_dir: String, data_dir: String, icloud_enabled: bool) -> a
         truth_root,
         db_path,
         device_id,
+        docs_dir,
         data_dir,
     });
     Ok(())
+}
+
+/// 决定真相/派生库路径:开了 iCloud 标记且 Dart 传入了容器根 → 真相在
+/// `<container>/Documents/vault`(与旧 Tauri 版路径拼法一致)、派生库在沙盒
+/// `<data_dir>/medme.db`;否则本机 `<docs_dir>/vault`(派生库同目录)。
+fn resolve_vault_paths(
+    docs_dir: &Path,
+    data_dir: &Path,
+    container: Option<&str>,
+) -> (PathBuf, PathBuf) {
+    let local_vault = docs_dir.join("vault");
+    let local_db = local_vault.join("medme.db");
+    if data_dir.join("icloud_enabled").exists() {
+        if let Some(c) = container {
+            let cv = Path::new(c).join("Documents").join("vault");
+            return (cv, data_dir.join("medme.db"));
+        }
+    }
+    (local_vault, local_db)
+}
+
+/// 在 `truth_root` 用 `open_split_resilient` 打开(派生库损坏可从日志重建);失败且
+/// truth_root 非本机时回退本机沙盒保险箱。返回实际使用的 `(vault, truth_root, db_path)`。
+fn open_resilient_with_fallback(
+    truth_root: &Path,
+    db_path: &Path,
+    local_vault: &Path,
+    local_db: &Path,
+    device_id: &str,
+) -> anyhow::Result<(Vault, PathBuf, PathBuf)> {
+    match Vault::open_split_resilient(truth_root, db_path, device_id) {
+        Ok(v) => Ok((v, truth_root.to_path_buf(), db_path.to_path_buf())),
+        Err(_) if truth_root != local_vault => {
+            let v = Vault::open_split_resilient(local_vault, local_db, device_id)
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+            Ok((v, local_vault.to_path_buf(), local_db.to_path_buf()))
+        }
+        Err(e) => Err(anyhow::anyhow!(e.to_string())),
+    }
 }
 
 /// 健康档案时间线:就诊组 + 独立文档,按日期倒序(无日期最后)。与桌面/Tauri
@@ -647,9 +689,64 @@ pub fn reset_vault() -> anyhow::Result<()> {
 /// 是 iOS-only 且依赖 Tauri 路径 API(见 Tauri 版 `apps/mobile/src-tauri/src/icloud.rs`),
 /// 不能直接照搬进这个平台无关的 FFI 层,留给 P5 用 Flutter/iOS 原生桥重做
 /// (见 `docs/020_Flutter_Mobile_Rewrite.md` 的「同步(iCloud,iOS)」一节)。
+/// iCloud 同步是否已在本设备开启(读持久标记)。`available`(容器是否可解析)由
+/// Dart 侧经 MethodChannel 判断——Rust 拿不到容器,恒返回 false,Dart 覆盖。
 pub fn icloud_status() -> IcloudStatusDto {
+    let enabled = with_state(|s| Ok(s.data_dir.join("icloud_enabled").exists())).unwrap_or(false);
     IcloudStatusDto {
         available: false,
-        enabled: false,
+        enabled,
     }
+}
+
+/// 开启 iCloud 同步:把保险箱真相迁进 iCloud 容器 `<container_dir>/Documents/vault`,
+/// 派生库留沙盒,写持久标记。容器路径由 Dart 经 MethodChannel 解析后传入。迁移用
+/// core-model `relocate_to`(搬 objects/log/db/VERSION;容器里已有别设备的 vault 则
+/// adopt+merge)——与已验证的 Tauri #38 同一套安全操作。幂等。
+pub fn enable_icloud_sync(container_dir: String) -> anyhow::Result<()> {
+    let container_vault = Path::new(&container_dir).join("Documents").join("vault");
+    with_state_mut(|state| {
+        if state.truth_root == container_vault {
+            std::fs::write(state.data_dir.join("icloud_enabled"), "1")?;
+            return Ok(());
+        }
+        let sandbox_db = state.data_dir.join("medme.db");
+        state
+            .vault
+            .relocate_to(&container_vault)
+            .map_err(|e| anyhow::anyhow!(format!("迁移保险箱到 iCloud 失败:{e}")))?;
+        let _ = std::fs::remove_file(container_vault.join("medme.db"));
+        let fresh = Vault::open_split(&container_vault, &sandbox_db, &state.device_id)
+            .map_err(|e| anyhow::anyhow!(format!("在 iCloud 容器打开保险箱失败:{e}")))?;
+        state.vault = fresh;
+        state.truth_root = container_vault;
+        state.db_path = sandbox_db;
+        std::fs::write(state.data_dir.join("icloud_enabled"), "1")?;
+        Ok(())
+    })
+}
+
+/// 关闭 iCloud 同步:把真相从容器**复制**回本机 `<docs_dir>/vault`(容器副本保留),
+/// 本地重开派生库,清标记 + 沙盒 iCloud 派生库。用 `copy_to` 只复制不删源。幂等。
+pub fn disable_icloud_sync() -> anyhow::Result<()> {
+    with_state_mut(|state| {
+        let local_vault = state.docs_dir.join("vault");
+        let local_db = local_vault.join("medme.db");
+        if state.truth_root == local_vault {
+            let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+            return Ok(());
+        }
+        state
+            .vault
+            .copy_to(&local_vault)
+            .map_err(|e| anyhow::anyhow!(format!("把保险箱复制回本机失败:{e}")))?;
+        let fresh = Vault::open_split(&local_vault, &local_db, &state.device_id)
+            .map_err(|e| anyhow::anyhow!(format!("在本机打开保险箱失败:{e}")))?;
+        state.vault = fresh;
+        state.truth_root = local_vault;
+        state.db_path = local_db;
+        let _ = std::fs::remove_file(state.data_dir.join("icloud_enabled"));
+        let _ = std::fs::remove_file(state.data_dir.join("medme.db"));
+        Ok(())
+    })
 }

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1829958053;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 665745695;
 
 // Section: executor
 
@@ -74,6 +74,75 @@ fn wire__crate__api__vault__create_share_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
                         let output_ok = crate::api::vault::create_share(api_expires_days)?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__disable_icloud_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "disable_icloud_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::disable_icloud_sync()?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__enable_icloud_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "enable_icloud_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_container_dir = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::enable_icloud_sync(api_container_dir)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -455,7 +524,7 @@ fn wire__crate__api__vault__open_vault_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_docs_dir = <String>::sse_decode(&mut deserializer);
             let api_data_dir = <String>::sse_decode(&mut deserializer);
-            let api_icloud_enabled = <bool>::sse_decode(&mut deserializer);
+            let api_icloud_container_dir = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -463,7 +532,7 @@ fn wire__crate__api__vault__open_vault_impl(
                         let output_ok = crate::api::vault::open_vault(
                             api_docs_dir,
                             api_data_dir,
-                            api_icloud_enabled,
+                            api_icloud_container_dir,
                         )?;
                         Ok(output_ok)
                     })(),
@@ -971,23 +1040,25 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__vault__create_share_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
-        8 => {
+        2 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
+        10 => {
             wire__crate__api__vault__ingest_image_with_text_impl(port, ptr, rust_vec_len, data_len)
         }
-        9 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1000,7 +1071,7 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        4 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
替掉链接失败的 C-ABI:Swift MethodChannel 在 app target 解析容器路径,Dart 传给 Rust。迁移仍用 core-model relocate_to/copy_to。需真机验证。