### PR TITLE
feat(mobile): 家庭多成员切换 + 主页链接

### DIFF
--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:mobile_flutter/src/rust/frb_generated.dart';
-import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/screens/archive_screen.dart';
 import 'package:mobile_flutter/screens/export_screen.dart';
 import 'package:mobile_flutter/screens/settings_screen.dart';
-import 'package:mobile_flutter/icloud_bridge.dart';
+import 'package:mobile_flutter/vault_boot.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -46,20 +44,8 @@ class VaultBootstrap extends StatefulWidget {
 }
 
 class _VaultBootstrapState extends State<VaultBootstrap> {
-  late final Future<void> _open = _openVault();
-
-  Future<void> _openVault() async {
-    final docs = await getApplicationDocumentsDirectory();
-    final support = await getApplicationSupportDirectory();
-    // iCloud 容器路径由原生 channel 解析(iOS 且登录了 iCloud 才非空),传给 Rust:
-    // 若之前开过同步(<data>/icloud_enabled 标记在)且容器可用,保险箱真相就开在容器里。
-    final container = await IcloudBridge.containerPath();
-    await openVault(
-      docsDir: docs.path,
-      dataDir: support.path,
-      icloudContainerDir: container,
-    );
-  }
+  // 打开「当前成员」的保险箱(多成员见 profile_manager / vault_boot)。
+  final Future<void> _open = openCurrentProfileVault();
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile_flutter/lib/profile_manager.dart
+++ b/apps/mobile_flutter/lib/profile_manager.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// 家庭多成员管理:每个成员一个独立保险箱(子文件夹),用**名字**区分(不设别名)。
+/// 成员表持久化到沙盒 `<support>/profiles.json`,与 Apple ID 无关——纯本地 + 子文件夹。
+///
+/// 路径策略(零迁移):**第一个成员(默认「我」)用原有位置** `<docs>/vault`
+/// (以及 iCloud `<container>/Documents/vault`),已有数据原地不动;新增成员用
+/// `<docs>/profiles/<名字>/vault`(iCloud `<container>/Documents/profiles/<名字>/vault`)。
+/// iCloud 是全局开关(在设置),开了后每个成员按自己的子路径同步进容器,天然覆盖全部成员。
+class ProfileManager {
+  ProfileManager._();
+  static final ProfileManager instance = ProfileManager._();
+
+  /// 当前成员变化时通知各屏重载(切换成员 = 重开保险箱)。
+  final ValueNotifier<String> currentMember = ValueNotifier<String>('我');
+
+  List<String> _members = const ['我'];
+  bool _loaded = false;
+  File? _file;
+
+  List<String> get members => List.unmodifiable(_members);
+  String get current => currentMember.value;
+
+  Future<File> _stateFile() async {
+    if (_file != null) return _file!;
+    final dir = await getApplicationSupportDirectory();
+    return _file = File('${dir.path}/profiles.json');
+  }
+
+  Future<void> ensureLoaded() async {
+    if (_loaded) return;
+    try {
+      final f = await _stateFile();
+      if (await f.exists()) {
+        final json = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+        final list = (json['members'] as List?)
+            ?.map((e) => e as String)
+            .toList();
+        if (list != null && list.isNotEmpty) _members = list;
+        final cur = json['current'] as String?;
+        currentMember.value = (cur != null && _members.contains(cur))
+            ? cur
+            : _members.first;
+      }
+    } catch (_) {
+      // 读坏了不致命:退回单成员「我」。
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    try {
+      final f = await _stateFile();
+      await f.writeAsString(
+        jsonEncode({'members': _members, 'current': current}),
+      );
+    } catch (_) {}
+  }
+
+  /// 切到某成员(需已存在)。调用方随后重开保险箱(见 `openCurrentProfileVault`)。
+  Future<void> switchTo(String name) async {
+    await ensureLoaded();
+    if (!_members.contains(name)) return;
+    if (currentMember.value == name) return;
+    currentMember.value = name;
+    await _save();
+  }
+
+  /// 新增一个成员并切过去。名字为空或重名则忽略/直接切过去。
+  Future<void> create(String name) async {
+    await ensureLoaded();
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return;
+    if (!_members.contains(trimmed)) {
+      _members = [..._members, trimmed];
+    }
+    currentMember.value = trimmed;
+    await _save();
+  }
+
+  // ---- 路径组合(第一个成员用原位置,其余用子文件夹)----
+
+  bool _isRoot(String name) => _members.isNotEmpty && name == _members.first;
+
+  String _safe(String name) => name.replaceAll('/', '_');
+
+  /// 当前成员的本机保险箱基目录(其下有 `vault/`)。
+  String localBase(String docsRoot) =>
+      _isRoot(current) ? docsRoot : '$docsRoot/profiles/${_safe(current)}';
+
+  /// 当前成员的 iCloud 目录基(其下有 `vault/`);容器不可用返回 null。
+  String? containerBase(String? containerRoot) {
+    if (containerRoot == null) return null;
+    return _isRoot(current)
+        ? '$containerRoot/Documents'
+        : '$containerRoot/Documents/profiles/${_safe(current)}';
+  }
+}

--- a/apps/mobile_flutter/lib/review_state.dart
+++ b/apps/mobile_flutter/lib/review_state.dart
@@ -3,23 +3,24 @@ import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
 
-/// 「新导入待确认」本地状态。持久化一份「待确认文档 id 集」到沙盒
-/// `<support>/review_state.json`(纯本设备 UI 状态,不进保险箱、不需跨设备同步)。
+import 'package:mobile_flutter/profile_manager.dart';
+
+/// 「新导入待确认」本地状态,**按成员分命名空间**(每个成员独立的待确认集,不同
+/// 成员的保险箱各自从 id 1 起,共用一个集合会撞车)。持久化到沙盒
+/// `<support>/review_state.json`(纯本设备 UI 状态,不进保险箱)。
 ///
-/// 语义(显式、可靠):
-/// - **导入**时,把本次新建的文档 id 显式加入待确认集([markPending])。
-/// - 健康档案顶部把待确认集里的文档列为「待确认」,置顶让用户过一眼。
-/// - 用户点「确认」→ 从集里移除([markReviewed]),归入正常时间线。
-///
-/// 不再靠「基线/已审集」反向推断(那种做法对已有数据、去重、时序都容易出错——用户
-/// 反馈过看不到待确认)。现在只有真正新导入的文档才进队列,零歧义、零 spine 风险。
+/// 语义:导入时把本次新建文档 id 显式加入**当前成员**的待确认集([markPending]);
+/// 健康档案顶部把当前成员待确认集里的文档置顶让用户核对;点「确认」移除([markReviewed])。
 class ReviewState {
   ReviewState._();
   static final ReviewState instance = ReviewState._();
 
-  final Set<int> _pending = {};
+  final Map<String, Set<int>> _byMember = {};
   bool _loaded = false;
   File? _file;
+
+  Set<int> _cur() =>
+      _byMember.putIfAbsent(ProfileManager.instance.current, () => <int>{});
 
   Future<File> _stateFile() async {
     if (_file != null) return _file!;
@@ -27,19 +28,22 @@ class ReviewState {
     return _file = File('${dir.path}/review_state.json');
   }
 
-  /// 从磁盘载入待确认集(幂等,每会话读一次)。健康档案 build 前调一次。
   Future<void> ensureLoaded() async {
     if (_loaded) return;
     try {
       final f = await _stateFile();
       if (await f.exists()) {
         final json = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
-        _pending
-          ..clear()
-          ..addAll((json['pending'] as List? ?? const []).map((e) => e as int));
+        final pending = json['pending'] as Map<String, dynamic>?;
+        if (pending != null) {
+          _byMember.clear();
+          pending.forEach((member, ids) {
+            _byMember[member] = (ids as List).map((e) => e as int).toSet();
+          });
+        }
       }
     } catch (_) {
-      // 读坏了不致命:当空集,后续导入会重新填。
+      // 读坏了不致命:当空,后续导入会重填。
     }
     _loaded = true;
   }
@@ -47,37 +51,39 @@ class ReviewState {
   Future<void> _save() async {
     try {
       final f = await _stateFile();
-      await f.writeAsString(jsonEncode({'pending': _pending.toList()}));
-    } catch (_) {
-      // 写失败不致命(下次再写);本会话内存状态仍对。
-    }
+      final map = <String, List<int>>{};
+      _byMember.forEach((m, ids) {
+        if (ids.isNotEmpty) map[m] = ids.toList();
+      });
+      await f.writeAsString(jsonEncode({'pending': map}));
+    } catch (_) {}
   }
 
-  /// 该文档是否「新导入·待确认」。
-  bool isPending(int docId) => _pending.contains(docId);
+  /// 当前成员下,该文档是否「新导入·待确认」。
+  bool isPending(int docId) => _cur().contains(docId);
 
-  /// 导入后把新建文档 id 加入待确认集。
+  /// 导入后把新建文档 id 加入当前成员的待确认集。
   Future<void> markPending(Iterable<int> docIds) async {
     await ensureLoaded();
     var changed = false;
     for (final id in docIds) {
-      changed = _pending.add(id) || changed;
+      changed = _cur().add(id) || changed;
     }
     if (changed) await _save();
   }
 
-  /// 确认通过一份 → 移出待确认集(归入正常时间线)。
+  /// 确认通过一份 → 移出当前成员待确认集。
   Future<void> markReviewed(int docId) async {
     await ensureLoaded();
-    if (_pending.remove(docId)) await _save();
+    if (_cur().remove(docId)) await _save();
   }
 
-  /// 一键全部确认。
+  /// 一键全部确认(当前成员)。
   Future<void> markAllReviewed(Iterable<int> docIds) async {
     await ensureLoaded();
     var changed = false;
     for (final id in docIds) {
-      changed = _pending.remove(id) || changed;
+      changed = _cur().remove(id) || changed;
     }
     if (changed) await _save();
   }

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -7,6 +7,8 @@ import 'package:mobile_flutter/screens/document_detail.dart';
 import 'package:mobile_flutter/vault_events.dart';
 import 'package:mobile_flutter/import_flow.dart';
 import 'package:mobile_flutter/review_state.dart';
+import 'package:mobile_flutter/profile_manager.dart';
+import 'package:mobile_flutter/vault_boot.dart';
 
 /// 底部导航一级 tab「健康档案」—— 生命时间线:就诊组 + 独立文档,按日期倒序,
 /// 点开看详情。与旧 Tauri 移动端 App.tsx 的 archive tab(phead + tl)同一观感,
@@ -177,6 +179,102 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
     if (mounted) setState(() {});
   }
 
+  /// 顶部 banner 点击:弹出成员切换器(家庭多成员)。
+  Future<void> _showProfileSwitcher() async {
+    await ProfileManager.instance.ensureLoaded();
+    final members = ProfileManager.instance.members;
+    final current = ProfileManager.instance.current;
+    if (!mounted) return;
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(20, 4, 20, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  '切换成员',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                ),
+              ),
+            ),
+            for (final m in members)
+              ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: MedMe.tealSoft,
+                  child: Text(
+                    m.isNotEmpty ? m[0] : '?',
+                    style: const TextStyle(
+                      color: MedMe.teal,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                title: Text(
+                  m,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                trailing: m == current
+                    ? const Icon(Icons.check, color: MedMe.teal)
+                    : null,
+                onTap: () => Navigator.of(context).pop('member:$m'),
+              ),
+            const Divider(height: 1),
+            ListTile(
+              leading: const Icon(Icons.person_add_alt, color: MedMe.teal),
+              title: const Text('添加成员'),
+              onTap: () => Navigator.of(context).pop('add'),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (action == null || !mounted) return;
+    if (action == 'add') {
+      await _addMember();
+    } else if (action.startsWith('member:')) {
+      final name = action.substring('member:'.length);
+      if (name != current) {
+        await switchProfileAndReopen(name);
+        if (mounted) setState(() {});
+      }
+    }
+  }
+
+  Future<void> _addMember() async {
+    final controller = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('添加成员'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: '成员名字(如:妈妈、爸爸)'),
+          onSubmitted: (v) => Navigator.of(context).pop(v),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('创建'),
+          ),
+        ],
+      ),
+    );
+    if (name == null || name.trim().isEmpty || !mounted) return;
+    await createProfileAndReopen(name.trim());
+    if (mounted) setState(() {});
+  }
+
   Future<void> _refresh() async {
     final next = _load();
     setState(() => _future = next);
@@ -247,7 +345,11 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
               physics: const AlwaysScrollableScrollPhysics(),
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
               children: [
-                _PatientHeader(profile: profile),
+                _PatientHeader(
+                  profile: profile,
+                  memberName: ProfileManager.instance.current,
+                  onTap: _showProfileSwitcher,
+                ),
                 const SizedBox(height: 20),
                 if (unreviewed.isNotEmpty) ...[
                   _NewImportsSection(
@@ -291,62 +393,90 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
 /// 患者头卡:姓名 / 性别·年龄 / 记录数,字段可空一律优雅缺省。
 class _PatientHeader extends StatelessWidget {
   final PatientProfileDto profile;
-  const _PatientHeader({required this.profile});
+  final String memberName;
+  final VoidCallback onTap;
+  const _PatientHeader({
+    required this.profile,
+    required this.memberName,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final initial = (profile.name?.isNotEmpty ?? false)
-        ? profile.name![0]
-        : '我';
+    final initial = memberName.isNotEmpty ? memberName[0] : '我';
     final subParts = [
       profile.gender,
       profile.age,
     ].whereType<String>().where((s) => s.isNotEmpty).toList();
     subParts.add('${profile.recordCount} 份记录');
 
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: MedMe.panel,
+    return Material(
+      color: MedMe.panel,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap, // 点顶部切换成员(家庭多成员)
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MedMe.line),
-      ),
-      child: Row(
-        children: [
-          CircleAvatar(
-            radius: 26,
-            backgroundColor: MedMe.tealSoft,
-            child: Text(
-              initial,
-              style: const TextStyle(
-                color: MedMe.teal,
-                fontWeight: FontWeight.w700,
-                fontSize: 18,
-              ),
-            ),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: MedMe.line),
           ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  profile.name ?? '我的健康档案',
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 26,
+                backgroundColor: MedMe.tealSoft,
+                child: Text(
+                  initial,
                   style: const TextStyle(
-                    fontSize: 17,
-                    fontWeight: FontWeight.w800,
-                    color: MedMe.ink,
+                    color: MedMe.teal,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 18,
                   ),
                 ),
-                const SizedBox(height: 2),
-                Text(
-                  subParts.join(' · '),
-                  style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            memberName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 17,
+                              fontWeight: FontWeight.w800,
+                              color: MedMe.ink,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        const Icon(
+                          Icons.unfold_more,
+                          size: 18,
+                          color: MedMe.faint,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subParts.join(' · '),
+                      style: const TextStyle(
+                        fontSize: 12.5,
+                        color: MedMe.faint,
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
 import 'package:mobile_flutter/icloud_bridge.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// 与 `pubspec.yaml` 的 `version:` 字段保持一致。P3 范围内没有为读版本号新增
 /// `package_info_plus` 依赖(约束里明确不加新依赖),手工同步即可——这颗
@@ -63,6 +64,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _showSnack(String text) {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+  }
+
+  Future<void> _openHomepage() async {
+    final uri = Uri.parse('https://chesterguan.github.io/medme/');
+    final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!ok) _showSnack('无法打开主页,请稍后重试');
   }
 
   Future<void> _loadDemoData() async {
@@ -169,6 +176,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _SectionLabel('关于'),
           _SettingsGroup(
             children: [
+              _SettingsRow(
+                icon: Icons.home_outlined,
+                title: 'MedMe 主页',
+                subtitle: '了解更多、下载其它平台版本',
+                onTap: _openHomepage,
+              ),
               _InfoRow(
                 title: 'MedMe 医我',
                 subtitle: 'v$_appVersion · 本地优先:你的病历只保存在你自己的设备上',

--- a/apps/mobile_flutter/lib/vault_boot.dart
+++ b/apps/mobile_flutter/lib/vault_boot.dart
@@ -1,0 +1,38 @@
+import 'package:path_provider/path_provider.dart';
+
+import 'package:mobile_flutter/src/rust/api/vault.dart';
+import 'package:mobile_flutter/icloud_bridge.dart';
+import 'package:mobile_flutter/profile_manager.dart';
+import 'package:mobile_flutter/vault_events.dart';
+
+/// 打开「当前成员」的保险箱:按 [ProfileManager] 组合本机/iCloud 路径,调 Rust
+/// `open_vault`(Rust 的进程级 vault 会被替换成该成员的)。启动 + 切换成员后都调它。
+///
+/// data 目录(设备 id、iCloud 全局开关标记、导入临时文件)所有成员共用——iCloud 是
+/// 全局开关(开了对所有成员生效);派生库则每成员独立(见 Rust `resolve_vault_paths`)。
+Future<void> openCurrentProfileVault() async {
+  await ProfileManager.instance.ensureLoaded();
+  final docsRoot = (await getApplicationDocumentsDirectory()).path;
+  final support = (await getApplicationSupportDirectory()).path;
+  final containerRoot = await IcloudBridge.containerPath();
+
+  await openVault(
+    docsDir: ProfileManager.instance.localBase(docsRoot),
+    dataDir: support,
+    icloudContainerDir: ProfileManager.instance.containerBase(containerRoot),
+  );
+}
+
+/// 切换到某成员并重开其保险箱,然后通知各屏刷新。
+Future<void> switchProfileAndReopen(String name) async {
+  await ProfileManager.instance.switchTo(name);
+  await openCurrentProfileVault();
+  bumpVaultRevision();
+}
+
+/// 新建成员(空库)并切过去、重开、刷新。
+Future<void> createProfileAndReopen(String name) async {
+  await ProfileManager.instance.create(name);
+  await openCurrentProfileVault();
+  bumpVaultRevision();
+}

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -944,6 +944,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -952,6 +976,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+11
+version: 1.2.0+12
 
 environment:
   sdk: ^3.12.2
@@ -47,6 +47,7 @@ dependencies:
   photo_view: ^0.15.0
   pdfx: ^2.9.2
   share_plus: ^11.0.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -144,8 +144,12 @@ fn resolve_vault_paths(
     let local_db = local_vault.join("medme.db");
     if data_dir.join("icloud_enabled").exists() {
         if let Some(c) = container {
-            let cv = Path::new(c).join("Documents").join("vault");
-            return (cv, data_dir.join("medme.db"));
+            // `container` 是 Dart 拼好的「该成员的 iCloud 目录基」(含 Documents 及
+            // 多成员子文件夹),这里只补 `vault`;派生库放**该成员的本机基目录**下
+            // (每成员独立、且不进 iCloud——多成员共用 data_dir/medme.db 会撞库)。
+            let _ = data_dir;
+            let cv = Path::new(c).join("vault");
+            return (cv, docs_dir.join("medme.db"));
         }
     }
     (local_vault, local_db)
@@ -715,13 +719,16 @@ pub fn icloud_status() -> IcloudStatusDto {
 /// core-model `relocate_to`(搬 objects/log/db/VERSION;容器里已有别设备的 vault 则
 /// adopt+merge)——与已验证的 Tauri #38 同一套安全操作。幂等。
 pub fn enable_icloud_sync(container_dir: String) -> anyhow::Result<()> {
-    let container_vault = Path::new(&container_dir).join("Documents").join("vault");
+    // `container_dir` 是 Dart 拼好的「该成员 iCloud 目录基」(含 Documents 及多成员
+    // 子文件夹),这里只补 `vault`。
+    let container_vault = Path::new(&container_dir).join("vault");
     with_state_mut(|state| {
         if state.truth_root == container_vault {
             std::fs::write(state.data_dir.join("icloud_enabled"), "1")?;
             return Ok(());
         }
-        let sandbox_db = state.data_dir.join("medme.db");
+        // 派生库放该成员本机基目录(每成员独立,不进 iCloud),避免多成员撞库。
+        let sandbox_db = state.docs_dir.join("medme.db");
         state
             .vault
             .relocate_to(&container_vault)


### PR DESCRIPTION
档案顶部 banner 切换成员(每成员独立库/子文件夹),iCloud 全局开关覆盖所有成员;设置加主页链接。analyze/cargo check 全过。