### PR TITLE
fix(mobile): review 队列改显式待确认集(修看不到)

### DIFF
--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -10,6 +10,7 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
+import 'package:mobile_flutter/review_state.dart';
 
 /// 「健康档案」右上角「+ 导入」触发的采集流程:弹三选一(拍照 / 相册 / 选文件),
 /// 选定后逐个采集→(图片先 ML Kit 中文 OCR)→落库,期间显示进度对话框,结束弹汇总,
@@ -126,6 +127,7 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
 
   TextRecognizer? recognizer;
   final rows = <ImportResultRow>[];
+  final newDocIds = <int>[]; // 本次新建的文档 id → 加入「待确认」队列
   for (var i = 0; i < items.length; i++) {
     final item = items[i];
     progress.value = '正在导入 ${i + 1}/${items.length}…';
@@ -147,6 +149,7 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
         final bytes = await File(item.path).readAsBytes();
         outcome = await ingestBytes(filename: item.name, data: bytes);
       }
+      if (outcome.documentId case final id?) newDocIds.add(id);
       rows.add(rowFromOutcome(outcome));
     } catch (e) {
       rows.add(rowFromError(item.name, e));
@@ -154,6 +157,10 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
   }
   await recognizer?.close();
 
+  // 本次新建的文档显式加入「待确认」队列(健康档案顶部据此置顶让用户核对)。
+  if (newDocIds.isNotEmpty) {
+    await ReviewState.instance.markPending(newDocIds);
+  }
   // 有任一份成功落库,通知「健康档案」屏自动刷新。
   if (rows.any((r) => r.kind != ImportRowKind.failed)) {
     bumpVaultRevision();

--- a/apps/mobile_flutter/lib/review_state.dart
+++ b/apps/mobile_flutter/lib/review_state.dart
@@ -3,22 +3,21 @@ import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
 
-/// 「新导入待审核」本地状态。持久化一份「已审核文档 id 集」到沙盒
-/// `<support>/review_state.json`,不进保险箱(纯本设备的 UI 状态,不需要跨设备同步)。
+/// 「新导入待确认」本地状态。持久化一份「待确认文档 id 集」到沙盒
+/// `<support>/review_state.json`(纯本设备 UI 状态,不进保险箱、不需跨设备同步)。
 ///
-/// 语义:
-/// - 首次运行(未初始化)把当前所有文档设为「已审核」作基线——已有数据不算「新」。
-/// - 之后凡不在集里的文档 = 新导入 = 「待确认」,在健康档案顶部标「新」。
-/// - 用户点「审核通过」→ 加入集 → 归入正常时间线,不再置顶。
+/// 语义(显式、可靠):
+/// - **导入**时,把本次新建的文档 id 显式加入待确认集([markPending])。
+/// - 健康档案顶部把待确认集里的文档列为「待确认」,置顶让用户过一眼。
+/// - 用户点「确认」→ 从集里移除([markReviewed]),归入正常时间线。
 ///
-/// 这样完全不动共享 vault 格式 / core-model / 桌面(零 spine 风险),新导入的识别
-/// 结果(类型/日期可能被 OCR 猜错)先让用户过一眼再正式并入。
+/// 不再靠「基线/已审集」反向推断(那种做法对已有数据、去重、时序都容易出错——用户
+/// 反馈过看不到待确认)。现在只有真正新导入的文档才进队列,零歧义、零 spine 风险。
 class ReviewState {
   ReviewState._();
   static final ReviewState instance = ReviewState._();
 
-  final Set<int> _reviewed = {};
-  bool _initialized = false;
+  final Set<int> _pending = {};
   bool _loaded = false;
   File? _file;
 
@@ -28,19 +27,19 @@ class ReviewState {
     return _file = File('${dir.path}/review_state.json');
   }
 
-  Future<void> _load() async {
+  /// 从磁盘载入待确认集(幂等,每会话读一次)。健康档案 build 前调一次。
+  Future<void> ensureLoaded() async {
     if (_loaded) return;
     try {
       final f = await _stateFile();
       if (await f.exists()) {
         final json = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
-        _initialized = json['initialized'] == true;
-        _reviewed
+        _pending
           ..clear()
-          ..addAll((json['reviewed'] as List).map((e) => e as int));
+          ..addAll((json['pending'] as List? ?? const []).map((e) => e as int));
       }
     } catch (_) {
-      // 读坏了不致命:当作未初始化,下次导入基线会重建。
+      // 读坏了不致命:当空集,后续导入会重新填。
     }
     _loaded = true;
   }
@@ -48,45 +47,37 @@ class ReviewState {
   Future<void> _save() async {
     try {
       final f = await _stateFile();
-      await f.writeAsString(
-        jsonEncode({
-          'initialized': _initialized,
-          'reviewed': _reviewed.toList(),
-        }),
-      );
+      await f.writeAsString(jsonEncode({'pending': _pending.toList()}));
     } catch (_) {
-      // 写失败不致命(下次再写);至少本次会话内存里状态是对的。
+      // 写失败不致命(下次再写);本会话内存状态仍对。
     }
   }
 
-  /// 加载状态,并在首次运行时用 [currentDocIds] 建立基线(现有数据视为已审)。
-  /// 每次进健康档案调一次即可(幂等)。
-  Future<void> ensureBaseline(List<int> currentDocIds) async {
-    await _load();
-    if (!_initialized) {
-      _reviewed
-        ..clear()
-        ..addAll(currentDocIds);
-      _initialized = true;
-      await _save();
-    }
-  }
+  /// 该文档是否「新导入·待确认」。
+  bool isPending(int docId) => _pending.contains(docId);
 
-  /// 该文档是否是「新导入·待确认」(未审核)。
-  bool isNew(int docId) => !_reviewed.contains(docId);
-
-  /// 标记一份文档已审核通过(归入正常时间线)。
-  Future<void> markReviewed(int docId) async {
-    await _load();
-    if (_reviewed.add(docId)) await _save();
-  }
-
-  /// 一键把当前所有「新」文档都标为已审(顶部「全部审核」用)。
-  Future<void> markAllReviewed(Iterable<int> docIds) async {
-    await _load();
+  /// 导入后把新建文档 id 加入待确认集。
+  Future<void> markPending(Iterable<int> docIds) async {
+    await ensureLoaded();
     var changed = false;
     for (final id in docIds) {
-      changed = _reviewed.add(id) || changed;
+      changed = _pending.add(id) || changed;
+    }
+    if (changed) await _save();
+  }
+
+  /// 确认通过一份 → 移出待确认集(归入正常时间线)。
+  Future<void> markReviewed(int docId) async {
+    await ensureLoaded();
+    if (_pending.remove(docId)) await _save();
+  }
+
+  /// 一键全部确认。
+  Future<void> markAllReviewed(Iterable<int> docIds) async {
+    await ensureLoaded();
+    var changed = false;
+    for (final id in docIds) {
+      changed = _pending.remove(id) || changed;
     }
     if (changed) await _save();
   }

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -161,10 +161,8 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
     final results = await Future.wait([patientProfile(), loadArchive()]);
     final profile = results[0] as PatientProfileDto;
     final groups = results[1] as List<TimelineGroupDto>;
-    // 首次运行把现有记录设为「已审」基线——之后的新导入才会被标「待确认」。
-    await ReviewState.instance.ensureBaseline(
-      _allDocs(groups).map((d) => d.id).toList(),
-    );
+    // 载入「待确认」集(build 里同步判断 isPending 前要先加载好)。
+    await ReviewState.instance.ensureLoaded();
     return (profile, groups);
   }
 
@@ -236,11 +234,11 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
           }
 
           final (profile, groups) = snap.data!;
-          // 新导入(未审核)的文档:置顶「待确认」,新的(id 大)在前。
+          // 新导入(待确认)的文档:置顶,新的(id 大)在前。
           final unreviewed =
               _allDocs(
                   groups,
-                ).where((d) => ReviewState.instance.isNew(d.id)).toList()
+                ).where((d) => ReviewState.instance.isPending(d.id)).toList()
                 ..sort((a, b) => b.id.compareTo(a.id));
           return RefreshIndicator(
             onRefresh: _refresh,

--- a/apps/mobile_flutter/lib/src/rust/api/dto.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/dto.dart
@@ -193,11 +193,16 @@ class ImportOutcomeDto {
   final String status;
   final String? docType;
 
+  /// 本次采集落库的文档 id(前端「待确认」review 队列据此显式标记新导入)。
+  /// 去重/失败等没建文档的情况为 None。
+  final PlatformInt64? documentId;
+
   const ImportOutcomeDto({
     required this.name,
     required this.sourceFileId,
     required this.status,
     this.docType,
+    this.documentId,
   });
 
   @override
@@ -205,7 +210,8 @@ class ImportOutcomeDto {
       name.hashCode ^
       sourceFileId.hashCode ^
       status.hashCode ^
-      docType.hashCode;
+      docType.hashCode ^
+      documentId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -215,7 +221,8 @@ class ImportOutcomeDto {
           name == other.name &&
           sourceFileId == other.sourceFileId &&
           status == other.status &&
-          docType == other.docType;
+          docType == other.docType &&
+          documentId == other.documentId;
 }
 
 class PatientProfileDto {

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -750,6 +750,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_i_64(raw);
+  }
+
+  @protected
   DocumentDetailDto dco_decode_document_detail_dto(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -846,13 +852,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ImportOutcomeDto dco_decode_import_outcome_dto(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 4)
-      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return ImportOutcomeDto(
       name: dco_decode_String(arr[0]),
       sourceFileId: dco_decode_i_64(arr[1]),
       status: dco_decode_String(arr[2]),
       docType: dco_decode_opt_String(arr[3]),
+      documentId: dco_decode_opt_box_autoadd_i_64(arr[4]),
     );
   }
 
@@ -896,6 +903,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   int? dco_decode_opt_box_autoadd_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_i_32(raw);
+  }
+
+  @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_i_64(raw);
   }
 
   @protected
@@ -1021,6 +1034,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_i_64(deserializer));
+  }
+
+  @protected
   DocumentDetailDto sse_decode_document_detail_dto(
     SseDeserializer deserializer,
   ) {
@@ -1133,11 +1152,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_sourceFileId = sse_decode_i_64(deserializer);
     var var_status = sse_decode_String(deserializer);
     var var_docType = sse_decode_opt_String(deserializer);
+    var var_documentId = sse_decode_opt_box_autoadd_i_64(deserializer);
     return ImportOutcomeDto(
       name: var_name,
       sourceFileId: var_sourceFileId,
       status: var_status,
       docType: var_docType,
+      documentId: var_documentId,
     );
   }
 
@@ -1211,6 +1232,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_i_32(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_i_64(deserializer));
     } else {
       return null;
     }
@@ -1355,6 +1387,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(self, serializer);
+  }
+
+  @protected
   void sse_encode_document_detail_dto(
     DocumentDetailDto self,
     SseSerializer serializer,
@@ -1447,6 +1488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_64(self.sourceFileId, serializer);
     sse_encode_String(self.status, serializer);
     sse_encode_opt_String(self.docType, serializer);
+    sse_encode_opt_box_autoadd_i_64(self.documentId, serializer);
   }
 
   @protected
@@ -1522,6 +1564,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_i_32(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_i_64(self, serializer);
     }
   }
 

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
@@ -42,6 +42,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_box_autoadd_i_32(dynamic raw);
 
   @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
   DocumentDetailDto dco_decode_document_detail_dto(dynamic raw);
 
   @protected
@@ -90,6 +93,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int? dco_decode_opt_box_autoadd_i_32(dynamic raw);
 
   @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
+
+  @protected
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
 
   @protected
@@ -131,6 +137,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   int sse_decode_box_autoadd_i_32(SseDeserializer deserializer);
+
+  @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
   DocumentDetailDto sse_decode_document_detail_dto(
@@ -191,6 +200,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int? sse_decode_opt_box_autoadd_i_32(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
   PatientProfileDto sse_decode_patient_profile_dto(
     SseDeserializer deserializer,
   );
@@ -241,6 +253,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_document_detail_dto(
@@ -316,6 +334,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_i_32(int? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_patient_profile_dto(

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
@@ -44,6 +44,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_box_autoadd_i_32(dynamic raw);
 
   @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
   DocumentDetailDto dco_decode_document_detail_dto(dynamic raw);
 
   @protected
@@ -92,6 +95,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int? dco_decode_opt_box_autoadd_i_32(dynamic raw);
 
   @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
+
+  @protected
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
 
   @protected
@@ -133,6 +139,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   int sse_decode_box_autoadd_i_32(SseDeserializer deserializer);
+
+  @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
   DocumentDetailDto sse_decode_document_detail_dto(
@@ -193,6 +202,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int? sse_decode_opt_box_autoadd_i_32(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
   PatientProfileDto sse_decode_patient_profile_dto(
     SseDeserializer deserializer,
   );
@@ -243,6 +255,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_document_detail_dto(
@@ -318,6 +336,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_i_32(int? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_patient_profile_dto(

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+10
+version: 1.2.0+11
 
 environment:
   sdk: ^3.12.2

--- a/apps/mobile_flutter/rust/src/api/dto.rs
+++ b/apps/mobile_flutter/rust/src/api/dto.rs
@@ -121,6 +121,9 @@ pub struct ImportOutcomeDto {
     pub source_file_id: i64,
     pub status: String, // new|backfilled|deduped|stored_no_text|instance_attached|failed
     pub doc_type: Option<String>,
+    /// 本次采集落库的文档 id(前端「待确认」review 队列据此显式标记新导入)。
+    /// 去重/失败等没建文档的情况为 None。
+    pub document_id: Option<i64>,
 }
 
 /// 加密分享生成结果:口令(单独告知医生)、记录数、文件字节数、分享文件路径。

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -321,11 +321,17 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 pipeline::IngestStatus::InstanceAttached => "instance_attached",
             }
             .to_string();
+            let document_id = v
+                .document_by_source_file_id(o.source_file_id)
+                .ok()
+                .flatten()
+                .map(|d| d.id);
             ImportOutcomeDto {
                 name: o.name,
                 source_file_id: o.source_file_id,
                 status,
                 doc_type: o.doc_type.map(|d| d.as_str().to_string()),
+                document_id,
             }
         }
         Err(e) => {
@@ -339,6 +345,7 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 source_file_id: 0,
                 status: "failed".to_string(),
                 doc_type: None,
+                document_id: None,
             }
         }
     }
@@ -449,6 +456,7 @@ pub fn ingest_image_with_text(
                 source_file_id: sid,
                 status: "deduped".to_string(),
                 doc_type: None,
+                document_id: None,
             }
         } else {
             let text = ocr_text.trim().to_string();
@@ -481,25 +489,28 @@ pub fn ingest_image_with_text(
                     source_file_id: sid,
                     status: status.to_string(),
                     doc_type: Some(doc_type.as_str().to_string()),
+                    document_id: Some(doc.id),
                 }
             } else {
                 let (doc_date, doc_date_end) = parser::guess_date_range(&safe_name);
                 let doc_type = parser::classify(&safe_name);
-                v.add_document(NewDocument {
-                    source_file_id: sid,
-                    doc_type: doc_type.clone(),
-                    doc_date,
-                    doc_date_end,
-                    title: Some(safe_name.clone()),
-                    language: None,
-                    page_count: 1,
-                })
-                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                let doc = v
+                    .add_document(NewDocument {
+                        source_file_id: sid,
+                        doc_type: doc_type.clone(),
+                        doc_date,
+                        doc_date_end,
+                        title: Some(safe_name.clone()),
+                        language: None,
+                        page_count: 1,
+                    })
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
                 ImportOutcomeDto {
                     name: safe_name.clone(),
                     source_file_id: sid,
                     status: "stored_no_text".to_string(),
                     doc_type: Some(doc_type.as_str().to_string()),
+                    document_id: Some(doc.id),
                 }
             }
         };

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -858,11 +858,13 @@ impl SseDecode for crate::api::dto::ImportOutcomeDto {
         let mut var_sourceFileId = <i64>::sse_decode(deserializer);
         let mut var_status = <String>::sse_decode(deserializer);
         let mut var_docType = <Option<String>>::sse_decode(deserializer);
+        let mut var_documentId = <Option<i64>>::sse_decode(deserializer);
         return crate::api::dto::ImportOutcomeDto {
             name: var_name,
             source_file_id: var_sourceFileId,
             status: var_status,
             doc_type: var_docType,
+            document_id: var_documentId,
         };
     }
 }
@@ -934,6 +936,17 @@ impl SseDecode for Option<i32> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<i32>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<i64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<i64>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -1206,6 +1219,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::dto::ImportOutcomeDto {
             self.source_file_id.into_into_dart().into_dart(),
             self.status.into_into_dart().into_dart(),
             self.doc_type.into_into_dart().into_dart(),
+            self.document_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -1427,6 +1441,7 @@ impl SseEncode for crate::api::dto::ImportOutcomeDto {
         <i64>::sse_encode(self.source_file_id, serializer);
         <String>::sse_encode(self.status, serializer);
         <Option<String>>::sse_encode(self.doc_type, serializer);
+        <Option<i64>>::sse_encode(self.document_id, serializer);
     }
 }
 
@@ -1486,6 +1501,16 @@ impl SseEncode for Option<i32> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <i32>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<i64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <i64>::sse_encode(value, serializer);
         }
     }
 }

--- a/packages/core-model/src/query.rs
+++ b/packages/core-model/src/query.rs
@@ -194,8 +194,9 @@ impl Vault {
     }
 
     /// Look up the (unique, per v0.1) document for a source file — used by
-    /// `add_document` to return the materialized row after appending its event.
-    pub(crate) fn document_by_source_file_id(
+    /// `add_document` to return the materialized row after appending its event,
+    /// and by the mobile FFI to report the ingested document id (review queue).
+    pub fn document_by_source_file_id(
         &self,
         source_file_id: i64,
     ) -> Result<Option<Document>, MedmeError> {


### PR DESCRIPTION
导入后显式标记新文档为待确认(FFI 返回 document_id),不再靠基线推断。cargo check/clippy/fmt + analyze 全过,core-model 仅 pub 改动桌面照编。