### PR TITLE
feat(mobile): 保险箱名字 + 去掉「我」+ 示例载入自动跳档案 (v14)

### DIFF
--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -11,7 +11,7 @@ import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
 import 'package:mobile_flutter/review_state.dart';
-import 'package:mobile_flutter/profile_manager.dart';
+import 'package:mobile_flutter/vault_boot.dart';
 
 /// 「健康档案」右上角「+ 导入」触发的采集流程:弹三选一(拍照 / 相册 / 选文件),
 /// 选定后逐个采集→(图片先 ML Kit 中文 OCR)→落库,期间显示进度对话框,结束弹汇总,
@@ -167,11 +167,7 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
       (n) => n != null && n.trim().isNotEmpty,
       orElse: () => null,
     );
-    if (detected != null) {
-      final old = ProfileManager.instance.current;
-      final renamed = await ProfileManager.instance.maybeAutoNameRoot(detected);
-      if (renamed != null) await ReviewState.instance.renameMember(old, renamed);
-    }
+    await autoNameCurrentProfileFrom(detected);
     await ReviewState.instance.markPending(newDocs);
   }
   // 有任一份成功落库,通知「健康档案」屏自动刷新。

--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:mobile_flutter/screens/archive_screen.dart';
 import 'package:mobile_flutter/screens/export_screen.dart';
 import 'package:mobile_flutter/screens/settings_screen.dart';
 import 'package:mobile_flutter/vault_boot.dart';
+import 'package:mobile_flutter/vault_events.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -109,12 +110,32 @@ class _HomeShellState extends State<HomeShell> {
   static const _screens = [ArchiveScreen(), ExportScreen(), SettingsScreen()];
 
   @override
+  void initState() {
+    super.initState();
+    // 别的屏(如设置载入示例后)可程序化切 tab。
+    selectedTab.addListener(_onTabRequested);
+  }
+
+  @override
+  void dispose() {
+    selectedTab.removeListener(_onTabRequested);
+    super.dispose();
+  }
+
+  void _onTabRequested() {
+    if (mounted && selectedTab.value != _index) {
+      setState(() => _index = selectedTab.value);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _index, children: _screens),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _index,
-        onDestinationSelected: (i) => setState(() => _index = i),
+        // 统一走 selectedTab:手点和程序化跳转(设置载入示例后)同一条路径。
+        onDestinationSelected: (i) => selectedTab.value = i,
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.folder_outlined),

--- a/apps/mobile_flutter/lib/profile_manager.dart
+++ b/apps/mobile_flutter/lib/profile_manager.dart
@@ -15,10 +15,19 @@ class ProfileManager {
   ProfileManager._();
   static final ProfileManager instance = ProfileManager._();
 
-  /// 当前成员变化时通知各屏重载(切换成员 = 重开保险箱)。
-  final ValueNotifier<String> currentMember = ValueNotifier<String>('我');
+  /// 保险箱默认名字(不用「我」这种身份词)。用户可在设置里改成「我家」「张建国的病历」等。
+  static const defaultVaultName = '我的医疗档案';
 
-  List<String> _members = const ['我'];
+  /// 当前成员变化时通知各屏重载(切换成员 = 重开保险箱)。
+  final ValueNotifier<String> currentMember = ValueNotifier<String>(
+    defaultVaultName,
+  );
+
+  List<String> _members = const [defaultVaultName];
+  // 整个保险箱的名字(家庭/个人层面,与「成员」是两回事);设置页展示 + 可改。
+  String _vaultName = defaultVaultName;
+  // 成员 → 最近一次已知记录数(档案屏加载时回填);设置页展示每人多少份,不必开各自库去数。
+  final Map<String, int> _counts = {};
   // 首个成员的名字是否仍是占位默认(未被用户/自动识别定过)。为 true 时,首次导入
   // 若从报告里识别到患者姓名,就把默认档案自动改成那个名字(见 [maybeAutoNameRoot])。
   bool _rootAutoNamed = true;
@@ -27,6 +36,15 @@ class ProfileManager {
 
   List<String> get members => List.unmodifiable(_members);
   String get current => currentMember.value;
+  String get vaultName => _vaultName;
+
+  /// 档案屏顶部展示名:只有一个、且还没被数据/用户命过名的默认成员时,显示保险箱名
+  /// (不把占位名露出来,彻底避开「我」);否则显示当前成员真名。
+  String get displayName =>
+      (_members.length == 1 && _rootAutoNamed) ? _vaultName : current;
+
+  /// 某成员最近已知记录数(没加载过为 null)。
+  int? countFor(String member) => _counts[member];
 
   Future<File> _stateFile() async {
     if (_file != null) return _file!;
@@ -49,6 +67,12 @@ class ProfileManager {
             ? cur
             : _members.first;
         _rootAutoNamed = json['rootAutoNamed'] as bool? ?? false;
+        _vaultName = json['vaultName'] as String? ?? defaultVaultName;
+        final counts = json['counts'] as Map<String, dynamic>?;
+        if (counts != null) {
+          _counts.clear();
+          counts.forEach((k, v) => _counts[k] = v as int);
+        }
       }
     } catch (_) {
       // 读坏了不致命:退回单成员「我」。
@@ -64,6 +88,8 @@ class ProfileManager {
           'members': _members,
           'current': current,
           'rootAutoNamed': _rootAutoNamed,
+          'vaultName': _vaultName,
+          'counts': _counts,
         }),
       );
     } catch (_) {}
@@ -103,11 +129,30 @@ class ProfileManager {
       await _save();
       return null;
     }
+    final old = _members.first;
+    if (_counts.remove(old) case final n?) _counts[name] = n;
     _members = [name];
     _rootAutoNamed = false;
     currentMember.value = name;
     await _save();
     return name;
+  }
+
+  /// 改保险箱名字(设置页)。空或没变则忽略。
+  Future<void> setVaultName(String name) async {
+    await ensureLoaded();
+    final t = name.trim();
+    if (t.isEmpty || t == _vaultName) return;
+    _vaultName = t;
+    await _save();
+  }
+
+  /// 回填某成员的记录数(档案屏加载时调),供设置页展示每人多少份。
+  Future<void> setCount(String member, int n) async {
+    await ensureLoaded();
+    if (_counts[member] == n) return;
+    _counts[member] = n;
+    await _save();
   }
 
   // ---- 路径组合(第一个成员用原位置,其余用子文件夹)----

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -165,6 +165,13 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
     final groups = results[1] as List<TimelineGroupDto>;
     // 载入「待确认」集(build 里同步判断 isPending 前要先加载好)。
     await ReviewState.instance.ensureLoaded();
+    // 兜底自动命名:示例数据等不走导入流程的路径,也能把默认档案改成识别到的姓名。
+    await autoNameCurrentProfileFrom(profile.name);
+    // 回填当前成员记录数,设置页据此展示每人多少份(不必逐个开库去数)。
+    await ProfileManager.instance.setCount(
+      ProfileManager.instance.current,
+      profile.recordCount,
+    );
     return (profile, groups);
   }
 
@@ -347,7 +354,7 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
               children: [
                 _PatientHeader(
                   profile: profile,
-                  memberName: ProfileManager.instance.current,
+                  memberName: ProfileManager.instance.displayName,
                   onTap: _showProfileSwitcher,
                 ),
                 const SizedBox(height: 20),

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
+import 'package:mobile_flutter/profile_manager.dart';
 import 'package:mobile_flutter/icloud_bridge.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -76,9 +77,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _busy = true);
     try {
       final n = await loadDemoData();
-      bumpVaultRevision(); // 通知「健康档案」屏自动重载
+      bumpVaultRevision(); // 通知「健康档案」屏自动重载(并按识别姓名自动命名档案)
       await _refresh();
-      _showSnack('已载入 $n 份示例病历,去「健康档案」查看');
+      goToArchive(); // 载入完直接跳到「健康档案」,不用用户再手点
+      _showSnack('已载入 $n 份示例病历');
     } catch (e) {
       _showSnack('载入示例数据失败:$e');
     } finally {
@@ -130,8 +132,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
         children: [
-          _SectionLabel('当前健康档案'),
-          _ProfileHeader(profile: _profile),
+          _SectionLabel('保险箱'),
+          _VaultCard(profile: _profile, onChanged: () => setState(() {})),
           _SectionLabel('示例数据'),
           _SettingsGroup(
             children: [
@@ -256,68 +258,101 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 }
 
-/// 身份卡:顶部醒目展示「这是谁的健康档案」——姓名 + 性别·年龄 + 记录数。
-/// 让用户清楚当前档案属于谁(为后续家庭多成员/共享方案铺路)。姓名等来自
-/// `patientProfile()`(据已导入病历推断);空库时给友好占位。
-class _ProfileHeader extends StatelessWidget {
-  const _ProfileHeader({required this.profile});
+/// 保险箱卡:展示 + 可改**保险箱名字**(整个箱子的名字,不是某个人),多成员时列出
+/// 每位成员各有多少份档案。切换成员/导入/加成员都在「健康档案」页,这里不重复那些
+/// 功能——只做「这是哪个箱子、里面各人多少份」。名字默认「我的医疗档案」,不用「我」。
+class _VaultCard extends StatelessWidget {
+  const _VaultCard({required this.profile, required this.onChanged});
   final PatientProfileDto? profile;
+  final VoidCallback onChanged;
+
+  /// 当前成员用刚查到的最新记录数,其余成员用缓存(没加载过为 null)。
+  int? _countOf(String member) {
+    final pm = ProfileManager.instance;
+    if (member == pm.current && profile != null) return profile!.recordCount;
+    return pm.countFor(member);
+  }
+
+  Future<void> _rename(BuildContext context) async {
+    final pm = ProfileManager.instance;
+    final controller = TextEditingController(text: pm.vaultName);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('保险箱名字'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: '例如:我家、张建国的病历'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    if (name != null && name.trim().isNotEmpty) {
+      await pm.setVaultName(name);
+      onChanged();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final p = profile;
-    final rawName = p?.name;
-    final gender = p?.gender;
-    final age = p?.age;
-    final hasName = rawName != null && rawName.isNotEmpty;
-    final hasRecords = p != null && p.recordCount > 0;
-    final name = hasName ? rawName : (hasRecords ? '未命名档案' : '还没有健康档案');
-    final meta = <String>[
-      if (gender != null && gender.isNotEmpty) gender,
-      if (age != null && age.isNotEmpty) age,
-      if (p != null) '${p.recordCount} 份记录',
-    ].join(' · ');
-
+    final pm = ProfileManager.instance;
+    final members = pm.members;
+    final multi = members.length > 1;
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            CircleAvatar(
-              radius: 26,
+      child: Column(
+        children: [
+          ListTile(
+            leading: const CircleAvatar(
+              radius: 24,
               backgroundColor: MedMe.tealSoft,
-              child: const Icon(Icons.person, color: MedMe.teal, size: 30),
+              child: Icon(Icons.folder_shared, color: MedMe.teal, size: 26),
             ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    name,
-                    style: const TextStyle(
-                      fontSize: 17,
-                      fontWeight: FontWeight.w700,
-                      color: MedMe.ink,
+            title: Text(
+              pm.vaultName,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+            subtitle: Text(
+              multi
+                  ? '${members.length} 位成员'
+                  : '${_countOf(pm.current) ?? 0} 份记录',
+              style: const TextStyle(color: MedMe.faint),
+            ),
+            trailing: IconButton(
+              icon: const Icon(Icons.edit_outlined, color: MedMe.faint),
+              tooltip: '改名字',
+              onPressed: () => _rename(context),
+            ),
+          ),
+          if (multi) ...[
+            const Divider(height: 1, color: MedMe.line),
+            for (final m in members)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(m, style: const TextStyle(fontSize: 14)),
                     ),
-                  ),
-                  if (meta.isNotEmpty) ...[
-                    const SizedBox(height: 4),
                     Text(
-                      meta,
-                      style: const TextStyle(fontSize: 13, color: MedMe.faint),
+                      _countOf(m) == null ? '—' : '${_countOf(m)} 份',
+                      style: const TextStyle(color: MedMe.faint, fontSize: 13),
                     ),
                   ],
-                  const SizedBox(height: 6),
-                  const Text(
-                    '当前设备上的这份档案 · 多成员切换即将支持',
-                    style: TextStyle(fontSize: 11.5, color: MedMe.faint),
-                  ),
-                ],
+                ),
               ),
-            ),
+            const SizedBox(height: 6),
           ],
-        ),
+        ],
       ),
     );
   }

--- a/apps/mobile_flutter/lib/vault_boot.dart
+++ b/apps/mobile_flutter/lib/vault_boot.dart
@@ -3,6 +3,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/icloud_bridge.dart';
 import 'package:mobile_flutter/profile_manager.dart';
+import 'package:mobile_flutter/review_state.dart';
 import 'package:mobile_flutter/vault_events.dart';
 
 /// 打开「当前成员」的保险箱:按 [ProfileManager] 组合本机/iCloud 路径,调 Rust
@@ -28,6 +29,15 @@ Future<void> switchProfileAndReopen(String name) async {
   await ProfileManager.instance.switchTo(name);
   await openCurrentProfileVault();
   bumpVaultRevision();
+}
+
+/// 用报告里识别到的患者姓名,给还没定过名的默认档案自动命名(迁移其待确认/标红键)。
+/// 导入、载入示例、档案加载等任一有患者姓名的地方都可调,幂等:只在首次未命名时生效。
+Future<void> autoNameCurrentProfileFrom(String? detectedName) async {
+  if (detectedName == null || detectedName.trim().isEmpty) return;
+  final old = ProfileManager.instance.current;
+  final renamed = await ProfileManager.instance.maybeAutoNameRoot(detectedName);
+  if (renamed != null) await ReviewState.instance.renameMember(old, renamed);
 }
 
 /// 新建成员(空库)并切过去、重开、刷新。

--- a/apps/mobile_flutter/lib/vault_events.dart
+++ b/apps/mobile_flutter/lib/vault_events.dart
@@ -10,3 +10,10 @@ final ValueNotifier<int> vaultRevision = ValueNotifier<int>(0);
 
 /// 保险箱内容变了(导入/清空/载入示例),通知所有监听屏重载。
 void bumpVaultRevision() => vaultRevision.value++;
+
+/// 当前底部一级 tab 下标(0=健康档案,1=导出分享,2=设置)。`HomeShell` 监听它
+/// 切换页面 —— 让「设置」里载入示例后能自动跳回「健康档案」,不用用户再手点。
+final ValueNotifier<int> selectedTab = ValueNotifier<int>(0);
+
+/// 跳到「健康档案」tab。
+void goToArchive() => selectedTab.value = 0;

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+13
+version: 1.2.0+14
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 目的
按用户对 build 13 的反馈重整多成员呈现:不要「我」这种身份词、设置页别和健康档案页功能重复、示例数据载入后自动跳转。

## 改动(纯 Dart,不碰 Rust,同步格式不变)
- **彻底去掉硬编码「我」**:默认成员/顶部展示改用**保险箱名**(默认「我的医疗档案」);导入/示例识别到真实姓名(张建国)就自动改成人名,识别不到才留占位(`displayName` 兜底逻辑)。
- **设置页顶部重做**:原「当前健康档案」banner 与健康档案页切换功能重合 → 换成**可编辑的保险箱名字**;多成员时列出**每人各多少份档案**。切换/导入/加成员仍只在健康档案页,设置页不重复。
- **示例数据修两处**:`loadDemoData` 不走导入流程,此前既不按姓名归类、又停在「我」→ 现在档案屏加载时**兜底按识别姓名自动命名**(幂等,`autoNameCurrentProfileFrom` 合并进 `vault_boot`),并在**载入后自动跳到健康档案页**(新增 `selectedTab` 信号)。
- `ProfileManager` 增 `vaultName` / 每成员记录数缓存(设置页展示用,不必逐个开库去数)。

## 迁移
已装 build 13 的设备(成员还是「我」):更新后首次进健康档案会自动把「我」改成识别到的姓名(张建国),并迁移待确认/记录数键。

## 验证
- `flutter analyze` 干净(含 test)
- 真机/模拟器行为待用户测
- 版本号 → 1.2.0+14

## 备注
UX 改动,按流程等你 approve。合并后触发 v14 双端出包。