### PR TITLE
fix(mobile): 空态文案指向右上角「导入」

### DIFF
--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -94,8 +94,8 @@ class _VaultBootstrapState extends State<VaultBootstrap> {
   }
 }
 
-/// 底部导航壳:三个一级 tab —— 导入导出 / 健康档案 / 设置。
-/// 「导入导出」按用户要求提升为一级 tab(不埋设置里),后续导出维度会变多。
+/// 底部导航壳:三个一级 tab —— 健康档案 / 导出分享 / 设置。
+/// 导入入口在「健康档案」页右上角「导入」按钮(不是独立 tab);导出/分享独立成一级 tab。
 class HomeShell extends StatefulWidget {
   const HomeShell({super.key});
   @override

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -534,7 +534,7 @@ class _PatientHeader extends StatelessWidget {
   }
 }
 
-/// 空态引导:没有记录时提示去「导入导出」或「设置」载入示例数据。
+/// 空态引导:没有记录时提示点右上角「导入」,或去「设置」载入示例数据。
 class _EmptyState extends StatelessWidget {
   const _EmptyState();
 
@@ -556,7 +556,7 @@ class _EmptyState extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           const Text(
-            '去「导入导出」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
+            '点右上角「导入」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
             textAlign: TextAlign.center,
             style: TextStyle(fontSize: 13, color: MedMe.faint, height: 1.6),
           ),


### PR DESCRIPTION
真机反馈:iOS 无病历时空态还写「去『导入导出』拍照或选择文件添加」,但导入入口早已改为「健康档案」页右上角「导入」按钮,「导入导出」tab 已不存在 → 误导。

改为「点右上角『导入』拍照或选择文件添加」;顺带纠正 main.dart 过时的 tab 列表注释(现为 健康档案/导出分享/设置)。纯文案。