### PR TITLE
feat(terminology): 药名确定性剥壳 + 覆盖率量化工具(盲测)

### DIFF
--- a/docs/030_Clinical_Handoff.md
+++ b/docs/030_Clinical_Handoff.md
@@ -1,0 +1,117 @@
+# 030 · Clinical Handoff · 患者掌控的临床交接层
+
+> **状态(2026-07-14)**:方向已定,但**医生 summary 的 UI 结构在保留状态** —— 需先把
+> 「国内医生标准套路」(《病历书写基本规范》/ 住院病案首页)与 IPS 对齐后再定版式(见 §3
+> 会重写)。**已 spin-off 的活 = 术语归一覆盖率**(见对应 issue):`terminology` 已加确定性
+> 药名剥壳,化验名候选拆分待落地,字典扩容到 ≥98% 是主要工作。抽取一律**确定性、无 LLM**;
+> LLM 仅可能用于「生成 summary 的组织」且**数字由确定性来源填**(见 §5,已收回服务器 LLM 方案)。
+
+
+
+> 战略「第二句话」:第一句是**所有权**——「你的病历只属于你,存在你自己的保险箱里」;
+> 第二句是**有用性**——「需要时,它替你把病情讲清楚,并把医生的新判断带回来」。
+> 本文是把第二句从口号落成技术方案的设计文档。产品定位与竞品判断见对话记录 2026-07-14。
+
+关联:[011_Storage_Sync](011_Storage_Sync.md)(CAS+日志+E2E 分享)· [015_Trends_and_Timelines](015_Trends_and_Timelines.md) · 记忆 `medme-v12-scope`
+
+---
+
+## 1. 现状 vs 目标
+
+- **现状**:加密分享包 = `{"records":[…逐份文档…]}`,查看器(`web/hosted-viewer` + `packages/share` 内嵌 HTML)把每份文档用内容感知渲染出来。= **给医生看一堆报告**。
+- **目标**:在文档列表**之上**加一个**医生首屏摘要**(problem list / 当前用药 / 过敏 / 关键化验+趋势 / 近期就诊),每条**能下钻到源文档**(证据回溯)。= **医生 10 秒看懂病情上下文**。
+- **不变量**:证据回溯、E2E(服务器永不见明文/密钥)、患者可撤销 —— 是第二句能不能立住的三条命脉。
+
+## 2. 分三阶段(每阶段独立可交付)
+
+| 阶段 | 内容 | 需要后端? |
+|---|---|---|
+| **A · 查看器 summary** | 查看器渲染 summary 首屏 + 证据下钻;summary 走**现有自包含加密分享**(发文件+口令) | ❌ 纯客户端 |
+| **B · 结构化提取** | app 侧把 OCR 文本抽成结构化临床事实(OMOP-lite 事件),物化出 summary 打进分享包 | ❌(LLM 可选,见 §5) |
+| **C · 小服务器** | 发**链接**代替发文件 + **真过期 / 撤销 / 访问日志**(#58) | ✅ 但只存密文 |
+
+**关键:A、B 零后端。** 服务器(C)只买「链接/过期/撤销/日志」四样,是第二阶段,等 summary 跑通再上,顺便去风险。
+
+## 3. 数据契约(THE artifact):doctor-summary JSON
+
+分享包在现有 `records` 之外新增 `summary` 字段(缺省则查看器回退到纯文档列表,老分享不受影响)。`evidence` 是 `records` 数组的下标,点击跳到源文档 → 证据回溯白拿。
+
+```jsonc
+{
+  "records": [ /* 现有:逐份文档(doc_type, ocr text, dicom…) */ ],
+  "summary": {
+    "generated_at": "2026-07-14T…",
+    "patient": { "name": "张建国", "gender": "男", "age": "58" },
+    "problems": [
+      { "term": "2型糖尿病", "since": "2023", "evidence": [3, 7] }
+    ],
+    "medications": [
+      { "name": "二甲双胍", "dose": "0.5g bid", "status": "active",
+        "since": "2024-01", "note": null, "evidence": [7] },
+      { "name": "阿司匹林", "dose": "100mg qd", "status": "stopped",
+        "since": "2023-06", "note": "2024-03 停用", "evidence": [2, 5] }
+    ],
+    "allergies": [
+      { "substance": "青霉素", "reaction": "皮疹", "evidence": [3] }
+    ],
+    "key_labs": [
+      { "analyte": "HbA1c", "unit": "%",
+        "latest": { "value": "7.2", "date": "2026-06", "flag": "high" },
+        "trend": [ {"date":"2025-12","value":"7.8"}, {"date":"2026-06","value":"7.2"} ],
+        "evidence": [9] }
+    ],
+    "recent_encounters": [
+      { "date": "2026-06-15", "provider": "协和内分泌", "kind": "门诊", "evidence": [9] }
+    ],
+    "notable_changes": [ "近半年 HbA1c 7.8→7.2", "阿司匹林 2024-03 停用" ]
+  }
+}
+```
+
+- **status = active|stopped|unknown**:当前用药靠对 drug 事件按日期 fold(见 §4)得出;冲突(停了又用)落在 `note`。
+- **不做**:标准词表编码(RxNorm/LOINC 概念 id)。医生看中文药名/指标名即可;编码是去重聚合 + Prometheno 互通用的,推后(§6)。
+
+## 4. OMOP-lite 结构层(阶段 B 的地基)
+
+采用 OMOP 的**领域形状**、跳过标准词表。每类事实建成**事件**进现有 append-only 日志(白拿证据回溯 + 跨设备合并 + 冲突物化):
+
+| OMOP 域 | MedMe 事件载荷 |
+|---|---|
+| drug_exposure | {药名, 剂量, 频次, 动作(start/continue/stop), 日期, source_file_hash} |
+| measurement | {指标, 值, 单位, 参考范围, 高低标记, 日期, source} |
+| condition | {诊断词, 日期, source} |
+| observation | {物质, 反应?, source}(过敏等) |
+| procedure | {名称, 日期, source} |
+| visit | 复用现有 encounter |
+
+**当前用药 = fold**:阿司匹林 start(d1)→ stop(d2)→ restart(d3) ⇒ `active(自 d3),note: d2 停`。**只有事件溯源能干净做,纯 AI 摘要做不到 —— 这是独有能力。**
+
+## 5. 抽取:parser 先,LLM 后(要拍板的分叉)
+
+- **化验**:本来就有表格解析 → **持久成结构事实**(不只显示)。走 parser。
+- **诊断/过敏/病程**(叙述性)→ LLM 结构化抽取更稳。隐私分叉:端上小模型(纯本地/弱) vs 服务器 LLM(强/OCR 文本出设备)。
+- **务实**:混合;且 **LLM 抽取只在「生成医生分享」那一刻跑**(用户已决定分享,是可接受一次 AI 调用的时机)。平时纯本地。
+- **MVP 不引入 LLM**:先用 parser/启发式从现有 `records` 抽 用药+化验+过敏,证明管线。
+
+## 6. 与 Prometheno 的桥
+
+结构层做成 OMOP 形状(哪怕不带词表)→ 患者数据将来流进 Prometheno 的 OMOP testbed **天然兼容**。MedMe = 患者侧的 OMOP-lite 喂数端。第三句(整个就医网络的受控协作)靠第二句攒下的医生网络效应,现在不做。
+
+## 7. 服务器边界(阶段 C,#58)
+
+只干四件事,**E2E 不变量:只存密文,永不见密钥/明文**:
+- 存加密分享包(密文 blob)→ 发链接代替发文件
+- 真过期(到期删密文)· 撤销(患者一键删)· 访问日志(谁何时打开)
+- 合规面最小:服务器上只有密文,PIPL/医疗数据暴露面 = 0 明文
+
+后续:医生「建议更正」= 一个 proposed 事件回传,患者确认后写入 → 从「发病历」进化到「共同维护病历」(第二句最重的半句)。
+
+## 8. 最小切片(现在就做)
+
+**查看器先行,零后端、零 app 改动**:
+1. 定死 §3 的 `summary` schema(本文即契约)。
+2. 查看器加 `renderSummary(payload.summary)`:文档列表**之上**渲染首屏(问题/用药/过敏/关键化验),每条 `evidence` → 点击滚动到对应 `records[i]`。`summary` 缺省则完全回退现状(老分享不受影响)。
+3. 用 sample payload 验 UX。
+4. 跑通后:app 侧做阶段 B 的 parser 抽取 → 产出 `summary` 打进分享包;再上阶段 C 服务器。
+
+顺序:**查看器(A)→ app 提取(B)→ 服务器(C)**。先证明医生觉得有用,再补撤销/链接。

--- a/packages/terminology/examples/coverage.rs
+++ b/packages/terminology/examples/coverage.rs
@@ -1,0 +1,205 @@
+//! 覆盖率验证:拿一份「不看字典生成」的真实中文报告(subagent 产出),跑
+//! `terminology::normalize`,统计分析物名/药名/单位的命中率 + 未命中清单。
+//! 用法:`cargo run -p terminology --example coverage -- <demo_reports.json>`
+//!
+//! 命中率是**诚实数字**:数据由不知道 dictionary.json 内容的 subagent 生成。
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use terminology::{normalize, Dictionary};
+
+#[derive(Deserialize)]
+struct Demo {
+    reports: Vec<Report>,
+}
+#[derive(Deserialize)]
+struct Report {
+    #[serde(default)]
+    items: Vec<Item>,
+    #[serde(default)]
+    drugs: Vec<Drug>,
+}
+#[derive(Deserialize)]
+struct Item {
+    name: String,
+    #[serde(default)]
+    unit: String,
+}
+#[derive(Deserialize)]
+struct Drug {
+    name: String,
+}
+
+/// 复合化验名 → 候选:去括号内容 + 括号内(可能是同义缩写)+ 按空格/斜杠切 token。
+/// 真实报告写「甘油三酯 TG」「皮质醇(8AM)」「肌酐 Cr(Scr)」,精确查表整串必 miss,
+/// 拆成 token 后各自去查。纯确定性,不是模型。
+fn lab_candidates(name: &str) -> Vec<String> {
+    let is_open = |c: char| matches!(c, '(' | '（' | '[' | '【');
+    let is_close = |c: char| matches!(c, ')' | '）' | ']' | '】');
+    // 去括号后的主体 + 收集括号内内容
+    let (mut stripped, mut inner_all) = (String::new(), Vec::<String>::new());
+    let mut inner = String::new();
+    let mut depth = 0i32;
+    for c in name.chars() {
+        if is_open(c) {
+            depth += 1;
+        } else if is_close(c) {
+            depth -= 1;
+            if depth <= 0 && !inner.trim().is_empty() {
+                inner_all.push(inner.trim().to_string());
+                inner.clear();
+            }
+        } else if depth >= 1 {
+            inner.push(c);
+        } else {
+            stripped.push(c);
+        }
+    }
+    let mut cands: Vec<String> = vec![stripped.trim().to_string()];
+    let seps = [' ', '\u{3000}', '/', '／', '、', ',', '，'];
+    for t in stripped.split(seps) {
+        let t = t.trim();
+        if !t.is_empty() {
+            cands.push(t.to_string());
+        }
+    }
+    for blk in inner_all {
+        for t in blk.split(seps) {
+            let t = t.trim();
+            if !t.is_empty() {
+                cands.push(t.to_string());
+            }
+        }
+    }
+    cands.retain(|c| !c.is_empty());
+    cands.dedup();
+    cands
+}
+
+/// 单位比较用的宽松归一:去空格、小写、µ/μ→u、×→x、去 ^,好让 UCUM(10*9/L)
+/// 和报告写法(×10^9/L)尽量对上;仍对不上就算 miss(多是记法差异,可补数据)。
+fn nu(u: &str) -> String {
+    u.chars()
+        .filter(|c| !c.is_whitespace())
+        .flat_map(|c| c.to_lowercase())
+        .map(|c| match c {
+            'µ' | 'μ' => 'u',
+            '×' => 'x',
+            _ => c,
+        })
+        .filter(|&c| c != '^')
+        .collect()
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("用法: cargo run -p terminology --example coverage -- <demo_reports.json>");
+    let demo: Demo = serde_json::from_str(&std::fs::read_to_string(&path).expect("读 demo 文件"))
+        .expect("解析 demo JSON");
+    let dict: Dictionary =
+        serde_json::from_str(include_str!("../dictionary.json")).expect("解析 dictionary.json");
+
+    // key -> 该条目接受的所有单位(canonical + 各转换单位),供单位命中判断。
+    let mut units: HashMap<String, Vec<String>> = HashMap::new();
+    for e in &dict.entries {
+        let mut us: Vec<String> = e.units.iter().map(|u| nu(&u.unit)).collect();
+        if let Some(cu) = &e.canonical_unit {
+            us.push(nu(cu));
+        }
+        units.insert(e.key.clone(), us);
+    }
+
+    let (mut lab_n, mut lab_hit, mut lab_ocr) = (0u32, 0u32, 0u32);
+    let (mut unit_n, mut unit_hit) = (0u32, 0u32);
+    let (mut drug_n, mut drug_hit, mut drug_ocr) = (0u32, 0u32, 0u32);
+    let mut lab_miss: Vec<String> = vec![];
+    let mut unit_miss: Vec<String> = vec![];
+    let mut drug_miss: Vec<String> = vec![];
+
+    for r in &demo.reports {
+        for it in &r.items {
+            lab_n += 1;
+            // 复合名先拆候选,任一 token 命中即算(确定性)。
+            let hit = lab_candidates(&it.name).iter().find_map(|c| normalize(c));
+            match hit {
+                Some(m) => {
+                    lab_hit += 1;
+                    if m.confidence < 1.0 {
+                        lab_ocr += 1;
+                    }
+                    if !it.unit.trim().is_empty() {
+                        unit_n += 1;
+                        let ok = units
+                            .get(&m.key)
+                            .is_some_and(|us| us.iter().any(|u| *u == nu(&it.unit)));
+                        if ok {
+                            unit_hit += 1;
+                        } else {
+                            unit_miss.push(format!("{} [{}]", it.name, it.unit));
+                        }
+                    }
+                }
+                None => lab_miss.push(it.name.clone()),
+            }
+        }
+        for d in &r.drugs {
+            drug_n += 1;
+            // normalize 内部已做确定性剥壳(盐基/剂型)。
+            match normalize(&d.name) {
+                Some(m) => {
+                    drug_hit += 1;
+                    if m.confidence < 1.0 {
+                        drug_ocr += 1;
+                    }
+                }
+                None => drug_miss.push(d.name.clone()),
+            }
+        }
+    }
+
+    let pct = |a: u32, b: u32| {
+        if b == 0 {
+            0.0
+        } else {
+            a as f64 * 100.0 / b as f64
+        }
+    };
+    println!(
+        "字典版本: {} · 条目数: {}",
+        dict.version,
+        dict.entries.len()
+    );
+    println!("──────────────────────────────────────────────");
+    println!(
+        "化验分析物名:  {}/{} 命中  = {:.1}%   (其中疑似 OCR/0.5 置信: {})",
+        lab_hit,
+        lab_n,
+        pct(lab_hit, lab_n),
+        lab_ocr
+    );
+    println!(
+        "药品名:        {}/{} 命中  = {:.1}%   (其中疑似 OCR/0.5 置信: {})",
+        drug_hit,
+        drug_n,
+        pct(drug_hit, drug_n),
+        drug_ocr
+    );
+    println!(
+        "单位(命中项):  {}/{} 匹配  = {:.1}%   (记法差异也算 miss,见下)",
+        unit_hit,
+        unit_n,
+        pct(unit_hit, unit_n)
+    );
+    println!("──────────────────────────────────────────────");
+    let show = |title: &str, v: &[String]| {
+        println!("\n【{} · {} 条】", title, v.len());
+        for x in v {
+            println!("  ✗ {x}");
+        }
+    };
+    show("未命中·化验分析物", &lab_miss);
+    show("未命中·药品", &drug_miss);
+    show("单位对不上", &unit_miss);
+}

--- a/packages/terminology/src/lib.rs
+++ b/packages/terminology/src/lib.rs
@@ -226,12 +226,101 @@ impl Index {
     }
 }
 
+/// 药名规范化前的**确定性剥壳**:真实处方写「盐酸二甲双胍片」「阿托伐他汀钙片」,而
+/// 字典按通用名(二甲双胍 / 阿托伐他汀)收录。这里对已 normalize 的词生成候选词干 ——
+/// 去前导盐基、去尾部剂型、再去尾部成盐金属字 —— 供 [`normalize`] 在直配未命中时逐个
+/// 重试。**候选式、不破坏原词**:某个候选没配上只是跳过,所以「碳酸氢钠」不会被误删成
+/// 「碳酸氢」再乱配——两个候选都配不上就整体 miss(诚实,交给上层保留原文)。
+fn drug_stem_candidates(norm: &str) -> Vec<String> {
+    // 前导成盐酸根(仅去一次)。刻意不含「单硝酸/碳酸氢」这类本身就是药名一部分的。
+    const SALT_PREFIX: &[&str] = &[
+        "盐酸",
+        "硫酸氢",
+        "硫酸",
+        "苯磺酸",
+        "琥珀酸",
+        "马来酸",
+        "富马酸",
+        "酒石酸",
+        "氢溴酸",
+        "磷酸",
+        "醋酸",
+        "枸橼酸",
+        "甲磺酸",
+        "门冬",
+    ];
+    const FORM_SUFFIX: &[&str] = &[
+        "缓释片",
+        "控释片",
+        "分散片",
+        "咀嚼片",
+        "泡腾片",
+        "肠溶片",
+        "口服溶液",
+        "口服液",
+        "软胶囊",
+        "缓释胶囊",
+        "肠溶胶囊",
+        "注射液",
+        "混悬液",
+        "干混悬剂",
+        "颗粒",
+        "胶囊",
+        "滴丸",
+        "糖浆",
+        "贴片",
+        "栓",
+        "片",
+    ];
+    const METAL_SALT: &[&str] = &["钙", "钠", "钾", "镁"];
+
+    let mut base = norm.to_string();
+    for p in SALT_PREFIX {
+        let pn = normalize_term(p);
+        if let Some(r) = base.strip_prefix(&pn) {
+            base = r.to_string();
+            break;
+        }
+    }
+    // 反复去尾部剂型(如「…钙片」先去片)。
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for f in FORM_SUFFIX {
+            let fnorm = normalize_term(f);
+            if let Some(r) = base.strip_suffix(&fnorm) {
+                base = r.to_string();
+                changed = true;
+                break;
+            }
+        }
+    }
+    let mut cands: Vec<String> = Vec::new();
+    if base != norm && !base.is_empty() {
+        cands.push(base.clone());
+    }
+    // 再去一个尾部成盐金属字(阿托伐他汀钙 → 阿托伐他汀);仅当剩余仍 >1 字。
+    for m in METAL_SALT {
+        let mn = normalize_term(m);
+        if base.ends_with(&mn) {
+            let shorter = base[..base.len() - mn.len()].to_string();
+            if shorter.chars().count() > 1 && shorter != norm {
+                cands.push(shorter);
+            }
+        }
+    }
+    cands.dedup();
+    cands
+}
+
 /// Map a single candidate term to its canonical concept. Returns `None` on no
 /// hit. This is a lookup, not a full-text scan — locating terms in free text is
 /// the extraction layer's job (design §6).
 ///
 /// An exact (normalized) alias hit yields `confidence == 1.0`; an
-/// `ocr_confusions` hit yields `confidence == 0.5`.
+/// `ocr_confusions` hit yields `confidence == 0.5`. If a raw drug term
+/// (`盐酸二甲双胍片`) doesn't match directly, deterministic salt/form stripping is
+/// retried and, on a **drug** hit, returned at confidence 1.0.
 pub fn normalize(raw_term: &str) -> Option<Match> {
     let norm = normalize_term(raw_term);
     if norm.is_empty() {
@@ -243,6 +332,14 @@ pub fn normalize(raw_term: &str) -> Option<Match> {
     }
     if let Some(hit) = idx.confusions.get(&norm) {
         return Some(idx.to_match(hit, 0.5));
+    }
+    // 药名剥壳兜底:去盐/剂型后重试,只接受 Drug 类精确命中(仍确定性、可核对)。
+    for cand in drug_stem_candidates(&norm) {
+        if let Some(hit) = idx.aliases.get(&cand) {
+            if idx.entries[hit.entry_idx].category == Category::Drug {
+                return Some(idx.to_match(hit, 1.0));
+            }
+        }
     }
     None
 }
@@ -360,6 +457,20 @@ mod tests {
         assert!(normalize("完全不是术语").is_none());
         assert!(normalize("").is_none());
         assert!(normalize("   ").is_none());
+    }
+
+    #[test]
+    fn strips_salt_and_dosage_form_to_ingredient() {
+        // 真实处方写法(盐基 + 通用名 + 剂型)→ 剥壳后命中通用名。
+        assert_eq!(normalize("盐酸二甲双胍片").unwrap().key, "metformin");
+        assert_eq!(normalize("琥珀酸美托洛尔缓释片").unwrap().key, "metoprolol");
+        assert_eq!(normalize("苯磺酸氨氯地平片").unwrap().key, "amlodipine");
+        // 「…钙片」先去剂型再去成盐金属字。
+        assert_eq!(normalize("阿托伐他汀钙片").unwrap().key, "atorvastatin");
+        // 候选式不破坏:词典没有的整体 miss,绝不误配(碳酸氢钠 ≠ 碳酸氢)。
+        assert!(normalize("碳酸氢钠片").is_none());
+        // 剥壳只接受 Drug 类,不会把化验名误当药。
+        assert_eq!(normalize("阿托伐他汀").unwrap().category, Category::Drug);
     }
 
     #[test]

--- a/packages/terminology/testdata/blind_common_panels.json
+++ b/packages/terminology/testdata/blind_common_panels.json
@@ -1,0 +1,356 @@
+{
+  "reports": [
+    {
+      "type": "lab",
+      "dept": "血液科",
+      "items": [
+        {"name": "白细胞计数", "value": "6.8", "unit": "10^9/L", "ref": "3.5-9.5"},
+        {"name": "红细胞计数", "value": "4.52", "unit": "10^12/L", "ref": "4.3-5.8"},
+        {"name": "血红蛋白", "value": "142", "unit": "g/L", "ref": "130-175"},
+        {"name": "红细胞压积", "value": "0.43", "unit": "L/L", "ref": "0.40-0.50"},
+        {"name": "平均红细胞体积", "value": "88.5", "unit": "fL", "ref": "82-100"},
+        {"name": "平均血红蛋白量", "value": "29.8", "unit": "pg", "ref": "27-34"},
+        {"name": "平均血红蛋白浓度", "value": "336", "unit": "g/L", "ref": "316-354"},
+        {"name": "红细胞分布宽度CV", "value": "12.8", "unit": "%", "ref": "11.5-14.5"},
+        {"name": "血小板计数", "value": "215", "unit": "10^9/L", "ref": "125-350"},
+        {"name": "平均血小板体积", "value": "10.2", "unit": "fL", "ref": "7.6-13.2"},
+        {"name": "中性粒细胞百分比", "value": "58.6", "unit": "%", "ref": "40-75"},
+        {"name": "淋巴细胞百分比", "value": "32.4", "unit": "%", "ref": "20-50"},
+        {"name": "单核细胞百分比", "value": "6.8", "unit": "%", "ref": "3-10"},
+        {"name": "嗜酸性粒细胞百分比", "value": "1.8", "unit": "%", "ref": "0.4-8.0"},
+        {"name": "嗜碱性粒细胞百分比", "value": "0.4", "unit": "%", "ref": "0-1"},
+        {"name": "中性粒细胞绝对值", "value": "3.98", "unit": "10^9/L", "ref": "1.8-6.3"},
+        {"name": "淋巴细胞绝对值", "value": "2.20", "unit": "10^9/L", "ref": "1.1-3.2"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "血液科",
+      "items": [
+        {"name": "血红蛋白", "value": "96", "unit": "g/L", "ref": "115-150"},
+        {"name": "红细胞计数", "value": "3.78", "unit": "10^12/L", "ref": "3.8-5.1"},
+        {"name": "MCV", "value": "72.3", "unit": "fL", "ref": "82-100"},
+        {"name": "MCH", "value": "23.5", "unit": "pg", "ref": "27-34"},
+        {"name": "红细胞体积分布宽度", "value": "16.9", "unit": "%", "ref": "11.5-14.5"},
+        {"name": "血清铁", "value": "5.2", "unit": "umol/L", "ref": "10.6-36.7"},
+        {"name": "总铁结合力", "value": "78.5", "unit": "umol/L", "ref": "45-77"},
+        {"name": "铁蛋白", "value": "6.8", "unit": "ng/mL", "ref": "13-150"},
+        {"name": "转铁蛋白", "value": "3.6", "unit": "g/L", "ref": "2.0-3.6"},
+        {"name": "转铁蛋白饱和度", "value": "8.5", "unit": "%", "ref": "20-50"},
+        {"name": "叶酸", "value": "7.2", "unit": "ng/mL", "ref": "3.1-19.9"},
+        {"name": "维生素B12", "value": "356", "unit": "pg/mL", "ref": "180-914"},
+        {"name": "网织红细胞百分比", "value": "1.8", "unit": "%", "ref": "0.5-1.5"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "生化",
+      "items": [
+        {"name": "丙氨酸氨基转移酶", "value": "78", "unit": "U/L", "ref": "9-50"},
+        {"name": "天门冬氨酸氨基转移酶", "value": "65", "unit": "U/L", "ref": "15-40"},
+        {"name": "γ-谷氨酰转移酶", "value": "112", "unit": "U/L", "ref": "10-60"},
+        {"name": "碱性磷酸酶", "value": "128", "unit": "U/L", "ref": "45-125"},
+        {"name": "总胆红素", "value": "22.5", "unit": "umol/L", "ref": "3.4-20.5"},
+        {"name": "直接胆红素", "value": "6.8", "unit": "umol/L", "ref": "0-6.8"},
+        {"name": "间接胆红素", "value": "15.7", "unit": "umol/L", "ref": "1.7-13.7"},
+        {"name": "总蛋白", "value": "72.5", "unit": "g/L", "ref": "65-85"},
+        {"name": "白蛋白", "value": "42.3", "unit": "g/L", "ref": "40-55"},
+        {"name": "球蛋白", "value": "30.2", "unit": "g/L", "ref": "20-40"},
+        {"name": "白球比", "value": "1.40", "unit": "", "ref": "1.2-2.4"},
+        {"name": "总胆汁酸", "value": "12.6", "unit": "umol/L", "ref": "0-10"},
+        {"name": "前白蛋白", "value": "185", "unit": "mg/L", "ref": "200-400"},
+        {"name": "胆碱酯酶", "value": "6850", "unit": "U/L", "ref": "5000-12000"},
+        {"name": "腺苷脱氨酶", "value": "18.5", "unit": "U/L", "ref": "4-24"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "生化",
+      "items": [
+        {"name": "尿素", "value": "9.8", "unit": "mmol/L", "ref": "3.1-8.0"},
+        {"name": "肌酐", "value": "156", "unit": "umol/L", "ref": "57-97"},
+        {"name": "尿酸", "value": "486", "unit": "umol/L", "ref": "208-428"},
+        {"name": "估算肾小球滤过率", "value": "48.5", "unit": "mL/min/1.73m2", "ref": ">90"},
+        {"name": "胱抑素C", "value": "1.68", "unit": "mg/L", "ref": "0.51-1.09"},
+        {"name": "β2-微球蛋白", "value": "3.85", "unit": "mg/L", "ref": "1.0-3.0"},
+        {"name": "视黄醇结合蛋白", "value": "68.5", "unit": "mg/L", "ref": "25-70"},
+        {"name": "钾", "value": "5.2", "unit": "mmol/L", "ref": "3.5-5.3"},
+        {"name": "钠", "value": "139", "unit": "mmol/L", "ref": "137-147"},
+        {"name": "氯", "value": "104", "unit": "mmol/L", "ref": "99-110"},
+        {"name": "钙", "value": "2.18", "unit": "mmol/L", "ref": "2.11-2.52"},
+        {"name": "无机磷", "value": "1.42", "unit": "mmol/L", "ref": "0.85-1.51"},
+        {"name": "镁", "value": "0.92", "unit": "mmol/L", "ref": "0.75-1.02"},
+        {"name": "二氧化碳结合力", "value": "21.5", "unit": "mmol/L", "ref": "22-29"},
+        {"name": "阴离子间隙", "value": "13.5", "unit": "mmol/L", "ref": "8-16"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "生化",
+      "items": [
+        {"name": "总胆固醇", "value": "6.85", "unit": "mmol/L", "ref": "<5.18"},
+        {"name": "甘油三酯", "value": "2.86", "unit": "mmol/L", "ref": "<1.70"},
+        {"name": "高密度脂蛋白胆固醇", "value": "0.92", "unit": "mmol/L", "ref": ">1.04"},
+        {"name": "低密度脂蛋白胆固醇", "value": "4.35", "unit": "mmol/L", "ref": "<3.37"},
+        {"name": "载脂蛋白A1", "value": "1.05", "unit": "g/L", "ref": "1.20-1.60"},
+        {"name": "载脂蛋白B", "value": "1.28", "unit": "g/L", "ref": "0.60-1.10"},
+        {"name": "脂蛋白(a)", "value": "385", "unit": "mg/L", "ref": "<300"},
+        {"name": "小而密低密度脂蛋白", "value": "1.15", "unit": "mmol/L", "ref": "0.24-1.09"},
+        {"name": "游离脂肪酸", "value": "0.68", "unit": "mmol/L", "ref": "0.1-0.9"},
+        {"name": "同型半胱氨酸", "value": "18.6", "unit": "umol/L", "ref": "<15"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌",
+      "items": [
+        {"name": "空腹血糖", "value": "8.9", "unit": "mmol/L", "ref": "3.9-6.1"},
+        {"name": "糖化血红蛋白", "value": "8.2", "unit": "%", "ref": "4.0-6.0"},
+        {"name": "糖化白蛋白", "value": "22.5", "unit": "%", "ref": "11-16"},
+        {"name": "空腹胰岛素", "value": "18.6", "unit": "uIU/mL", "ref": "2.6-24.9"},
+        {"name": "空腹C肽", "value": "2.85", "unit": "ng/mL", "ref": "0.78-5.19"},
+        {"name": "餐后2小时血糖", "value": "14.6", "unit": "mmol/L", "ref": "<7.8"},
+        {"name": "胰岛素抵抗指数", "value": "7.35", "unit": "", "ref": "<2.69"},
+        {"name": "谷氨酸脱羧酶抗体", "value": "阴性", "unit": "", "ref": "阴性"},
+        {"name": "尿微量白蛋白", "value": "68.5", "unit": "mg/L", "ref": "<20"},
+        {"name": "尿白蛋白肌酐比", "value": "42.6", "unit": "mg/g", "ref": "<30"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌",
+      "items": [
+        {"name": "促甲状腺激素", "value": "8.65", "unit": "uIU/mL", "ref": "0.27-4.20"},
+        {"name": "游离甲状腺素", "value": "9.8", "unit": "pmol/L", "ref": "12.0-22.0"},
+        {"name": "游离三碘甲状腺原氨酸", "value": "3.2", "unit": "pmol/L", "ref": "3.1-6.8"},
+        {"name": "总甲状腺素", "value": "68.5", "unit": "nmol/L", "ref": "66-181"},
+        {"name": "总三碘甲状腺原氨酸", "value": "1.15", "unit": "nmol/L", "ref": "1.3-3.1"},
+        {"name": "甲状腺过氧化物酶抗体", "value": "285", "unit": "IU/mL", "ref": "<34"},
+        {"name": "甲状腺球蛋白抗体", "value": "412", "unit": "IU/mL", "ref": "<115"},
+        {"name": "甲状腺球蛋白", "value": "12.5", "unit": "ng/mL", "ref": "3.5-77"},
+        {"name": "促甲状腺激素受体抗体", "value": "0.8", "unit": "IU/L", "ref": "<1.75"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "心内科",
+      "items": [
+        {"name": "肌酸激酶", "value": "285", "unit": "U/L", "ref": "50-310"},
+        {"name": "肌酸激酶同工酶CK-MB", "value": "38", "unit": "U/L", "ref": "0-24"},
+        {"name": "乳酸脱氢酶", "value": "268", "unit": "U/L", "ref": "120-250"},
+        {"name": "α-羟丁酸脱氢酶", "value": "215", "unit": "U/L", "ref": "72-182"},
+        {"name": "肌钙蛋白I", "value": "2.85", "unit": "ng/mL", "ref": "<0.04"},
+        {"name": "高敏肌钙蛋白T", "value": "285.6", "unit": "pg/mL", "ref": "<14"},
+        {"name": "肌红蛋白", "value": "186", "unit": "ng/mL", "ref": "<70"},
+        {"name": "N末端脑钠肽前体", "value": "1856", "unit": "pg/mL", "ref": "<125"},
+        {"name": "超敏C反应蛋白", "value": "8.6", "unit": "mg/L", "ref": "<3.0"},
+        {"name": "D-二聚体", "value": "1.28", "unit": "mg/L FEU", "ref": "<0.5"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "生化",
+      "items": [
+        {"name": "尿酸", "value": "568", "unit": "umol/L", "ref": "208-428"},
+        {"name": "肌酐", "value": "98", "unit": "umol/L", "ref": "57-111"},
+        {"name": "尿素氮", "value": "6.2", "unit": "mmol/L", "ref": "3.1-8.0"},
+        {"name": "血沉", "value": "38", "unit": "mm/h", "ref": "0-15"},
+        {"name": "超敏C反应蛋白", "value": "12.5", "unit": "mg/L", "ref": "<3.0"},
+        {"name": "24小时尿尿酸", "value": "4.85", "unit": "mmol/24h", "ref": "1.48-4.43"},
+        {"name": "抗链球菌溶血素O", "value": "125", "unit": "IU/mL", "ref": "<200"},
+        {"name": "类风湿因子", "value": "18.5", "unit": "IU/mL", "ref": "<20"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "凝血",
+      "items": [
+        {"name": "凝血酶原时间", "value": "13.8", "unit": "s", "ref": "11.0-14.5"},
+        {"name": "国际标准化比值", "value": "1.08", "unit": "", "ref": "0.8-1.2"},
+        {"name": "活化部分凝血活酶时间", "value": "36.5", "unit": "s", "ref": "28-40"},
+        {"name": "凝血酶时间", "value": "17.2", "unit": "s", "ref": "14-21"},
+        {"name": "纤维蛋白原", "value": "4.85", "unit": "g/L", "ref": "2.0-4.0"},
+        {"name": "D-二聚体", "value": "0.68", "unit": "mg/L FEU", "ref": "<0.5"},
+        {"name": "纤维蛋白降解产物", "value": "6.2", "unit": "ug/mL", "ref": "<5"},
+        {"name": "PT活动度", "value": "92", "unit": "%", "ref": "70-130"},
+        {"name": "抗凝血酶III", "value": "95", "unit": "%", "ref": "80-120"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "检验科",
+      "items": [
+        {"name": "尿比重", "value": "1.020", "unit": "", "ref": "1.003-1.030"},
+        {"name": "尿酸碱度", "value": "6.0", "unit": "", "ref": "4.5-8.0"},
+        {"name": "尿蛋白", "value": "++", "unit": "", "ref": "阴性"},
+        {"name": "尿葡萄糖", "value": "+++", "unit": "", "ref": "阴性"},
+        {"name": "尿酮体", "value": "阴性", "unit": "", "ref": "阴性"},
+        {"name": "尿隐血", "value": "+", "unit": "", "ref": "阴性"},
+        {"name": "尿胆原", "value": "正常", "unit": "", "ref": "正常"},
+        {"name": "尿胆红素", "value": "阴性", "unit": "", "ref": "阴性"},
+        {"name": "尿亚硝酸盐", "value": "阴性", "unit": "", "ref": "阴性"},
+        {"name": "尿白细胞酯酶", "value": "阴性", "unit": "", "ref": "阴性"},
+        {"name": "尿红细胞", "value": "15.6", "unit": "/uL", "ref": "0-25"},
+        {"name": "尿白细胞", "value": "8.2", "unit": "/uL", "ref": "0-28"},
+        {"name": "尿上皮细胞", "value": "5.8", "unit": "/uL", "ref": "0-40"},
+        {"name": "尿管型", "value": "0", "unit": "/uL", "ref": "0-1"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "检验科",
+      "items": [
+        {"name": "甲胎蛋白", "value": "8.6", "unit": "ng/mL", "ref": "<7.0"},
+        {"name": "癌胚抗原", "value": "6.8", "unit": "ng/mL", "ref": "<5.0"},
+        {"name": "糖类抗原125", "value": "42.5", "unit": "U/mL", "ref": "<35"},
+        {"name": "糖类抗原19-9", "value": "38.6", "unit": "U/mL", "ref": "<37"},
+        {"name": "糖类抗原15-3", "value": "18.5", "unit": "U/mL", "ref": "<25"},
+        {"name": "糖类抗原72-4", "value": "3.2", "unit": "U/mL", "ref": "<6.9"},
+        {"name": "神经元特异性烯醇化酶", "value": "12.5", "unit": "ng/mL", "ref": "<16.3"},
+        {"name": "细胞角蛋白19片段", "value": "2.8", "unit": "ng/mL", "ref": "<3.3"},
+        {"name": "鳞状细胞癌抗原", "value": "1.2", "unit": "ng/mL", "ref": "<1.5"},
+        {"name": "总前列腺特异性抗原", "value": "3.85", "unit": "ng/mL", "ref": "<4.0"},
+        {"name": "游离前列腺特异性抗原", "value": "0.72", "unit": "ng/mL", "ref": "<0.93"},
+        {"name": "胃泌素释放肽前体", "value": "45.6", "unit": "pg/mL", "ref": "<63"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "感染科",
+      "items": [
+        {"name": "白细胞计数", "value": "14.6", "unit": "10^9/L", "ref": "3.5-9.5"},
+        {"name": "中性粒细胞百分比", "value": "86.5", "unit": "%", "ref": "40-75"},
+        {"name": "C反应蛋白", "value": "86", "unit": "mg/L", "ref": "<10"},
+        {"name": "降钙素原", "value": "2.85", "unit": "ng/mL", "ref": "<0.05"},
+        {"name": "血清淀粉样蛋白A", "value": "156", "unit": "mg/L", "ref": "<10"},
+        {"name": "白介素-6", "value": "68.5", "unit": "pg/mL", "ref": "<7.0"},
+        {"name": "红细胞沉降率", "value": "52", "unit": "mm/h", "ref": "0-15"},
+        {"name": "内毒素", "value": "0.28", "unit": "EU/mL", "ref": "<0.1"},
+        {"name": "G试验", "value": "185", "unit": "pg/mL", "ref": "<100"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "生化",
+      "items": [
+        {"name": "ALT", "value": "52", "unit": "U/L", "ref": "9-50"},
+        {"name": "AST", "value": "48", "unit": "U/L", "ref": "15-40"},
+        {"name": "GGT", "value": "88", "unit": "U/L", "ref": "10-60"},
+        {"name": "TBIL", "value": "18.6", "unit": "umol/L", "ref": "3.4-20.5"},
+        {"name": "ALB", "value": "38.5", "unit": "g/L", "ref": "40-55"},
+        {"name": "Glu", "value": "6.8", "unit": "mmol/L", "ref": "3.9-6.1"},
+        {"name": "Cr", "value": "82", "unit": "umol/L", "ref": "57-97"},
+        {"name": "BUN", "value": "5.6", "unit": "mmol/L", "ref": "3.1-8.0"},
+        {"name": "UA", "value": "398", "unit": "umol/L", "ref": "208-428"},
+        {"name": "TG", "value": "1.85", "unit": "mmol/L", "ref": "<1.70"},
+        {"name": "TC", "value": "5.62", "unit": "mmol/L", "ref": "<5.18"},
+        {"name": "HDL - C", "value": "1.12", "unit": "mmol/L", "ref": ">1.04"},
+        {"name": "LDL-C", "value": "3.58", "unit": "mmol/L", "ref": "<3.37"},
+        {"name": "eGFR", "value": "92", "unit": "mL/min/1.73m2", "ref": ">90"}
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌",
+      "items": [
+        {"name": "25-羟基维生素D", "value": "18.6", "unit": "ng/mL", "ref": "30-100"},
+        {"name": "甲状旁腺激素", "value": "82.5", "unit": "pg/mL", "ref": "15-65"},
+        {"name": "骨钙素", "value": "28.6", "unit": "ng/mL", "ref": "11-43"},
+        {"name": "β-胶原降解产物", "value": "0.685", "unit": "ng/mL", "ref": "<0.584"},
+        {"name": "总I型胶原氨基端延长肽", "value": "68.5", "unit": "ng/mL", "ref": "15-58"},
+        {"name": "皮质醇", "value": "685", "unit": "nmol/L", "ref": "171-536"},
+        {"name": "促肾上腺皮质激素", "value": "45.6", "unit": "pg/mL", "ref": "7.2-63.3"},
+        {"name": "醛固酮", "value": "285", "unit": "pg/mL", "ref": "40-310"},
+        {"name": "血浆肾素活性", "value": "1.85", "unit": "ng/mL/h", "ref": "0.15-2.33"},
+        {"name": "性激素结合球蛋白", "value": "42.5", "unit": "nmol/L", "ref": "18.3-54.1"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "原发性高血压",
+      "drugs": [
+        {"name": "苯磺酸氨氯地平片", "dose": "5mg", "freq": "每日一次"},
+        {"name": "缬沙坦胶囊", "dose": "80mg", "freq": "每日一次"},
+        {"name": "氢氯噻嗪片", "dose": "12.5mg", "freq": "每日一次"},
+        {"name": "琥珀酸美托洛尔缓释片", "dose": "47.5mg", "freq": "每日一次"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "2型糖尿病",
+      "drugs": [
+        {"name": "盐酸二甲双胍片", "dose": "0.5g", "freq": "每日三次"},
+        {"name": "阿卡波糖片", "dose": "50mg", "freq": "每日三次餐中"},
+        {"name": "达格列净片", "dose": "10mg", "freq": "每日一次"},
+        {"name": "格列美脲片", "dose": "2mg", "freq": "每日一次早餐前"},
+        {"name": "甘精胰岛素注射液", "dose": "16U", "freq": "每晚睡前皮下注射"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "高脂血症",
+      "drugs": [
+        {"name": "阿托伐他汀钙片", "dose": "20mg", "freq": "每晚一次"},
+        {"name": "非诺贝特胶囊", "dose": "0.2g", "freq": "每日一次"},
+        {"name": "依折麦布片", "dose": "10mg", "freq": "每日一次"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "冠心病 稳定型心绞痛",
+      "drugs": [
+        {"name": "阿司匹林肠溶片", "dose": "100mg", "freq": "每日一次"},
+        {"name": "硫酸氢氯吡格雷片", "dose": "75mg", "freq": "每日一次"},
+        {"name": "瑞舒伐他汀钙片", "dose": "10mg", "freq": "每晚一次"},
+        {"name": "单硝酸异山梨酯缓释片", "dose": "40mg", "freq": "每日一次"},
+        {"name": "硝酸甘油片", "dose": "0.5mg", "freq": "心绞痛发作时舌下含服"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "甲状腺功能减退症",
+      "drugs": [
+        {"name": "左甲状腺素钠片", "dose": "50ug", "freq": "每日一次早餐前"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "痛风性关节炎",
+      "drugs": [
+        {"name": "非布司他片", "dose": "40mg", "freq": "每日一次"},
+        {"name": "秋水仙碱片", "dose": "0.5mg", "freq": "每日两次"},
+        {"name": "依托考昔片", "dose": "60mg", "freq": "每日一次"},
+        {"name": "碳酸氢钠片", "dose": "1g", "freq": "每日三次"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "缺铁性贫血",
+      "drugs": [
+        {"name": "多糖铁复合物胶囊", "dose": "150mg", "freq": "每日一次"},
+        {"name": "维生素C片", "dose": "0.1g", "freq": "每日三次"},
+        {"name": "叶酸片", "dose": "5mg", "freq": "每日一次"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "慢性肾脏病3期",
+      "drugs": [
+        {"name": "复方α-酮酸片", "dose": "2.52g", "freq": "每日三次"},
+        {"name": "百令胶囊", "dose": "2g", "freq": "每日三次"},
+        {"name": "碳酸钙D3片", "dose": "0.6g", "freq": "每日一次"},
+        {"name": "硝苯地平控释片", "dose": "30mg", "freq": "每日一次"}
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "上呼吸道感染",
+      "drugs": [
+        {"name": "阿莫西林克拉维酸钾片", "dose": "0.457g", "freq": "每日两次"},
+        {"name": "复方氨酚烷胺胶囊", "dose": "1粒", "freq": "每日两次"},
+        {"name": "氨溴索口服溶液", "dose": "10mL", "freq": "每日三次"},
+        {"name": "连花清瘟胶囊", "dose": "4粒", "freq": "每日三次"}
+      ]
+    }
+  ]
+}

--- a/packages/terminology/testdata/blind_specialty_hard.json
+++ b/packages/terminology/testdata/blind_specialty_hard.json
@@ -1,0 +1,386 @@
+{
+  "reports": [
+    {
+      "type": "lab",
+      "dept": "内分泌科",
+      "items": [
+        { "name": "皮质醇(8AM)", "value": "21.6", "unit": "µg/dL", "ref": "6.2-19.4" },
+        { "name": "皮质醇 (16:00)", "value": "12.8", "unit": "μg/dl", "ref": "2.3-11.9" },
+        { "name": "皮质醇（0AM/午夜）", "value": "9.4", "unit": "ug/dL", "ref": "<7.5" },
+        { "name": "ACTH（促肾上腺皮质激素）", "value": "68.2", "unit": "pg/mL", "ref": "7.2-63.3" },
+        { "name": "24h尿游离皮质醇 UFC", "value": "285", "unit": "µg/24h", "ref": "36-137" },
+        { "name": "血浆醛固酮 (卧位)", "value": "18.6", "unit": "ng/dL", "ref": "3.0-23.6" },
+        { "name": "血浆肾素活性 PRA", "value": "0.42", "unit": "ng/mL/h", "ref": "0.15-2.33" },
+        { "name": "醛固酮/肾素比值 ARR", "value": "44.3", "unit": "", "ref": "<30" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌科",
+      "items": [
+        { "name": "卵泡刺激素(FSH)", "value": "6.8", "unit": "mIU/mL", "ref": "3.5-12.5" },
+        { "name": "黄体生成素 LH", "value": "5.2", "unit": "IU/L", "ref": "2.4-12.6" },
+        { "name": "催乳素（PRL/泌乳素）", "value": "38.6", "unit": "ng/mL", "ref": "4.79-23.3" },
+        { "name": "雌二醇 E2", "value": "42", "unit": "pg/mL", "ref": "12.5-166" },
+        { "name": "孕酮 (P)", "value": "0.8", "unit": "ng/mL", "ref": "<0.89" },
+        { "name": "睾酮 T（总睾酮）", "value": "0.28", "unit": "ng/mL", "ref": "0.084-0.481" },
+        { "name": "游离睾酮", "value": "1.9", "unit": "pg/mL", "ref": "0.29-3.18" },
+        { "name": "硫酸脱氢表雄酮 DHEA-S", "value": "312", "unit": "µg/dL", "ref": "35-430" },
+        { "name": "性激素结合球蛋白 SHBG", "value": "56", "unit": "nmol/L", "ref": "18-114" },
+        { "name": "抗苗勒管激素 AMH", "value": "1.24", "unit": "ng/mL", "ref": "1.0-6.8" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌科",
+      "items": [
+        { "name": "甲状旁腺激素 PTH", "value": "88.4", "unit": "pg/mL", "ref": "15-65" },
+        { "name": "25-羟基维生素D [25(OH)D]", "value": "16.2", "unit": "ng/mL", "ref": "30-100" },
+        { "name": "1,25-双羟维生素D3", "value": "42", "unit": "pg/mL", "ref": "19.6-54.3" },
+        { "name": "血清钙 (Ca)", "value": "2.68", "unit": "mmol/L", "ref": "2.11-2.52" },
+        { "name": "血清磷 P", "value": "0.72", "unit": "mmol/L", "ref": "0.85-1.51" },
+        { "name": "β-胶原降解产物 β-CTX", "value": "0.68", "unit": "ng/mL", "ref": "0.10-0.70" },
+        { "name": "总I型胶原氨基端延长肽 P1NP", "value": "68.2", "unit": "ng/mL", "ref": "15.1-58.6" },
+        { "name": "骨钙素 N-MID", "value": "24.6", "unit": "ng/mL", "ref": "11-43" },
+        { "name": "碱性磷酸酶 ALP", "value": "126", "unit": "U/L", "ref": "45-125" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "风湿免疫科",
+      "items": [
+        { "name": "抗核抗体 ANA（间接免疫荧光）", "value": "1:320 核颗粒型", "unit": "", "ref": "<1:100" },
+        { "name": "抗双链DNA抗体 抗ds-DNA", "value": "186", "unit": "IU/mL", "ref": "<100" },
+        { "name": "补体C3", "value": "0.58", "unit": "g/L", "ref": "0.9-1.8" },
+        { "name": "补体C4", "value": "0.09", "unit": "g/L", "ref": "0.1-0.4" },
+        { "name": "类风湿因子 RF", "value": "128", "unit": "IU/mL", "ref": "<20" },
+        { "name": "抗环瓜氨酸肽抗体 抗CCP", "value": "245", "unit": "U/mL", "ref": "<17" },
+        { "name": "C反应蛋白 CRP", "value": "32.6", "unit": "mg/L", "ref": "<8" },
+        { "name": "红细胞沉降率 ESR（血沉）", "value": "58", "unit": "mm/h", "ref": "0-20" },
+        { "name": "免疫球蛋白 IgG", "value": "18.6", "unit": "g/L", "ref": "7.0-16.0" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "风湿免疫科",
+      "items": [
+        { "name": "抗 SSA/Ro52 抗体", "value": "阳性(+++)", "unit": "", "ref": "阴性" },
+        { "name": "抗SSA/Ro60抗体", "value": "阳性(++)", "unit": "", "ref": "阴性" },
+        { "name": "抗SSB/La抗体", "value": "阳性(+)", "unit": "", "ref": "阴性" },
+        { "name": "抗Sm抗体", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗 U1-nRNP 抗体", "value": "弱阳性", "unit": "", "ref": "阴性" },
+        { "name": "抗Scl-70抗体", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗Jo-1抗体", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗着丝点抗体 CENP-B", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗中性粒细胞胞浆抗体 p-ANCA(MPO)", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗 c-ANCA(PR3)", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "抗β2糖蛋白1抗体 IgG", "value": "26", "unit": "RU/mL", "ref": "<20" },
+        { "name": "抗心磷脂抗体 ACA-IgG", "value": "18", "unit": "GPL", "ref": "<12" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "感染科",
+      "items": [
+        { "name": "降钙素原 PCT", "value": "4.86", "unit": "ng/mL", "ref": "<0.5" },
+        { "name": "白细胞介素-6 (IL-6)", "value": "128", "unit": "pg/mL", "ref": "<7" },
+        { "name": "(1,3)-β-D-葡聚糖 G试验", "value": "186", "unit": "pg/mL", "ref": "<100" },
+        { "name": "半乳甘露聚糖 GM试验", "value": "0.82", "unit": "I", "ref": "<0.5" },
+        { "name": "结核感染T细胞检测 T-SPOT.TB", "value": "阳性", "unit": "", "ref": "阴性" },
+        { "name": "隐球菌荚膜多糖抗原", "value": "阴性", "unit": "", "ref": "阴性" },
+        { "name": "内毒素（鲎试验）", "value": "0.32", "unit": "EU/mL", "ref": "<0.5" },
+        { "name": "血清淀粉样蛋白A SAA", "value": "162", "unit": "mg/L", "ref": "<10" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "肿瘤科",
+      "items": [
+        { "name": "甲胎蛋白 AFP", "value": "6.8", "unit": "ng/mL", "ref": "<7.0" },
+        { "name": "癌胚抗原 CEA", "value": "12.6", "unit": "ng/mL", "ref": "<5.0" },
+        { "name": "糖类抗原 CA19-9", "value": "86", "unit": "U/mL", "ref": "<37" },
+        { "name": "糖类抗原125 CA125", "value": "168", "unit": "U/mL", "ref": "<35" },
+        { "name": "糖类抗原15-3 CA15-3", "value": "22", "unit": "U/mL", "ref": "<25" },
+        { "name": "糖类抗原72-4 CA72-4", "value": "3.1", "unit": "U/mL", "ref": "<6.9" },
+        { "name": "细胞角蛋白19片段 CYFRA21-1", "value": "4.8", "unit": "ng/mL", "ref": "<3.3" },
+        { "name": "神经元特异性烯醇化酶 NSE", "value": "18.6", "unit": "ng/mL", "ref": "<16.3" },
+        { "name": "鳞状细胞癌抗原 SCC", "value": "1.2", "unit": "ng/mL", "ref": "<1.5" },
+        { "name": "胃泌素释放肽前体 ProGRP", "value": "42", "unit": "pg/mL", "ref": "<63" },
+        { "name": "总前列腺特异性抗原 tPSA", "value": "8.6", "unit": "ng/mL", "ref": "<4.0" },
+        { "name": "游离PSA / 总PSA 比值 (f/tPSA)", "value": "0.12", "unit": "", "ref": ">0.16" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "心内科",
+      "items": [
+        { "name": "N末端B型钠尿肽前体 NT-proBNP", "value": "3860", "unit": "pg/mL", "ref": "<125" },
+        { "name": "B型钠尿肽 BNP", "value": "820", "unit": "pg/mL", "ref": "<100" },
+        { "name": "高敏肌钙蛋白T hs-cTnT", "value": "86", "unit": "ng/L", "ref": "<14" },
+        { "name": "肌钙蛋白I（cTnI）", "value": "0.68", "unit": "ng/mL", "ref": "<0.034" },
+        { "name": "肌红蛋白 Mb", "value": "156", "unit": "ng/mL", "ref": "<70" },
+        { "name": "肌酸激酶同工酶 CK-MB质量", "value": "18.6", "unit": "ng/mL", "ref": "<5.0" },
+        { "name": "肌酸激酶 CK", "value": "286", "unit": "U/L", "ref": "38-174" },
+        { "name": "乳酸脱氢酶 LDH", "value": "312", "unit": "U/L", "ref": "120-250" },
+        { "name": "同型半胱氨酸 Hcy", "value": "22.6", "unit": "µmol/L", "ref": "<15" },
+        { "name": "超敏C反应蛋白 hs-CRP", "value": "6.8", "unit": "mg/L", "ref": "<3.0" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "血液科",
+      "items": [
+        { "name": "血清铁 (SI)", "value": "6.2", "unit": "µmol/L", "ref": "10.6-36.7" },
+        { "name": "总铁结合力 TIBC", "value": "78", "unit": "µmol/L", "ref": "48.3-68.0" },
+        { "name": "转铁蛋白饱和度 TSAT", "value": "8", "unit": "%", "ref": "20-50" },
+        { "name": "铁蛋白 (Ferritin/SF)", "value": "8.6", "unit": "ng/mL", "ref": "13-150" },
+        { "name": "转铁蛋白 TRF", "value": "3.8", "unit": "g/L", "ref": "2.0-3.6" },
+        { "name": "可溶性转铁蛋白受体 sTfR", "value": "3.2", "unit": "mg/L", "ref": "1.9-4.4" },
+        { "name": "叶酸 (Folate)", "value": "3.2", "unit": "ng/mL", "ref": "3.1-19.9" },
+        { "name": "维生素B12（VitB12/钴胺素）", "value": "168", "unit": "pg/mL", "ref": "197-771" },
+        { "name": "网织红细胞百分比 Ret%", "value": "0.6", "unit": "%", "ref": "0.5-1.5" },
+        { "name": "促红细胞生成素 EPO", "value": "42", "unit": "mIU/mL", "ref": "4.3-29" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "血液科",
+      "items": [
+        { "name": "凝血酶原时间 PT", "value": "16.8", "unit": "s", "ref": "11-14.5" },
+        { "name": "国际标准化比值 INR", "value": "1.42", "unit": "", "ref": "0.8-1.2" },
+        { "name": "活化部分凝血活酶时间 APTT", "value": "48.6", "unit": "s", "ref": "28-40" },
+        { "name": "凝血酶时间 TT", "value": "18.2", "unit": "s", "ref": "14-21" },
+        { "name": "纤维蛋白原 Fbg（FIB）", "value": "5.8", "unit": "g/L", "ref": "2.0-4.0" },
+        { "name": "D-二聚体 D-Dimer", "value": "3.86", "unit": "mg/L FEU", "ref": "<0.5" },
+        { "name": "纤维蛋白（原）降解产物 FDP", "value": "18.6", "unit": "µg/mL", "ref": "<5.0" },
+        { "name": "抗凝血酶Ⅲ AT-III", "value": "68", "unit": "%", "ref": "80-120" },
+        { "name": "凝血酶原活动度 PTA", "value": "62", "unit": "%", "ref": "70-130" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "肾内科",
+      "items": [
+        { "name": "尿红细胞计数（定量）", "value": "186", "unit": "/µL", "ref": "<25" },
+        { "name": "尿白细胞（定量/镜检）", "value": "62", "unit": "/µL", "ref": "<28" },
+        { "name": "尿蛋白定量（24h）", "value": "2860", "unit": "mg/24h", "ref": "<150" },
+        { "name": "尿微量白蛋白 mALB", "value": "286", "unit": "mg/L", "ref": "<20" },
+        { "name": "尿白蛋白/肌酐比值 ACR", "value": "320", "unit": "mg/g", "ref": "<30" },
+        { "name": "尿β2-微球蛋白", "value": "3.8", "unit": "mg/L", "ref": "<0.3" },
+        { "name": "尿α1-微球蛋白", "value": "42", "unit": "mg/L", "ref": "<12" },
+        { "name": "尿 N-乙酰-β-D-氨基葡萄糖苷酶 NAG", "value": "28", "unit": "U/L", "ref": "<11.5" },
+        { "name": "尿管型（透明管型）", "value": "3", "unit": "/LPF", "ref": "0-1" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "重症医学科",
+      "items": [
+        { "name": "酸碱度 pH", "value": "7.28", "unit": "", "ref": "7.35-7.45" },
+        { "name": "二氧化碳分压 PaCO2", "value": "56", "unit": "mmHg", "ref": "35-45" },
+        { "name": "氧分压 PaO2", "value": "62", "unit": "mmHg", "ref": "80-100" },
+        { "name": "碳酸氢根 HCO3-", "value": "20.6", "unit": "mmol/L", "ref": "22-27" },
+        { "name": "剩余碱 BE", "value": "-4.8", "unit": "mmol/L", "ref": "-3~+3" },
+        { "name": "血氧饱和度 SaO2", "value": "89", "unit": "%", "ref": "95-99" },
+        { "name": "乳酸 Lac", "value": "3.6", "unit": "mmol/L", "ref": "0.5-1.6" },
+        { "name": "阴离子间隙 AG", "value": "18", "unit": "mmol/L", "ref": "8-16" },
+        { "name": "氧合指数 P/F", "value": "206", "unit": "", "ref": ">300" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "变态反应科",
+      "items": [
+        { "name": "总IgE (tIgE)", "value": "486", "unit": "IU/mL", "ref": "<100" },
+        { "name": "特异性IgE-户尘螨 (d1) sIgE", "value": "3级 (8.2 kUA/L)", "unit": "kUA/L", "ref": "<0.35" },
+        { "name": "sIgE-粉尘螨 d2", "value": "3级", "unit": "", "ref": "<0.35" },
+        { "name": "特异性IgE 猫毛皮屑 e1", "value": "2级 (1.8)", "unit": "kUA/L", "ref": "<0.35" },
+        { "name": "sIgE-鸡蛋白 f1", "value": "0级", "unit": "", "ref": "<0.35" },
+        { "name": "特异性IgE-牛奶 f2", "value": "1级 (0.68)", "unit": "kUA/L", "ref": "<0.35" },
+        { "name": "sIgE-花生 f13", "value": "0级", "unit": "", "ref": "<0.35" },
+        { "name": "特异性IgE 艾蒿 w6", "value": "4级 (26)", "unit": "kUA/L", "ref": "<0.35" },
+        { "name": "嗜酸性粒细胞阳离子蛋白 ECP", "value": "32", "unit": "µg/L", "ref": "<13.3" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "药学监护/TDM",
+      "items": [
+        { "name": "万古霉素血药浓度（谷浓度）", "value": "22.6", "unit": "µg/mL", "ref": "10-20" },
+        { "name": "他克莫司 (FK506) 谷浓度", "value": "12.8", "unit": "ng/mL", "ref": "5-15" },
+        { "name": "环孢素 CsA 谷浓度 C0", "value": "186", "unit": "ng/mL", "ref": "100-200" },
+        { "name": "地高辛血药浓度", "value": "2.4", "unit": "ng/mL", "ref": "0.8-2.0" },
+        { "name": "丙戊酸（丙戊酸钠）浓度", "value": "48", "unit": "µg/mL", "ref": "50-100" },
+        { "name": "卡马西平血药浓度", "value": "10.6", "unit": "µg/mL", "ref": "4-12" },
+        { "name": "苯妥英钠浓度", "value": "8.2", "unit": "µg/mL", "ref": "10-20" },
+        { "name": "甲氨蝶呤浓度 (24h)", "value": "5.8", "unit": "µmol/L", "ref": "<10" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "消化内科",
+      "items": [
+        { "name": "谷 丙 转 氨 酶 ALT", "value": "186", "unit": "U/L", "ref": "9-50" },
+        { "name": "谷草转氨酶 AST", "value": "142", "unit": "U/L", "ref": "15-40" },
+        { "name": "y-谷氨酰转肽酶 GGT", "value": "286", "unit": "U/L", "ref": "10-60" },
+        { "name": "总胆红素 TBIL", "value": "68.2", "unit": "µmol/L", "ref": "3.4-20.5" },
+        { "name": "直接胆红素 DBIL", "value": "42.6", "unit": "μmol/L", "ref": "0-6.8" },
+        { "name": "总蛋白 TP", "value": "58", "unit": "g/L", "ref": "65-85" },
+        { "name": "白蛋白 ALB", "value": "28", "unit": "g/L", "ref": "40-55" },
+        { "name": "球蛋白 GLB", "value": "30", "unit": "g/L", "ref": "20-40" },
+        { "name": "总胆汁酸 TBA", "value": "68", "unit": "µmol/L", "ref": "0-10" },
+        { "name": "胆碱酯酶 ChE", "value": "3200", "unit": "U/L", "ref": "5000-12000" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "肾内科",
+      "items": [
+        { "name": "尿素氮 BUN", "value": "18.6", "unit": "mmol/L", "ref": "3.1-8.0" },
+        { "name": "肌酐 Cr（Scr）", "value": "286", "unit": "µmol/L", "ref": "44-133" },
+        { "name": "估算肾小球滤过率 eGFR", "value": "28", "unit": "mL/min/1.73m²", "ref": ">90" },
+        { "name": "尿酸 UA", "value": "526", "unit": "µmol/L", "ref": "208-428" },
+        { "name": "胱抑素C Cys-C", "value": "2.86", "unit": "mg/L", "ref": "0.51-1.09" },
+        { "name": "钾 K+", "value": "5.8", "unit": "mmol/L", "ref": "3.5-5.3" },
+        { "name": "钠 Na+", "value": "132", "unit": "mmol/L", "ref": "137-147" },
+        { "name": "氯 Cl-", "value": "108", "unit": "mmol/L", "ref": "99-110" },
+        { "name": "二氧化碳结合力 CO2-CP", "value": "18", "unit": "mmol/L", "ref": "22-29" },
+        { "name": "镁 Mg2+", "value": "0.68", "unit": "mmol/L", "ref": "0.75-1.02" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌科",
+      "items": [
+        { "name": "空腹血糖 GLU", "value": "9.8", "unit": "mmol/L", "ref": "3.9-6.1" },
+        { "name": "糖化血红蛋白 HbA1c", "value": "8.6", "unit": "%", "ref": "4.0-6.0" },
+        { "name": "糖化白蛋白 GA", "value": "22.6", "unit": "%", "ref": "11-16" },
+        { "name": "空腹C肽 C-P", "value": "0.68", "unit": "ng/mL", "ref": "1.1-4.4" },
+        { "name": "空腹胰岛素 INS", "value": "3.2", "unit": "µIU/mL", "ref": "2.6-24.9" },
+        { "name": "胰岛素抵抗指数 HOMA-IR", "value": "1.4", "unit": "", "ref": "<2.0" },
+        { "name": "谷氨酸脱羧酶抗体 GADA", "value": "阳性 (86)", "unit": "IU/mL", "ref": "<10" },
+        { "name": "胰岛细胞抗体 ICA", "value": "阳性", "unit": "", "ref": "阴性" },
+        { "name": "总胆固醇 TC", "value": "6.8", "unit": "mmol/L", "ref": "<5.2" },
+        { "name": "甘油三酯 TG", "value": "3.86", "unit": "mmol/L", "ref": "<1.7" },
+        { "name": "低密度脂蛋白胆固醇 LDL-C", "value": "4.62", "unit": "mmol/L", "ref": "<3.4" },
+        { "name": "高密度脂蛋白胆固醇 HDL-C", "value": "0.86", "unit": "mmol/L", "ref": ">1.0" },
+        { "name": "脂蛋白(a) Lp(a)", "value": "486", "unit": "mg/L", "ref": "<300" },
+        { "name": "载脂蛋白B ApoB", "value": "1.28", "unit": "g/L", "ref": "0.6-1.1" }
+      ]
+    },
+    {
+      "type": "lab",
+      "dept": "内分泌科",
+      "items": [
+        { "name": "游离三碘甲状腺原氨酸 FT3", "value": "2.86", "unit": "pmol/L", "ref": "3.1-6.8" },
+        { "name": "游离甲状腺素 FT4", "value": "8.6", "unit": "pmol/L", "ref": "12-22" },
+        { "name": "促甲状腺激素 TSH", "value": "18.6", "unit": "µIU/mL", "ref": "0.27-4.2" },
+        { "name": "总T3 (TT3)", "value": "0.86", "unit": "nmol/L", "ref": "1.3-3.1" },
+        { "name": "总甲状腺素 TT4", "value": "62", "unit": "nmol/L", "ref": "66-181" },
+        { "name": "甲状腺过氧化物酶抗体 TPOAb（TPO-Ab）", "value": "486", "unit": "IU/mL", "ref": "<34" },
+        { "name": "甲状腺球蛋白抗体 TgAb", "value": "286", "unit": "IU/mL", "ref": "<115" },
+        { "name": "促甲状腺激素受体抗体 TRAb", "value": "1.2", "unit": "IU/L", "ref": "<1.75" },
+        { "name": "甲状腺球蛋白 Tg", "value": "12.8", "unit": "ng/mL", "ref": "1.4-78" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "类风湿关节炎",
+      "drugs": [
+        { "name": "甲氨蝶呤片", "dose": "12.5mg", "freq": "每周一次" },
+        { "name": "来氟米特片", "dose": "20mg", "freq": "每日一次" },
+        { "name": "叶酸片", "dose": "10mg", "freq": "每周一次(MTX次日)" },
+        { "name": "醋酸泼尼松片", "dose": "10mg", "freq": "每日一次" },
+        { "name": "注射用重组人II型肿瘤坏死因子受体-抗体融合蛋白(依那西普)", "dose": "25mg", "freq": "皮下注射 每周两次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "社区获得性肺炎",
+      "drugs": [
+        { "name": "注射用头孢曲松钠", "dose": "2g", "freq": "静滴 每日一次" },
+        { "name": "阿奇霉素分散片", "dose": "0.5g", "freq": "每日一次" },
+        { "name": "盐酸莫西沙星氯化钠注射液", "dose": "0.4g", "freq": "静滴 每日一次" },
+        { "name": "盐酸氨溴索口服溶液", "dose": "10mL", "freq": "每日三次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "高血压病3级 冠心病",
+      "drugs": [
+        { "name": "富马酸比索洛尔片", "dose": "5mg", "freq": "每日一次" },
+        { "name": "苯磺酸氨氯地平片", "dose": "5mg", "freq": "每日一次" },
+        { "name": "缬沙坦氢氯噻嗪片", "dose": "1片", "freq": "每日一次 晨服" },
+        { "name": "单硝酸异山梨酯缓释片", "dose": "40mg", "freq": "每日一次" },
+        { "name": "阿托伐他汀钙片", "dose": "20mg", "freq": "每晚一次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "2型糖尿病",
+      "drugs": [
+        { "name": "盐酸二甲双胍缓释片", "dose": "0.5g", "freq": "每日两次 随餐" },
+        { "name": "达格列净片", "dose": "10mg", "freq": "每日一次" },
+        { "name": "司美格鲁肽注射液", "dose": "0.5mg", "freq": "皮下注射 每周一次" },
+        { "name": "甘精胰岛素注射液", "dose": "16U", "freq": "睡前皮下注射" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "系统性红斑狼疮",
+      "drugs": [
+        { "name": "硫酸羟氯喹片", "dose": "0.2g", "freq": "每日两次" },
+        { "name": "吗替麦考酚酯胶囊", "dose": "0.75g", "freq": "每日两次" },
+        { "name": "甲泼尼龙片", "dose": "16mg", "freq": "每日一次" },
+        { "name": "他克莫司胶囊", "dose": "1mg", "freq": "每12小时一次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "慢性阻塞性肺疾病",
+      "drugs": [
+        { "name": "噻托溴铵粉吸入剂", "dose": "18µg", "freq": "每日一次吸入" },
+        { "name": "布地奈德福莫特罗吸入粉雾剂", "dose": "1吸", "freq": "每日两次" },
+        { "name": "乙酰半胱氨酸泡腾片", "dose": "0.6g", "freq": "每日一次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "干眼症 结膜炎",
+      "drugs": [
+        { "name": "玻璃酸钠滴眼液", "dose": "1滴", "freq": "每日四次 双眼" },
+        { "name": "妥布霉素地塞米松滴眼液", "dose": "1滴", "freq": "每日三次" },
+        { "name": "环孢素滴眼液(II)", "dose": "1滴", "freq": "每日两次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "慢性胃炎 功能性消化不良",
+      "drugs": [
+        { "name": "雷贝拉唑钠肠溶片", "dose": "20mg", "freq": "每日一次 早餐前" },
+        { "name": "枸橼酸铋钾颗粒", "dose": "1袋", "freq": "每日两次" },
+        { "name": "复方消化酶胶囊", "dose": "2粒", "freq": "餐后服" },
+        { "name": "气滞胃痛颗粒", "dose": "1袋", "freq": "每日三次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "冠心病 非瓣膜性房颤",
+      "drugs": [
+        { "name": "利伐沙班片", "dose": "20mg", "freq": "每日一次 随餐" },
+        { "name": "硫酸氢氯吡格雷片", "dose": "75mg", "freq": "每日一次" },
+        { "name": "盐酸胺碘酮片", "dose": "0.2g", "freq": "每日一次" }
+      ]
+    },
+    {
+      "type": "rx",
+      "dx": "脑梗死恢复期",
+      "drugs": [
+        { "name": "阿司匹林肠溶片", "dose": "100mg", "freq": "每日一次" },
+        { "name": "银杏叶提取物片", "dose": "1片", "freq": "每日三次" },
+        { "name": "丁苯酞软胶囊", "dose": "0.2g", "freq": "每日三次 空腹" },
+        { "name": "甲钴胺片", "dose": "0.5mg", "freq": "每日三次" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Refs #125(术语归一覆盖率 → ≥98% 工作流的**第一步**)。

医生 summary 结构层的术语归一地基,**全确定性、无模型**。

## 改动
- **`normalize` 加确定性药名剥壳兜底**:真实处方「盐酸二甲双胍片」「阿托伐他汀钙片」,字典按通用名收录。候选式去盐前缀 + 剂型后缀 + 尾部成盐金属字,**只接受 Drug 类命中**,配不上的候选跳过(不破坏原词,`碳酸氢钠`≠`碳酸氢`)。+ 6 项断言测试。
- **`examples/coverage.rs`**:拿盲测报告跑 `normalize`,统计化验/药/单位命中率 + 未命中清单,作字典扩容回归工具。
- **`testdata/`**:两套 subagent **不看字典**盲生成的中文报告(常见盘 + 专科难集),诚实测覆盖率。
- **`docs/030_Clinical_Handoff.md`**:Clinical Handoff 设计文档(方向 + 数据契约草案;UI 版式待与国内标准对齐,保留中)。

## 盲测结论(191 条字典)
药 6%→**58%**(剥壳);专科难集化验 0%→**41%**(名字候选拆分,待落进提取层);剩余 miss = 真缺专科盘 → 字典扩容(#125)。

## 验证
`cargo fmt --check` 干净;`cargo test -p terminology` 16 passed。纯新增 + 兜底,不改 `normalize` 已有语义。

## 备注
这块按用户要求 spin-off,后续(化验名拆分落地 + 字典扩容到 98%)在 #125 另开 session 做。