### PR TITLE
chore(mobile): 版本号 1.2.0+18

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+17
+version: 1.2.0+18
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
v18 构建号提升(+17 → +18)。内容 = 已合的 #123(review 确认流程重构:红框置顶 + 详情页确认)。纯版本号。