### PR TITLE
fix(mobile): 「清空所有数据」全清所有成员 + 修份数缓存 + 空态文案

### DIFF
--- a/apps/mobile_flutter/lib/main.dart
+++ b/apps/mobile_flutter/lib/main.dart
@@ -94,8 +94,8 @@ class _VaultBootstrapState extends State<VaultBootstrap> {
   }
 }
 
-/// 底部导航壳:三个一级 tab —— 导入导出 / 健康档案 / 设置。
-/// 「导入导出」按用户要求提升为一级 tab(不埋设置里),后续导出维度会变多。
+/// 底部导航壳:三个一级 tab —— 健康档案 / 导出分享 / 设置。
+/// 导入入口在「健康档案」页右上角「导入」按钮(不是独立 tab);导出/分享独立成一级 tab。
 class HomeShell extends StatefulWidget {
   const HomeShell({super.key});
   @override

--- a/apps/mobile_flutter/lib/profile_manager.dart
+++ b/apps/mobile_flutter/lib/profile_manager.dart
@@ -155,6 +155,17 @@ class ProfileManager {
     await _save();
   }
 
+  /// 恢复出厂:成员表清回单一默认(root)、清份数缓存、保险箱名回默认、允许自动命名。
+  /// 「清空所有数据」调它(配合删各 profile 的 vault 目录),而不是只清当前 profile。
+  Future<void> factoryReset() async {
+    _members = const [defaultVaultName];
+    _vaultName = defaultVaultName;
+    _counts.clear();
+    _rootAutoNamed = true;
+    currentMember.value = defaultVaultName;
+    await _save();
+  }
+
   // ---- 路径组合(第一个成员用原位置,其余用子文件夹)----
 
   bool _isRoot(String name) => _members.isNotEmpty && name == _members.first;

--- a/apps/mobile_flutter/lib/review_state.dart
+++ b/apps/mobile_flutter/lib/review_state.dart
@@ -122,6 +122,14 @@ class ReviewState {
     if (changed) await _save();
   }
 
+  /// 清空全部成员的待确认/标红状态(「清空所有数据」恢复出厂时调)。
+  Future<void> clearAll() async {
+    await ensureLoaded();
+    _byMember.clear();
+    _flagged.clear();
+    await _save();
+  }
+
   /// 成员改名(如默认档案被识别到的姓名自动重命名)时迁移其待确认/标红键。
   Future<void> renameMember(String from, String to) async {
     if (from == to) return;

--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -534,7 +534,7 @@ class _PatientHeader extends StatelessWidget {
   }
 }
 
-/// 空态引导:没有记录时提示去「导入导出」或「设置」载入示例数据。
+/// 空态引导:没有记录时提示点右上角「导入」,或去「设置」载入示例数据。
 class _EmptyState extends StatelessWidget {
   const _EmptyState();
 
@@ -556,7 +556,7 @@ class _EmptyState extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           const Text(
-            '去「导入导出」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
+            '点右上角「导入」拍照或选择文件添加,\n或在「设置」里载入示例数据试试看',
             textAlign: TextAlign.center,
             style: TextStyle(fontSize: 13, color: MedMe.faint, height: 1.6),
           ),

--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 import 'package:mobile_flutter/vault_events.dart';
+import 'package:mobile_flutter/vault_boot.dart';
 import 'package:mobile_flutter/profile_manager.dart';
 import 'package:mobile_flutter/icloud_bridge.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -92,10 +93,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('清空保险箱?'),
+        title: const Text('清空所有数据?'),
         content: const Text(
-          '确定清空全部记录?示例数据和已导入的病历都会被删除,'
-          '此操作不可撤销。',
+          '确定清空全部记录?所有成员的示例数据和已导入病历都会被删除,'
+          '保险箱恢复到初始状态,此操作不可撤销。',
         ),
         actions: [
           TextButton(
@@ -114,8 +115,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     setState(() => _busy = true);
     try {
-      await resetVault();
-      bumpVaultRevision(); // 通知「健康档案」屏自动清空重载
+      await wipeAllData(); // 全清:所有成员 vault + 份数缓存 + 待确认 + 恢复出厂
       await _refresh();
       _showSnack('已清空');
     } catch (e) {

--- a/apps/mobile_flutter/lib/vault_boot.dart
+++ b/apps/mobile_flutter/lib/vault_boot.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:path_provider/path_provider.dart';
 
 import 'package:mobile_flutter/src/rust/api/vault.dart';
@@ -28,6 +30,30 @@ Future<void> openCurrentProfileVault() async {
 Future<void> switchProfileAndReopen(String name) async {
   await ProfileManager.instance.switchTo(name);
   await openCurrentProfileVault();
+  bumpVaultRevision();
+}
+
+/// 「清空所有数据」= 恢复出厂:清**所有**成员的 vault(不只当前 profile)+ 份数缓存
+/// + 待确认状态,重置成单一默认档案。做法:先把注册表恢复出厂(current 回默认 root)、
+/// 重开 root vault 并 `resetVault` 清它,再删掉所有子成员(`profiles/`)的数据目录。
+Future<void> wipeAllData() async {
+  final docsRoot = (await getApplicationDocumentsDirectory()).path;
+  final containerRoot = await IcloudBridge.containerPath();
+
+  // 1. 注册表恢复出厂(current→默认 root)+ 清待确认。
+  await ProfileManager.instance.factoryReset();
+  await ReviewState.instance.clearAll();
+
+  // 2. 重开默认(root)vault → 活跃 vault = root;3. 清它(删目录+重开空)。
+  await openCurrentProfileVault();
+  await resetVault();
+
+  // 4. 删掉所有子成员的数据目录(它们没被打开,直接删)。root 已由 resetVault 清掉。
+  for (final root in [docsRoot, if (containerRoot != null) '$containerRoot/Documents']) {
+    final profiles = Directory('$root/profiles');
+    if (await profiles.exists()) await profiles.delete(recursive: true);
+  }
+
   bumpVaultRevision();
 }
 


### PR DESCRIPTION
真机反馈修复。

## 清空 bug(主)
现象:「清空所有数据」后仍显示「张建国 22 份」,要清两次才彻底。
- **根因**:`reset_vault` 只删**当前** profile 的 vault 目录(多成员时别人没清);且我给设置页加的**份数缓存 `_counts` 没清** → 设置页显示 stale 份数。
- **修**:「清空所有数据」→ `wipeAllData()`(恢复出厂,一次到底):
  - `ProfileManager.factoryReset`:成员表回单一默认、清份数缓存、保险箱名回默认、允许自动命名。
  - `ReviewState.clearAll`:清所有成员待确认/标红。
  - 清 root vault(`resetVault`)+ 删所有子成员 `profiles/` 目录(本机 + iCloud 容器)。
- 「清某个人数据」按你要求以后再做。

## 文案
- 空态:「去『导入导出』拍照…」→「点右上角『导入』拍照…」(导入入口早已改为健康档案页右上角按钮,「导入导出」tab 不存在)。
- 纠正 main.dart 过时的 tab 注释。含原 #120 内容,#120 已关。

## 验证
`flutter analyze` 干净。清空逻辑是 UI 编排(FFI + 文件删),没自动化测,靠真机验。

## 备注
review 确认流程重构(红框置顶 + 详情页确认)是**下一件**,单独做。