### PR TITLE
chore(mobile): 版本号 1.2.0+15

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+14
+version: 1.2.0+15
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
v15 出包用构建号提升(+14 → +15)。内容 = 已合的 #113(清理+安卓包名 com.medme.mobile)+ #114(iOS Vision OCR + HEIC)+ #112(保险箱名/去「我」)。纯版本号。