### PR TITLE
fix(mobile): 中文本地化(日历)+ iCloud 在文件App可见

### DIFF
--- a/apps/mobile_flutter/ios/Runner/Info.plist
+++ b/apps/mobile_flutter/ios/Runner/Info.plist
@@ -77,5 +77,19 @@
 	<!-- 只用标准/豁免加密(本机端到端分享用的是标准算法),免每次 TestFlight 问出口合规。 -->
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- 让 iCloud 容器的 Documents 在系统「文件」App → iCloud 云盘里以「MedMe 医我」
+	     可见 —— 用户开启同步后能眼见为实地看到病历文件夹(vault),确认数据进了 iCloud。 -->
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.com.medme.mobile</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>MedMe 医我</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:mobile_flutter/src/rust/frb_generated.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
@@ -22,6 +23,14 @@ class MedMeApp extends StatelessWidget {
       title: 'MedMe 医我',
       theme: MedMe.theme(),
       debugShowCheckedModeBanner: false,
+      // 面向简体中文用户:强制中文本地化,日历选择器/所有 Material 弹窗都显示中文。
+      locale: const Locale('zh', 'CN'),
+      supportedLocales: const [Locale('zh', 'CN'), Locale('en')],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       home: const VaultBootstrap(),
     );
   }

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -192,7 +192,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       return '请先在系统「设置」登录 iCloud 并开启 iCloud 云盘,再回来开启同步';
     }
     if (!_icloud!.enabled) return '开启后病历会同步到你其它苹果设备(实验性,建议先备份)';
-    return '已开启,病历会自动同步到你的苹果设备';
+    return '已开启 · 可在「文件」App → iCloud 云盘 → MedMe 医我 里看到已同步的病历';
   }
 
   Future<void> _toggleIcloud(bool want) async {

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -315,6 +315,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -503,6 +508,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+9
+version: 1.2.0+10
 
 environment:
   sdk: ^3.12.2
@@ -29,6 +29,8 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
+    sdk: flutter
+  flutter_localizations:
     sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
build9 反馈 #4(日历英文→中文本地化)+ #6(iCloud 容器在文件App可见,眼见为实)。analyze 干净。