### PR TITLE
feat(mobile): 删除单份文档(事件溯源)+ review/时间线/详情三处入口

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,36 +3182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,29 +3817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "medme-mobile"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "core-model",
- "dicom",
- "jni 0.22.4",
- "medme-share",
- "ndk-context",
- "ocr",
- "parser",
- "pipeline",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-opener",
- "tempfile",
-]
-
-[[package]]
 name = "medme-share"
 version = "0.1.0"
 dependencies = [
@@ -4086,12 +4033,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -5788,7 +5729,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -6196,16 +6137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,12 +6144,6 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -6488,7 +6413,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -6550,7 +6475,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "mime",
@@ -6736,7 +6661,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -6759,7 +6684,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -8400,7 +8325,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk",
  "objc2",

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -186,6 +186,49 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
     if (mounted) setState(() {});
   }
 
+  /// 删除前确认(销毁性操作)。返回用户是否确认。
+  Future<bool> _confirmDelete(String what) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('删除这份记录?'),
+        content: Text('「$what」将从健康档案移除,此操作不可撤销。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: MedMe.danger),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  /// 删除一份文档:调 FFI(追加删除事件 + 重放),清掉可能的「待确认」标记,刷新档案。
+  Future<void> _delete(int docId) async {
+    try {
+      await deleteDocument(documentId: docId);
+      await ReviewState.instance.markReviewed(docId);
+      bumpVaultRevision();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('删除失败:$e')));
+      }
+    }
+  }
+
+  /// 确认后删除(供 review 卡按钮 / 时间线左滑复用)。
+  Future<void> _confirmAndDelete(int docId, String label) async {
+    if (await _confirmDelete(label)) await _delete(docId);
+  }
+
   /// 顶部 banner 点击:弹出成员切换器(家庭多成员)。
   Future<void> _showProfileSwitcher() async {
     await ProfileManager.instance.ensureLoaded();
@@ -364,6 +407,7 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
                     onReview: _review,
                     onReviewAll: () => _reviewAll(unreviewed.map((d) => d.id)),
                     onOpen: _openDoc,
+                    onDelete: _confirmAndDelete,
                   ),
                   const SizedBox(height: 20),
                 ],
@@ -386,6 +430,7 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
                         }
                       },
                       onOpenSubDoc: _openDoc,
+                      onDelete: _confirmAndDelete,
                     ),
                   ],
               ],
@@ -522,17 +567,30 @@ class _EmptyState extends StatelessWidget {
 }
 
 /// 时间线一项:就诊组(可展开子文档)或独立文档。
+/// 时间线/待确认项左滑删除时的红底背景(靠右露出删除图标),Outlook 邮件式。
+Widget swipeDeleteBackground() => Container(
+  alignment: Alignment.centerRight,
+  padding: const EdgeInsets.symmetric(horizontal: 20),
+  decoration: BoxDecoration(
+    color: MedMe.danger,
+    borderRadius: BorderRadius.circular(14),
+  ),
+  child: const Icon(Icons.delete_outline, color: Colors.white),
+);
+
 class _TimelineItem extends StatelessWidget {
   final TimelineGroupDto group;
   final bool expanded;
   final VoidCallback onTap;
   final void Function(int docId) onOpenSubDoc;
+  final Future<void> Function(int docId, String label) onDelete;
 
   const _TimelineItem({
     required this.group,
     required this.expanded,
     required this.onTap,
     required this.onOpenSubDoc,
+    required this.onDelete,
   });
 
   @override
@@ -550,7 +608,7 @@ class _TimelineItem extends StatelessWidget {
       TimelineGroupDto_Document(:final doc) => _iconForDoc(doc.docType),
     };
 
-    return Container(
+    final Widget card = Container(
       decoration: BoxDecoration(
         color: MedMe.panel,
         borderRadius: BorderRadius.circular(14),
@@ -629,27 +687,56 @@ class _TimelineItem extends StatelessWidget {
               TimelineGroupDto_Encounter(:final docs) => _SubDocList(
                 docs: docs,
                 onOpenSubDoc: onOpenSubDoc,
+                onDelete: onDelete,
               ),
               TimelineGroupDto_Document() => const SizedBox.shrink(),
             },
         ],
       ),
     );
+
+    // 独立文档项:左滑删除(Outlook 式)。就诊组不整组删——展开后删组内单份。
+    if (group case TimelineGroupDto_Document(:final doc)) {
+      return Dismissible(
+        key: ValueKey('tl-doc-${doc.id}'),
+        direction: DismissDirection.endToStart,
+        background: swipeDeleteBackground(),
+        confirmDismiss: (_) async {
+          await onDelete(doc.id, _groupTitle(group));
+          return false; // 由数据重载移除,避免与 Dismissible 自身移除冲突
+        },
+        child: card,
+      );
+    }
+    return card;
   }
 }
 
 class _SubDocList extends StatelessWidget {
   final List<DocumentSummaryDto> docs;
   final void Function(int docId) onOpenSubDoc;
+  final Future<void> Function(int docId, String label) onDelete;
 
-  const _SubDocList({required this.docs, required this.onOpenSubDoc});
+  const _SubDocList({
+    required this.docs,
+    required this.onOpenSubDoc,
+    required this.onDelete,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         for (final d in docs)
-          Container(
+          Dismissible(
+            key: ValueKey('sub-doc-${d.id}'),
+            direction: DismissDirection.endToStart,
+            background: swipeDeleteBackground(),
+            confirmDismiss: (_) async {
+              await onDelete(d.id, d.title ?? _docLabel[d.docType] ?? '记录');
+              return false;
+            },
+            child: Container(
             decoration: const BoxDecoration(
               border: Border(top: BorderSide(color: MedMe.line)),
             ),
@@ -695,6 +782,7 @@ class _SubDocList extends StatelessWidget {
                 ),
               ),
             ),
+            ),
           ),
       ],
     );
@@ -709,12 +797,14 @@ class _NewImportsSection extends StatelessWidget {
     required this.onReview,
     required this.onReviewAll,
     required this.onOpen,
+    required this.onDelete,
   });
 
   final List<DocumentSummaryDto> docs;
   final void Function(int docId) onReview;
   final VoidCallback onReviewAll;
   final void Function(int docId) onOpen;
+  final Future<void> Function(int docId, String label) onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -787,12 +877,29 @@ class _NewImportsSection extends StatelessWidget {
                         fontSize: 12.5,
                       ),
                     ),
-                    trailing: FilledButton(
-                      style: FilledButton.styleFrom(
-                        visualDensity: VisualDensity.compact,
-                      ),
-                      onPressed: () => onReview(d.id),
-                      child: const Text('确认'),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(
+                            Icons.delete_outline,
+                            color: MedMe.danger,
+                          ),
+                          tooltip: '删除',
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () => onDelete(
+                            d.id,
+                            d.title ?? _docLabel[d.docType] ?? '记录',
+                          ),
+                        ),
+                        FilledButton(
+                          style: FilledButton.styleFrom(
+                            visualDensity: VisualDensity.compact,
+                          ),
+                          onPressed: () => onReview(d.id),
+                          child: const Text('确认'),
+                        ),
+                      ],
                     ),
                     onTap: () => onOpen(d.id),
                   ),

--- a/apps/mobile_flutter/lib/screens/document_detail.dart
+++ b/apps/mobile_flutter/lib/screens/document_detail.dart
@@ -6,6 +6,7 @@ import 'package:pdfx/pdfx.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
+import 'package:mobile_flutter/vault_events.dart';
 import 'package:mobile_flutter/widgets/report_content.dart';
 
 // doc_type → 中文标签,与 archive_screen.dart 保持同一份映射(桌面/旧移动端
@@ -42,10 +43,53 @@ class DocumentDetailScreen extends StatefulWidget {
 class _DocumentDetailScreenState extends State<DocumentDetailScreen> {
   late final Future<DocumentDetailDto> _future = getDocument(id: widget.docId);
 
+  /// 删除这份文档:确认 → FFI 删除 → 通知档案刷新 → 退回上一屏。
+  Future<void> _delete() async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('删除这份记录?'),
+        content: const Text('将从健康档案移除,此操作不可撤销。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: MedMe.danger),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    try {
+      await deleteDocument(documentId: widget.docId);
+      bumpVaultRevision();
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('删除失败:$e')));
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('文档详情')),
+      appBar: AppBar(
+        title: const Text('文档详情'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: '删除',
+            onPressed: _delete,
+          ),
+        ],
+      ),
       body: FutureBuilder<DocumentDetailDto>(
         future: _future,
         builder: (context, snap) {

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -54,6 +54,12 @@ Future<Uint8List> readSourceBytes({required PlatformInt64 id}) =>
 Future<Uint8List> renderDicomPng({required PlatformInt64 id}) =>
     RustLib.instance.api.crateApiVaultRenderDicomPng(id: id);
 
+/// 删除一份文档(用户在 review 队列 / 时间线 / 详情页移除)。追加 `DocumentDeleted`
+/// 事件 + 重放,原始字节留在 CAS(见 core-model `delete_document`)。文档不存在 = no-op。
+/// 前端删完 `bumpVaultRevision` 刷新即可。
+Future<void> deleteDocument({required PlatformInt64 documentId}) =>
+    RustLib.instance.api.crateApiVaultDeleteDocument(documentId: documentId);
+
 /// 患者档案头(姓名/性别/年龄/记录数)。与桌面/Tauri 移动端同构。
 Future<PatientProfileDto> patientProfile() =>
     RustLib.instance.api.crateApiVaultPatientProfile();

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 665745695;
+  int get rustContentHash => -948527968;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -83,6 +83,8 @@ abstract class RustLibApi extends BaseApi {
   Future<ShareResultDto> crateApiVaultCreateShare({
     required PlatformInt64 expiresDays,
   });
+
+  Future<void> crateApiVaultDeleteDocument({required PlatformInt64 documentId});
 
   Future<void> crateApiVaultDisableIcloudSync();
 
@@ -177,6 +179,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "create_share", argNames: ["expiresDays"]);
 
   @override
+  Future<void> crateApiVaultDeleteDocument({
+    required PlatformInt64 documentId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_i_64(documentId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultDeleteDocumentConstMeta,
+        argValues: [documentId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultDeleteDocumentConstMeta =>
+      const TaskConstMeta(
+        debugName: "delete_document",
+        argNames: ["documentId"],
+      );
+
+  @override
   Future<void> crateApiVaultDisableIcloudSync() {
     return handler.executeNormal(
       NormalTask(
@@ -185,7 +220,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -213,7 +248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -248,7 +283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -281,7 +316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -306,7 +341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -331,7 +366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -363,7 +398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -393,7 +428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -429,7 +464,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -459,7 +494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -486,7 +521,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -513,7 +548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -547,7 +582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -576,7 +611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -604,7 +639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -632,7 +667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -659,7 +694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -687,7 +722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -286,6 +286,18 @@ pub fn render_dicom_png(id: i64) -> anyhow::Result<Vec<u8>> {
     })
 }
 
+/// 删除一份文档(用户在 review 队列 / 时间线 / 详情页移除)。追加 `DocumentDeleted`
+/// 事件 + 重放,原始字节留在 CAS(见 core-model `delete_document`)。文档不存在 = no-op。
+/// 前端删完 `bumpVaultRevision` 刷新即可。
+pub fn delete_document(document_id: i64) -> anyhow::Result<()> {
+    with_state(|state| {
+        state
+            .vault
+            .delete_document(document_id)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))
+    })
+}
+
 /// 患者档案头(姓名/性别/年龄/记录数)。与桌面/Tauri 移动端同构。
 pub fn patient_profile() -> anyhow::Result<PatientProfileDto> {
     with_state(|state| {

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 665745695;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -948527968;
 
 // Section: executor
 
@@ -74,6 +74,41 @@ fn wire__crate__api__vault__create_share_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
                         let output_ok = crate::api::vault::create_share(api_expires_days)?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__delete_document_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "delete_document",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_document_id = <i64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::delete_document(api_document_id)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -1055,25 +1090,26 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__vault__create_share_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
-        10 => {
+        2 => wire__crate__api__vault__delete_document_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
+        11 => {
             wire__crate__api__vault__ingest_image_with_text_impl(port, ptr, rust_vec_len, data_len)
         }
-        11 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__simple__vault_smoke_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1086,7 +1122,7 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        6 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/packages/core-model/src/audit.rs
+++ b/packages/core-model/src/audit.rs
@@ -90,6 +90,13 @@ impl Vault {
                     format!("{record_count} 条记录 · 有效期至 {expires}"),
                     Some(sha256.clone()),
                 ),
+                Event::DocumentDeleted {
+                    source_file_hash, ..
+                } => (
+                    "删除",
+                    "移除一份文档".to_string(),
+                    Some(source_file_hash.clone()),
+                ),
                 Event::DocumentAdded { .. }
                 | Event::OcrAdded { .. }
                 | Event::ImagingInstanceAdded { .. } => continue,

--- a/packages/core-model/src/event.rs
+++ b/packages/core-model/src/event.rs
@@ -88,6 +88,14 @@ pub enum Event {
         sha256: String,
         expires: String,
     },
+    /// 删除一份文档(用户在 UI 里移除)。按锚点 source_file 的**内容哈希**引用,脱库
+    /// 重放稳定(不用 DB 自增 id)。materialize 时移除该文档的派生行
+    /// (document / ocr_result / imaging_instance / FTS);**原始字节留在 CAS 不动**
+    /// —— Raw Never Dies + 同步安全,删除只是墓碑。删除作为事件同步,各端重放后一致。
+    DocumentDeleted {
+        source_file_hash: String,
+        deleted_at: String,
+    },
 }
 
 /// One line in the append-only log: an `Event` plus the envelope needed for

--- a/packages/core-model/src/materialize.rs
+++ b/packages/core-model/src/materialize.rs
@@ -564,6 +564,30 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
                 rusqlite::params![study_uid, document_id],
             )?;
         }
+        // 删除文档:按锚点 source_file 内容哈希定位当前库里的文档,移除其派生行
+        // (FTS / ocr_result / imaging_instance / document)。source_file 与 CAS 对象
+        // 保留(Raw Never Dies)。目标不在库里(已删,或 add 尚未同步)→ **no-op**,
+        // 绝不 defer —— 一条悬空删除若 defer 会永久卡住该设备段的后续事件。encounter
+        // 是二次派生,由调用方随后 rebuild_encounters 重算。
+        Event::DocumentDeleted {
+            source_file_hash,
+            deleted_at: _,
+        } => {
+            let document_id: Option<i64> = tx
+                .query_row(
+                    "SELECT d.id FROM document d JOIN source_file sf ON d.source_file_id = sf.id
+                     WHERE sf.content_hash = ?1",
+                    [source_file_hash],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if let Some(id) = document_id {
+                tx.execute("DELETE FROM document_fts WHERE document_id = ?1", [id])?;
+                tx.execute("DELETE FROM ocr_result WHERE document_id = ?1", [id])?;
+                tx.execute("DELETE FROM imaging_instance WHERE document_id = ?1", [id])?;
+                tx.execute("DELETE FROM document WHERE id = ?1", [id])?;
+            }
+        }
         // 审计事件:纯粹的日志留痕(见 crate::audit),对 DB 投影是 no-op —— 不
         // 建任何表行,`rebuild_from_log` 重放时必须能安全跳过而不报错。
         Event::ExportPerformed { .. } | Event::ShareCreated { .. } => {}
@@ -1045,6 +1069,47 @@ mod tests {
             2,
             "deferred page recovered — not stranded by the higher-seq event"
         );
+    }
+
+    /// Deleting a document removes its derived rows (document/ocr/FTS) but keeps
+    /// the raw source_file (CAS), and the deletion — being a logged event —
+    /// survives a full rebuild-from-log (it doesn't resurrect).
+    #[test]
+    fn delete_document_removes_projection_keeps_raw_and_survives_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_doc(dir.path(), "del.txt", "DeleteMeNeedle");
+        let v = Vault::open(dir.path()).unwrap();
+        assert_eq!(v.debug_count("document"), 1);
+        let doc_id: i64 = v
+            .conn()
+            .query_row("SELECT id FROM document LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+
+        v.delete_document(doc_id).unwrap();
+        assert_eq!(v.debug_count("document"), 0, "doc projection removed");
+        assert_eq!(v.debug_count("ocr_result"), 0, "its OCR removed");
+        assert_eq!(
+            v.search("DeleteMeNeedle", 10).unwrap().len(),
+            0,
+            "gone from full-text search"
+        );
+        assert_eq!(
+            v.debug_count("source_file"),
+            1,
+            "raw source_file retained (Raw Never Dies)"
+        );
+
+        // The delete is a logged event → a full rebuild replays add-then-delete
+        // and the doc stays gone (no resurrection).
+        v.rebuild_from_log().unwrap();
+        assert_eq!(
+            v.debug_count("document"),
+            0,
+            "still deleted after rebuild-from-log"
+        );
+
+        // Deleting a non-existent doc id is a harmless no-op.
+        v.delete_document(9999).unwrap();
     }
 
     // ---- hardening: forged / dangling references + malformed hashes ---------

--- a/packages/core-model/src/query.rs
+++ b/packages/core-model/src/query.rs
@@ -206,6 +206,31 @@ impl Vault {
             .next())
     }
 
+    /// 删除一份文档:追加 [`Event::DocumentDeleted`] 事件 → 重放 → 重算就诊分组。
+    /// **原始字节留在 CAS**(只移除派生投影,Raw Never Dies + 同步安全)。文档不存在
+    /// (已删)→ `Ok(())`(no-op)。删除作为事件同步,各端重放后一致。
+    pub fn delete_document(&self, doc_id: i64) -> Result<(), MedmeError> {
+        let source_file_hash: Option<String> = self
+            .conn()
+            .query_row(
+                "SELECT sf.content_hash FROM document d
+                 JOIN source_file sf ON d.source_file_id = sf.id WHERE d.id = ?1",
+                [doc_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let Some(hash) = source_file_hash else {
+            return Ok(()); // 已经不在了
+        };
+        self.append_event(crate::event::Event::DocumentDeleted {
+            source_file_hash: hash,
+            deleted_at: Self::now_rfc3339(),
+        })?;
+        self.materialize()?;
+        self.rebuild_encounters()?;
+        Ok(())
+    }
+
     pub fn rebuild_encounters(&self) -> Result<(), MedmeError> {
         use std::collections::HashSet;
         let tx = self.conn().unchecked_transaction()?;


### PR DESCRIPTION
## 目的
补齐 app 级缺口 + 修用户反馈:此前**只能「清空重置」全删,无法删单份**;review 队列「不确认」没出口。现在给出「删除」。

## core-model(事件溯源,跨设备同步安全)
- **`Event::DocumentDeleted`**:按锚点 source_file **内容哈希**引用(不用 DB 自增 id),脱库重放稳定。
- **materialize**:重放时移除该文档派生行(`document`/`ocr_result`/`imaging_instance`/FTS);**原始字节留在 CAS 不动**(Raw Never Dies + 同步安全,删除=墓碑);目标不在库(已删/未同步)→ **no-op,绝不 defer**(一条悬空删除若 defer 会卡住设备段后续事件)。
- **`Vault::delete_document(id)`**:追加删除事件 + 重放 + 重算就诊分组;不存在=no-op。
- `audit_log` 收录「删除」动作(审计=事件日志)。
- 测试:删除移投影 / 保留原件 / **重放不复活** / 删不存在=no-op。core-model 77 tests green。

## FFI
- `delete_document(id)`(mobile)。

## UI(三处入口,均带确认弹窗,删完刷新)
- **待确认卡片**:加「删除」按钮(配合「确认」)——修「不确认没操作」。
- **健康档案时间线**:独立文档 + 就诊组内子文档**左滑删除**(Outlook 式)。
- **文档详情页**:右上角删除。

## 验证
- `flutter analyze` 干净;core-model `cargo test` 77 pass;workspace 消费方(pipeline/share/cli/desktop)全编译。
- ⚠️ UI 交互未真机跑,靠你 TestFlight 真机验。

## 备注
- 移到其他成员(导错人)→ 按你定的放 1.3。
- spine 改动(core-model + 同步语义),等你 approve。
- 附带清理 Cargo.lock 里 #113 删 apps/mobile 后残留的 jni 依赖。