### PR TITLE
feat(mobile): 档案名自动识别 + 导入姓名不符警告

### DIFF
--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -11,6 +11,7 @@ import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
 import 'package:mobile_flutter/review_state.dart';
+import 'package:mobile_flutter/profile_manager.dart';
 
 /// 「健康档案」右上角「+ 导入」触发的采集流程:弹三选一(拍照 / 相册 / 选文件),
 /// 选定后逐个采集→(图片先 ML Kit 中文 OCR)→落库,期间显示进度对话框,结束弹汇总,
@@ -127,7 +128,9 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
 
   TextRecognizer? recognizer;
   final rows = <ImportResultRow>[];
-  final newDocIds = <int>[]; // 本次新建的文档 id → 加入「待确认」队列
+  // 本次新建文档 id → 报告里识别到的患者姓名(识别不到为 null),进「待确认」队列;
+  // 姓名与当前成员不符者会被标红,识别到的姓名还用来自动命名默认档案。
+  final newDocs = <int, String?>{};
   for (var i = 0; i < items.length; i++) {
     final item = items[i];
     progress.value = '正在导入 ${i + 1}/${items.length}…';
@@ -149,7 +152,7 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
         final bytes = await File(item.path).readAsBytes();
         outcome = await ingestBytes(filename: item.name, data: bytes);
       }
-      if (outcome.documentId case final id?) newDocIds.add(id);
+      if (outcome.documentId case final id?) newDocs[id] = outcome.detectedName;
       rows.add(rowFromOutcome(outcome));
     } catch (e) {
       rows.add(rowFromError(item.name, e));
@@ -158,8 +161,18 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
   await recognizer?.close();
 
   // 本次新建的文档显式加入「待确认」队列(健康档案顶部据此置顶让用户核对)。
-  if (newDocIds.isNotEmpty) {
-    await ReviewState.instance.markPending(newDocIds);
+  if (newDocs.isNotEmpty) {
+    // 默认档案还没定过名字时,用识别到的第一个患者姓名自动命名它(迁移待确认键)。
+    final detected = newDocs.values.firstWhere(
+      (n) => n != null && n.trim().isNotEmpty,
+      orElse: () => null,
+    );
+    if (detected != null) {
+      final old = ProfileManager.instance.current;
+      final renamed = await ProfileManager.instance.maybeAutoNameRoot(detected);
+      if (renamed != null) await ReviewState.instance.renameMember(old, renamed);
+    }
+    await ReviewState.instance.markPending(newDocs);
   }
   // 有任一份成功落库,通知「健康档案」屏自动刷新。
   if (rows.any((r) => r.kind != ImportRowKind.failed)) {

--- a/apps/mobile_flutter/lib/profile_manager.dart
+++ b/apps/mobile_flutter/lib/profile_manager.dart
@@ -19,6 +19,9 @@ class ProfileManager {
   final ValueNotifier<String> currentMember = ValueNotifier<String>('我');
 
   List<String> _members = const ['我'];
+  // 首个成员的名字是否仍是占位默认(未被用户/自动识别定过)。为 true 时,首次导入
+  // 若从报告里识别到患者姓名,就把默认档案自动改成那个名字(见 [maybeAutoNameRoot])。
+  bool _rootAutoNamed = true;
   bool _loaded = false;
   File? _file;
 
@@ -45,6 +48,7 @@ class ProfileManager {
         currentMember.value = (cur != null && _members.contains(cur))
             ? cur
             : _members.first;
+        _rootAutoNamed = json['rootAutoNamed'] as bool? ?? false;
       }
     } catch (_) {
       // 读坏了不致命:退回单成员「我」。
@@ -56,7 +60,11 @@ class ProfileManager {
     try {
       final f = await _stateFile();
       await f.writeAsString(
-        jsonEncode({'members': _members, 'current': current}),
+        jsonEncode({
+          'members': _members,
+          'current': current,
+          'rootAutoNamed': _rootAutoNamed,
+        }),
       );
     } catch (_) {}
   }
@@ -78,8 +86,28 @@ class ProfileManager {
     if (!_members.contains(trimmed)) {
       _members = [..._members, trimmed];
     }
+    _rootAutoNamed = false; // 用户已主动管理成员,别再自动改默认档案名
     currentMember.value = trimmed;
     await _save();
+  }
+
+  /// 首个(唯一)成员仍是占位默认时,用报告里识别到的患者姓名自动命名它。
+  /// 返回被改成的新名字(发生了重命名)或 null(未改)。根成员路径与名字无关
+  /// (见 [localBase]),重命名只是换标签,无需迁移文件/重开保险箱。
+  Future<String?> maybeAutoNameRoot(String detectedName) async {
+    await ensureLoaded();
+    final name = detectedName.trim();
+    if (!_rootAutoNamed || _members.length != 1 || name.isEmpty) return null;
+    if (_members.first == name) {
+      _rootAutoNamed = false;
+      await _save();
+      return null;
+    }
+    _members = [name];
+    _rootAutoNamed = false;
+    currentMember.value = name;
+    await _save();
+    return name;
   }
 
   // ---- 路径组合(第一个成员用原位置,其余用子文件夹)----

--- a/apps/mobile_flutter/lib/review_state.dart
+++ b/apps/mobile_flutter/lib/review_state.dart
@@ -9,6 +9,9 @@ import 'package:mobile_flutter/profile_manager.dart';
 /// 成员的保险箱各自从 id 1 起,共用一个集合会撞车)。持久化到沙盒
 /// `<support>/review_state.json`(纯本设备 UI 状态,不进保险箱)。
 ///
+/// 除了待确认集,还记录每份新导入报告里**识别到的患者姓名**——若它和当前成员档案
+/// 名字不一致([_flagged]),说明可能导错了人,健康档案会给这份标红警告。
+///
 /// 语义:导入时把本次新建文档 id 显式加入**当前成员**的待确认集([markPending]);
 /// 健康档案顶部把当前成员待确认集里的文档置顶让用户核对;点「确认」移除([markReviewed])。
 class ReviewState {
@@ -16,11 +19,15 @@ class ReviewState {
   static final ReviewState instance = ReviewState._();
 
   final Map<String, Set<int>> _byMember = {};
+  // 成员 → (文档 id → 报告里识别到的、与该成员名字**不符**的患者姓名)。
+  final Map<String, Map<int, String>> _flagged = {};
   bool _loaded = false;
   File? _file;
 
   Set<int> _cur() =>
       _byMember.putIfAbsent(ProfileManager.instance.current, () => <int>{});
+  Map<int, String> _curFlagged() =>
+      _flagged.putIfAbsent(ProfileManager.instance.current, () => <int, String>{});
 
   Future<File> _stateFile() async {
     if (_file != null) return _file!;
@@ -41,6 +48,15 @@ class ReviewState {
             _byMember[member] = (ids as List).map((e) => e as int).toSet();
           });
         }
+        final flagged = json['flagged'] as Map<String, dynamic>?;
+        if (flagged != null) {
+          _flagged.clear();
+          flagged.forEach((member, m) {
+            _flagged[member] = (m as Map<String, dynamic>).map(
+              (k, v) => MapEntry(int.parse(k), v as String),
+            );
+          });
+        }
       }
     } catch (_) {
       // 读坏了不致命:当空,后续导入会重填。
@@ -51,31 +67,48 @@ class ReviewState {
   Future<void> _save() async {
     try {
       final f = await _stateFile();
-      final map = <String, List<int>>{};
+      final pending = <String, List<int>>{};
       _byMember.forEach((m, ids) {
-        if (ids.isNotEmpty) map[m] = ids.toList();
+        if (ids.isNotEmpty) pending[m] = ids.toList();
       });
-      await f.writeAsString(jsonEncode({'pending': map}));
+      final flagged = <String, Map<String, String>>{};
+      _flagged.forEach((m, map) {
+        if (map.isNotEmpty) {
+          flagged[m] = map.map((k, v) => MapEntry(k.toString(), v));
+        }
+      });
+      await f.writeAsString(jsonEncode({'pending': pending, 'flagged': flagged}));
     } catch (_) {}
   }
 
   /// 当前成员下,该文档是否「新导入·待确认」。
   bool isPending(int docId) => _cur().contains(docId);
 
-  /// 导入后把新建文档 id 加入当前成员的待确认集。
-  Future<void> markPending(Iterable<int> docIds) async {
+  /// 该待确认文档识别到的、与当前成员名字不符的患者姓名;一致或无则 null。
+  String? mismatchName(int docId) => _curFlagged()[docId];
+
+  /// 导入后把新建文档加入当前成员的待确认集。`docs` = 文档 id → 报告里识别到的
+  /// 患者姓名(识别不到为 null);姓名与当前成员不符的记为「疑似导错人」。
+  Future<void> markPending(Map<int, String?> docs) async {
     await ensureLoaded();
+    final member = ProfileManager.instance.current;
     var changed = false;
-    for (final id in docIds) {
+    docs.forEach((id, detected) {
       changed = _cur().add(id) || changed;
-    }
+      if (detected != null && detected.trim().isNotEmpty && detected != member) {
+        _curFlagged()[id] = detected;
+        changed = true;
+      }
+    });
     if (changed) await _save();
   }
 
-  /// 确认通过一份 → 移出当前成员待确认集。
+  /// 确认通过一份 → 移出当前成员待确认集(连同标红)。
   Future<void> markReviewed(int docId) async {
     await ensureLoaded();
-    if (_cur().remove(docId)) await _save();
+    final a = _cur().remove(docId);
+    final b = _curFlagged().remove(docId) != null;
+    if (a || b) await _save();
   }
 
   /// 一键全部确认(当前成员)。
@@ -84,7 +117,19 @@ class ReviewState {
     var changed = false;
     for (final id in docIds) {
       changed = _cur().remove(id) || changed;
+      changed = (_curFlagged().remove(id) != null) || changed;
     }
     if (changed) await _save();
+  }
+
+  /// 成员改名(如默认档案被识别到的姓名自动重命名)时迁移其待确认/标红键。
+  Future<void> renameMember(String from, String to) async {
+    if (from == to) return;
+    await ensureLoaded();
+    final p = _byMember.remove(from);
+    if (p != null) (_byMember[to] ??= <int>{}).addAll(p);
+    final fl = _flagged.remove(from);
+    if (fl != null) (_flagged[to] ??= <int, String>{}).addAll(fl);
+    if (p != null || fl != null) await _save();
   }
 }

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -748,40 +748,96 @@ class _NewImportsSection extends StatelessWidget {
           for (final d in docs)
             Card(
               margin: const EdgeInsets.only(top: 8),
-              child: ListTile(
-                leading: CircleAvatar(
-                  backgroundColor: _colorFor(d.docType).withValues(alpha: 0.12),
-                  child: Icon(
-                    _iconForDoc(d.docType),
-                    color: _colorFor(d.docType),
-                    size: 20,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: _colorFor(
+                        d.docType,
+                      ).withValues(alpha: 0.12),
+                      child: Icon(
+                        _iconForDoc(d.docType),
+                        color: _colorFor(d.docType),
+                        size: 20,
+                      ),
+                    ),
+                    title: Text(
+                      d.title ?? _docLabel[d.docType] ?? '记录',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    subtitle: Text(
+                      [
+                        _docLabel[d.docType] ?? d.docType,
+                        _fmtDate(d.docDate).isNotEmpty
+                            ? _fmtDate(d.docDate)
+                            : '无日期',
+                      ].join(' · '),
+                      style: const TextStyle(
+                        color: MedMe.faint,
+                        fontSize: 12.5,
+                      ),
+                    ),
+                    trailing: FilledButton(
+                      style: FilledButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                      ),
+                      onPressed: () => onReview(d.id),
+                      child: const Text('确认'),
+                    ),
+                    onTap: () => onOpen(d.id),
                   ),
-                ),
-                title: Text(
-                  d.title ?? _docLabel[d.docType] ?? '记录',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontWeight: FontWeight.w600),
-                ),
-                subtitle: Text(
-                  [
-                    _docLabel[d.docType] ?? d.docType,
-                    _fmtDate(d.docDate).isNotEmpty
-                        ? _fmtDate(d.docDate)
-                        : '无日期',
-                  ].join(' · '),
-                  style: const TextStyle(color: MedMe.faint, fontSize: 12.5),
-                ),
-                trailing: FilledButton(
-                  style: FilledButton.styleFrom(
-                    visualDensity: VisualDensity.compact,
-                  ),
-                  onPressed: () => onReview(d.id),
-                  child: const Text('确认'),
-                ),
-                onTap: () => onOpen(d.id),
+                  if (ReviewState.instance.mismatchName(d.id) case final who?)
+                    _MismatchBanner(who: who),
+                ],
               ),
             ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 这份报告识别到的患者姓名和当前档案不一致 → 醒目提示,可能导错了人。
+/// 只警告不自动搬(用户可自行处理);点开核对无误后「确认」即可归档。
+class _MismatchBanner extends StatelessWidget {
+  const _MismatchBanner({required this.who});
+
+  final String who;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.orange.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.orange.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            color: Colors.orange,
+            size: 18,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              '报告上的姓名是「$who」,与当前档案「${ProfileManager.instance.current}」不一致,'
+              '请核对是否导错了人。',
+              style: const TextStyle(
+                fontSize: 12,
+                height: 1.4,
+                color: Color(0xFFB25E00),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/apps/mobile_flutter/lib/src/rust/api/dto.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/dto.dart
@@ -197,12 +197,18 @@ class ImportOutcomeDto {
   /// 去重/失败等没建文档的情况为 None。
   final PlatformInt64? documentId;
 
+  /// 从本份报告文本里识别出的**患者姓名**(`parser::extract_demographics`)。
+  /// 前端用它和当前成员档案名字比对——不一致就在「待确认」里标红警告(防导错人)。
+  /// 识别不到为 None。
+  final String? detectedName;
+
   const ImportOutcomeDto({
     required this.name,
     required this.sourceFileId,
     required this.status,
     this.docType,
     this.documentId,
+    this.detectedName,
   });
 
   @override
@@ -211,7 +217,8 @@ class ImportOutcomeDto {
       sourceFileId.hashCode ^
       status.hashCode ^
       docType.hashCode ^
-      documentId.hashCode;
+      documentId.hashCode ^
+      detectedName.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -222,7 +229,8 @@ class ImportOutcomeDto {
           sourceFileId == other.sourceFileId &&
           status == other.status &&
           docType == other.docType &&
-          documentId == other.documentId;
+          documentId == other.documentId &&
+          detectedName == other.detectedName;
 }
 
 class PatientProfileDto {

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'dto.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `doc_summary`, `ingest_one`, `machine_device_id`, `open_resilient_with_fallback`, `resolve_vault_paths`, `vault_cell`, `with_state_mut`, `with_state`
+// These functions are ignored because they are not marked as `pub`: `collect_demo_files`, `detected_name_for`, `doc_summary`, `ingest_one`, `machine_device_id`, `open_resilient_with_fallback`, `resolve_vault_paths`, `vault_cell`, `with_state_mut`, `with_state`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultState`
 
 /// 打开(或新建)保险箱。iCloud 容器路径由 **Dart 侧经 MethodChannel 解析后传入**

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -852,14 +852,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ImportOutcomeDto dco_decode_import_outcome_dto(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return ImportOutcomeDto(
       name: dco_decode_String(arr[0]),
       sourceFileId: dco_decode_i_64(arr[1]),
       status: dco_decode_String(arr[2]),
       docType: dco_decode_opt_String(arr[3]),
       documentId: dco_decode_opt_box_autoadd_i_64(arr[4]),
+      detectedName: dco_decode_opt_String(arr[5]),
     );
   }
 
@@ -1153,12 +1154,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_status = sse_decode_String(deserializer);
     var var_docType = sse_decode_opt_String(deserializer);
     var var_documentId = sse_decode_opt_box_autoadd_i_64(deserializer);
+    var var_detectedName = sse_decode_opt_String(deserializer);
     return ImportOutcomeDto(
       name: var_name,
       sourceFileId: var_sourceFileId,
       status: var_status,
       docType: var_docType,
       documentId: var_documentId,
+      detectedName: var_detectedName,
     );
   }
 
@@ -1489,6 +1492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.status, serializer);
     sse_encode_opt_String(self.docType, serializer);
     sse_encode_opt_box_autoadd_i_64(self.documentId, serializer);
+    sse_encode_opt_String(self.detectedName, serializer);
   }
 
   @protected

--- a/apps/mobile_flutter/rust/src/api/dto.rs
+++ b/apps/mobile_flutter/rust/src/api/dto.rs
@@ -124,6 +124,10 @@ pub struct ImportOutcomeDto {
     /// 本次采集落库的文档 id(前端「待确认」review 队列据此显式标记新导入)。
     /// 去重/失败等没建文档的情况为 None。
     pub document_id: Option<i64>,
+    /// 从本份报告文本里识别出的**患者姓名**(`parser::extract_demographics`)。
+    /// 前端用它和当前成员档案名字比对——不一致就在「待确认」里标红警告(防导错人)。
+    /// 识别不到为 None。
+    pub detected_name: Option<String>,
 }
 
 /// 加密分享生成结果:口令(单独告知医生)、记录数、文件字节数、分享文件路径。

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -306,6 +306,13 @@ pub fn patient_profile() -> anyhow::Result<PatientProfileDto> {
 /// Flutter 端已用 `google_mlkit_text_recognition` 识别好图片文本,走
 /// `ingest_image_with_text`,这里只处理 PDF/TXT/DICOM 等有文本层/结构化元数据的
 /// 文件类型(见 `docs/020_Flutter_Mobile_Rewrite.md` 的 OCR 分工)。
+/// 从一份文档的 OCR 文本里识别患者姓名(用于「导错人」核对)。读文本失败或识别不到返回 None。
+fn detected_name_for(v: &Vault, doc_id: i64) -> Option<String> {
+    v.ocr_text(doc_id)
+        .ok()
+        .and_then(|t| parser::extract_demographics(&t).name)
+}
+
 fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
     // Panic firewall:parser/dicom 栈里的 panic 不能一路 unwind 穿过持锁的 Vault、
     // 污染共享 Mutex(与 Tauri 版 `ingest_one` 同一理由)。
@@ -330,12 +337,14 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 .ok()
                 .flatten()
                 .map(|d| d.id);
+            let detected_name = document_id.and_then(|id| detected_name_for(v, id));
             ImportOutcomeDto {
                 name: o.name,
                 source_file_id: o.source_file_id,
                 status,
                 doc_type: o.doc_type.map(|d| d.as_str().to_string()),
                 document_id,
+                detected_name,
             }
         }
         Err(e) => {
@@ -350,6 +359,7 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 status: "failed".to_string(),
                 doc_type: None,
                 document_id: None,
+                detected_name: None,
             }
         }
     }
@@ -461,6 +471,7 @@ pub fn ingest_image_with_text(
                 status: "deduped".to_string(),
                 doc_type: None,
                 document_id: None,
+                detected_name: None,
             }
         } else {
             let text = ocr_text.trim().to_string();
@@ -494,6 +505,7 @@ pub fn ingest_image_with_text(
                     status: status.to_string(),
                     doc_type: Some(doc_type.as_str().to_string()),
                     document_id: Some(doc.id),
+                    detected_name: parser::extract_demographics(&text).name,
                 }
             } else {
                 let (doc_date, doc_date_end) = parser::guess_date_range(&safe_name);
@@ -515,6 +527,7 @@ pub fn ingest_image_with_text(
                     status: "stored_no_text".to_string(),
                     doc_type: Some(doc_type.as_str().to_string()),
                     document_id: Some(doc.id),
+                    detected_name: None, // 无文本,识别不到名字
                 }
             }
         };

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -859,12 +859,14 @@ impl SseDecode for crate::api::dto::ImportOutcomeDto {
         let mut var_status = <String>::sse_decode(deserializer);
         let mut var_docType = <Option<String>>::sse_decode(deserializer);
         let mut var_documentId = <Option<i64>>::sse_decode(deserializer);
+        let mut var_detectedName = <Option<String>>::sse_decode(deserializer);
         return crate::api::dto::ImportOutcomeDto {
             name: var_name,
             source_file_id: var_sourceFileId,
             status: var_status,
             doc_type: var_docType,
             document_id: var_documentId,
+            detected_name: var_detectedName,
         };
     }
 }
@@ -1220,6 +1222,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::dto::ImportOutcomeDto {
             self.status.into_into_dart().into_dart(),
             self.doc_type.into_into_dart().into_dart(),
             self.document_id.into_into_dart().into_dart(),
+            self.detected_name.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -1442,6 +1445,7 @@ impl SseEncode for crate::api::dto::ImportOutcomeDto {
         <String>::sse_encode(self.status, serializer);
         <Option<String>>::sse_encode(self.doc_type, serializer);
         <Option<i64>>::sse_encode(self.document_id, serializer);
+        <Option<String>>::sse_encode(self.detected_name, serializer);
     }
 }
 


### PR DESCRIPTION
## 目的
让「多成员 + 待确认核对」这套流程真正有意义:不再硬编码档案名「我」,并在导入时自动检查报告姓名是否对得上当前档案。

## 改动
- **FFI**:`ImportOutcomeDto` 新增 `detected_name` —— 每次采集回传报告里识别到的患者姓名(`parser::extract_demographics`)。5 处 ingest 构造全部填好。
- **默认档案自动命名**:首次导入若识别到姓名,把默认档案(占位「我」)自动改成那个名字。根成员路径与名字无关,只换标签,**零迁移、无需重开保险箱**。识别不到才保持占位,由用户自行处理。
- **导入姓名不符警告**:导入时比对报告姓名 vs 当前成员名字,不一致的在「待确认」卡片里标红警告 —— **只提示不自动搬**,用户核对后自行处理(「用户应该没那么傻」)。
- `ReviewState` 增记每份待确认报告的疑似姓名,并随成员重命名迁移键。

## 验证
- `flutter analyze lib` 干净
- `cargo check`(rust crate)通过
- 真机/模拟器行为待用户测

## 备注
UX 改动,按流程需你 approve 后再合。