### PR TITLE
chore(mobile): 版本号 1.2.0+13

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+12
+version: 1.2.0+13
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
v13 出包用的构建号提升(1.2.0+12 → +13)。内容 = 已合的 #110(档案名自动识别 + 导入姓名不符警告)。纯版本号,不涉逻辑。