### PR TITLE
feat(mobile): iOS OCR 换 Apple Vision(原生·中文更强·支持 HEIC)

### DIFF
--- a/apps/mobile_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/mobile_flutter/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import Vision
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -13,6 +14,7 @@ import UIKit
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     registerICloudChannel(engineBridge.pluginRegistry)
+    registerOcrChannel(engineBridge.pluginRegistry)
   }
 
   // MARK: - iCloud MethodChannel(iOS-only)
@@ -37,6 +39,87 @@ import UIKit
       default:
         result(FlutterMethodNotImplemented)
       }
+    }
+  }
+
+  // MARK: - OCR MethodChannel(iOS-only,Apple Vision)
+  //
+  // Dart 的 `ocr_bridge.dart` 在 iOS 走此 channel 调原生 Vision(中文识别更强、
+  // 原生支持 HEIC),安卓侧走 ML Kit——功能一致、各用平台最强引擎。`recognize`
+  // 收一个图片文件路径,返回 { text, confidence(0~1) }。识别失败降级为空文本
+  // (上层据此走「仅存原件」),不抛。
+  private func registerOcrChannel(_ registry: FlutterPluginRegistry) {
+    guard let registrar = registry.registrar(forPlugin: "MedMeOCR") else { return }
+    let channel = FlutterMethodChannel(
+      name: "medme/ocr", binaryMessenger: registrar.messenger())
+    channel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "recognize":
+        guard let args = call.arguments as? [String: Any],
+          let path = args["path"] as? String
+        else {
+          result(FlutterError(code: "bad_args", message: "missing path", details: nil))
+          return
+        }
+        // Vision 是 CPU/GPU 密集,切后台线程,别卡 UI。
+        DispatchQueue.global(qos: .userInitiated).async {
+          let out = AppDelegate.recognizeText(atPath: path)
+          DispatchQueue.main.async { result(out) }
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  /// 用 Apple Vision 识别一张图片(含 HEIC)的文字。返回 `{text, confidence}`;
+  /// 打不开/识别不到时返回空文本 + `confidence = NSNull`(Dart 侧兜底)。
+  private static func recognizeText(atPath path: String) -> [String: Any] {
+    let empty: [String: Any] = ["text": "", "confidence": NSNull()]
+    guard let image = UIImage(contentsOfFile: path), let cg = image.cgImage else {
+      return empty
+    }
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = true
+    // 简/繁中文 + 英文;顺序即优先级。zh-* 自 iOS 14 起支持,部署目标 15.5 满足。
+    request.recognitionLanguages = ["zh-Hans", "zh-Hant", "en-US"]
+    let handler = VNImageRequestHandler(
+      cgImage: cg, orientation: cgOrientation(image.imageOrientation), options: [:])
+    do {
+      try handler.perform([request])
+    } catch {
+      return empty
+    }
+    guard let observations = request.results, !observations.isEmpty else {
+      return empty
+    }
+    var lines: [String] = []
+    var confs: [Float] = []
+    for obs in observations {
+      guard let top = obs.topCandidates(1).first else { continue }
+      lines.append(top.string)
+      confs.append(top.confidence)
+    }
+    let text = lines.joined(separator: "\n")
+    let confidence: Any =
+      confs.isEmpty ? NSNull() : Double(confs.reduce(0, +) / Float(confs.count))
+    return ["text": text, "confidence": confidence]
+  }
+
+  /// UIImage 的 EXIF 方向 → Vision 需要的 CGImagePropertyOrientation
+  /// (`cgImage` 丢方向;手机拍的照片常带旋转,不校正会识别错/识别不到)。
+  private static func cgOrientation(_ o: UIImage.Orientation) -> CGImagePropertyOrientation {
+    switch o {
+    case .up: return .up
+    case .down: return .down
+    case .left: return .left
+    case .right: return .right
+    case .upMirrored: return .upMirrored
+    case .downMirrored: return .downMirrored
+    case .leftMirrored: return .leftMirrored
+    case .rightMirrored: return .rightMirrored
+    @unknown default: return .up
     }
   }
 }

--- a/apps/mobile_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/mobile_flutter/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import ImageIO
 import UIKit
 import Vision
 

--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -2,9 +2,9 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'package:mobile_flutter/ocr_bridge.dart';
 import 'package:mobile_flutter/screens/import_helpers.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
@@ -126,7 +126,6 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
     ),
   );
 
-  TextRecognizer? recognizer;
   final rows = <ImportResultRow>[];
   // 本次新建文档 id → 报告里识别到的患者姓名(识别不到为 null),进「待确认」队列;
   // 姓名与当前成员不符者会被标红,识别到的姓名还用来自动命名默认档案。
@@ -137,16 +136,14 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
     try {
       final ImportOutcomeDto outcome;
       if (item.isImage) {
-        recognizer ??= TextRecognizer(script: TextRecognitionScript.chinese);
-        final recognized = await recognizer.processImage(
-          InputImage.fromFilePath(item.path),
-        );
+        // 各平台原生最强 OCR:iOS Apple Vision / 安卓 ML Kit(见 ocr_bridge.dart)。
+        final ocr = await recognizeImageText(item.path);
         final bytes = await File(item.path).readAsBytes();
         outcome = await ingestImageWithText(
           name: item.name,
           bytes: bytes,
-          ocrText: recognized.text,
-          confidence: averageMlkitConfidence(recognized),
+          ocrText: ocr.text,
+          confidence: ocr.confidence,
         );
       } else {
         final bytes = await File(item.path).readAsBytes();
@@ -158,7 +155,6 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
       rows.add(rowFromError(item.name, e));
     }
   }
-  await recognizer?.close();
 
   // 本次新建的文档显式加入「待确认」队列(健康档案顶部据此置顶让用户核对)。
   if (newDocs.isNotEmpty) {

--- a/apps/mobile_flutter/lib/ocr_bridge.dart
+++ b/apps/mobile_flutter/lib/ocr_bridge.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+/// 一张图片的 OCR 结果:识别文本 + 平均置信度(0~1)。
+class OcrResult {
+  final String text;
+  final double confidence;
+  const OcrResult(this.text, this.confidence);
+}
+
+const MethodChannel _channel = MethodChannel('medme/ocr');
+
+/// 置信度拿不到时的兜底值(空文本/引擎不给),让导入流程照常继续。
+const double _confFallback = 0.9;
+
+/// 识别一张图片里的文字。**各平台用原生最强引擎、功能一致**:
+/// - iOS:Apple Vision(`VNRecognizeTextRequest`,中文更强,原生支持 HEIC),经
+///   `medme/ocr` MethodChannel 调用(见 `ios/Runner/AppDelegate.swift`)。
+/// - 安卓/其它:ML Kit 中文文本识别。
+///
+/// 返回 [OcrResult];引擎/路径异常时降级为空文本(上层据此走「仅存原件」),不抛。
+Future<OcrResult> recognizeImageText(String path) async {
+  if (Platform.isIOS) {
+    try {
+      final res = await _channel.invokeMapMethod<String, dynamic>('recognize', {
+        'path': path,
+      });
+      final text = (res?['text'] as String?) ?? '';
+      final conf = (res?['confidence'] as num?)?.toDouble() ?? _confFallback;
+      return OcrResult(text, conf);
+    } on PlatformException {
+      return const OcrResult('', _confFallback);
+    }
+  }
+  // 安卓 + 其它:ML Kit 中文
+  final recognizer = TextRecognizer(script: TextRecognitionScript.chinese);
+  try {
+    final recognized = await recognizer.processImage(
+      InputImage.fromFilePath(path),
+    );
+    return OcrResult(recognized.text, _averageMlkitConfidence(recognized));
+  } finally {
+    await recognizer.close();
+  }
+}
+
+/// ML Kit 结果的平均置信度:遍历 blocks→lines→elements 取有值的 `confidence` 求平均;
+/// 全空(如无文本)回退到 [_confFallback]。
+double _averageMlkitConfidence(RecognizedText recognized) {
+  final values = <double>[];
+  for (final block in recognized.blocks) {
+    for (final line in block.lines) {
+      for (final element in line.elements) {
+        final c = element.confidence;
+        if (c != null) values.add(c);
+      }
+    }
+  }
+  if (values.isEmpty) return _confFallback;
+  return values.reduce((a, b) => a + b) / values.length;
+}

--- a/apps/mobile_flutter/lib/screens/import_helpers.dart
+++ b/apps/mobile_flutter/lib/screens/import_helpers.dart
@@ -1,4 +1,3 @@
-import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 
 /// 「导入导出」屏的纯逻辑小工具:与 Widget 树无关,方便单独看清楚。
@@ -101,20 +100,3 @@ ImportResultRow rowFromError(String name, Object error) => ImportResultRow(
   statusLabel: '导入失败:$error',
   kind: ImportRowKind.failed,
 );
-
-/// 一张图片识别结果的平均置信度:遍历 blocks→lines→elements,取所有有值的
-/// `element.confidence` 求平均。iOS 端 ML Kit 不提供置信度(全为 null),
-/// 这时回退到一个合理默认值,让「导入」流程照常继续、不因缺置信度而中断。
-double averageMlkitConfidence(RecognizedText recognized) {
-  final values = <double>[];
-  for (final block in recognized.blocks) {
-    for (final line in block.lines) {
-      for (final element in line.elements) {
-        final c = element.confidence;
-        if (c != null) values.add(c);
-      }
-    }
-  }
-  if (values.isEmpty) return 0.9; // iOS 无置信度回退值
-  return values.reduce((a, b) => a + b) / values.length;
-}


### PR DESCRIPTION
## 目的
1.2「手机端做到极致」第一项:各平台用**原生最强 OCR**,功能一致。iOS 从 ML Kit 升级到 **Apple Vision**(中文识别更强、原生支持 HEIC);安卓保持 ML Kit(安卓原生首选)。用户拍板「各平台原生最强」。

## 改动
- **新增 `lib/ocr_bridge.dart`**:`recognizeImageText(path)` 抽象——iOS 走 `medme/ocr` MethodChannel 调 Vision;安卓/其它走 ML Kit 中文。返回 `{text, confidence}`,异常降级空文本(上层走「仅存原件」),不抛。
- **`ios/Runner/AppDelegate.swift`** 加 `registerOcrChannel`:`UIImage(contentsOfFile:)` **原生解 HEIC** → `VNRecognizeTextRequest`(`zh-Hans`/`zh-Hant`/`en-US`,`.accurate` + 语言纠正),校正 EXIF 方向,返回文本 + 平均置信度。后台线程跑,不卡 UI。
- **`import_flow.dart`** 改调 `recognizeImageText`,移除对 ML Kit 的直接识别/`TextRecognizer` 生命周期;置信度计算收进 `ocr_bridge`(删 `import_helpers.averageMlkitConfidence`)。

## 顺带解决
- **HEIC**(iPhone 默认格式):Vision 原生吃 HEIC,iOS 拍照/选图端到端可识别。

## 验证
- `flutter analyze` 干净
- Swift 由 `ios-release` CI 编译验证(本地无 Xcode 构建上下文,SourceKit 的 "No such module Flutter" 是误报)
- ⚠️ **iOS Vision 未真机验证** —— 识别质量需你在 TestFlight 真机测(和当初 ML Kit 一样是发前门槛)

## 备注
安卓 ML Kit 依赖保留(安卓仍用它);iOS 侧 ML Kit pod 虽仍随插件链接但运行时不再用。UX/功能改动,等你 approve。