### PR TITLE
fix(mobile): 清空数据安全 + 删除防复活 + 就诊组显示(code-review 4 处)

### DIFF
--- a/apps/mobile_flutter/lib/screens/archive_screen.dart
+++ b/apps/mobile_flutter/lib/screens/archive_screen.dart
@@ -105,7 +105,9 @@ String _groupDesc(TimelineGroupDto g) {
       for (final d in docs) {
         kinds.add(_docLabel[d.docType] ?? d.docType);
       }
-      final parts = ['${encounter.docCount} 份记录', ...kinds.take(3)];
+      // 用实际 docs.length —— 待确认剔除后 `_confirmedOnly` 会重建只含已确认文档的组,
+      // 此时 encounter.docCount(FFI 按全量算)会 stale,显示条数与展开数量对不上。
+      final parts = ['${docs.length} 份记录', ...kinds.take(3)];
       if (encounter.transferred) parts.add('转院');
       return parts.join(' · ');
     }(),
@@ -162,7 +164,7 @@ class ArchiveScreen extends StatefulWidget {
 
 class _ArchiveScreenState extends State<ArchiveScreen> {
   late Future<(PatientProfileDto, List<TimelineGroupDto>)> _future = _load();
-  // 就诊组在时间线里点开时展开其子文档(可再点开各自详情)。
+  // 已展开的就诊组(按 **encounter.id** 记,不用列表下标——删除/导入后下标会错位)。
   final Set<int> _expanded = {};
 
   @override
@@ -449,15 +451,22 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
                     if (i > 0) const SizedBox(height: 10),
                     _TimelineItem(
                       group: confirmed[i],
-                      expanded: _expanded.contains(i),
+                      // 按就诊组 id 记展开态(不用列表下标)——删除/导入后下标会错位到别的组。
+                      expanded: switch (confirmed[i]) {
+                        TimelineGroupDto_Encounter(:final encounter) =>
+                          _expanded.contains(encounter.id),
+                        _ => false,
+                      },
                       onTap: () {
-                        final g = confirmed[i];
-                        if (g is TimelineGroupDto_Document) {
-                          _openDoc(g.doc.id);
-                        } else {
-                          setState(() {
-                            if (!_expanded.add(i)) _expanded.remove(i);
-                          });
+                        switch (confirmed[i]) {
+                          case TimelineGroupDto_Document(:final doc):
+                            _openDoc(doc.id);
+                          case TimelineGroupDto_Encounter(:final encounter):
+                            setState(() {
+                              if (!_expanded.add(encounter.id)) {
+                                _expanded.remove(encounter.id);
+                              }
+                            });
                         }
                       },
                       onOpenSubDoc: _openDoc,

--- a/apps/mobile_flutter/lib/vault_boot.dart
+++ b/apps/mobile_flutter/lib/vault_boot.dart
@@ -33,25 +33,42 @@ Future<void> switchProfileAndReopen(String name) async {
   bumpVaultRevision();
 }
 
-/// 「清空所有数据」= 恢复出厂:清**所有**成员的 vault(不只当前 profile)+ 份数缓存
-/// + 待确认状态,重置成单一默认档案。做法:先把注册表恢复出厂(current 回默认 root)、
-/// 重开 root vault 并 `resetVault` 清它,再删掉所有子成员(`profiles/`)的数据目录。
+/// 「清空所有数据」= 恢复出厂:清**所有成员、所有位置**的 vault 数据(本机 + iCloud
+/// 容器)+ 份数缓存 + 待确认,重置成单一默认档案。
+///
+/// ⚠️ root 成员有**两处** vault:本机 `<docs>/vault` 与 iCloud `<container>/Documents/vault`
+/// (关 iCloud 时容器副本会被 `disable_icloud_sync` 保留)。`resetVault` 只干净清掉**当前
+/// 活跃**那处(正常关连接 + 删 db/wal + 重开空);另一处必须显式删,否则清空后容器里仍留
+/// 整份病历、再开 iCloud 会 adopt 回来(评审 Critical)。子成员整个 `profiles/` 删掉。
 Future<void> wipeAllData() async {
   final docsRoot = (await getApplicationDocumentsDirectory()).path;
   final containerRoot = await IcloudBridge.containerPath();
+
+  Future<void> rmDir(String path) async {
+    final d = Directory(path);
+    if (await d.exists()) await d.delete(recursive: true);
+  }
 
   // 1. 注册表恢复出厂(current→默认 root)+ 清待确认。
   await ProfileManager.instance.factoryReset();
   await ReviewState.instance.clearAll();
 
-  // 2. 重开默认(root)vault → 活跃 vault = root;3. 清它(删目录+重开空)。
+  // 2. 重开默认(root)vault → 活跃 = root;3. resetVault 干净清活跃那处(含 db/wal)+ 重开空。
   await openCurrentProfileVault();
   await resetVault();
 
-  // 4. 删掉所有子成员的数据目录(它们没被打开,直接删)。root 已由 resetVault 清掉。
+  // 4. 删 root 的**非活跃**那处 vault 副本(resetVault 没碰到的):iCloud 开时活跃=容器,
+  //    非活跃=本机;关时反之。icloudStatus().enabled 与 Rust 的路径决策同源(同一 marker)。
+  final icloudOn = (await icloudStatus()).enabled;
+  if (icloudOn) {
+    await rmDir('$docsRoot/vault');
+  } else if (containerRoot != null) {
+    await rmDir('$containerRoot/Documents/vault');
+  }
+
+  // 5. 删所有子成员数据(各自 vault + 派生库都在 profiles/ 内);本机 + iCloud 容器都删。
   for (final root in [docsRoot, if (containerRoot != null) '$containerRoot/Documents']) {
-    final profiles = Directory('$root/profiles');
-    if (await profiles.exists()) await profiles.delete(recursive: true);
+    await rmDir('$root/profiles');
   }
 
   bumpVaultRevision();

--- a/packages/core-model/src/materialize.rs
+++ b/packages/core-model/src/materialize.rs
@@ -84,6 +84,18 @@ impl Vault {
     pub fn materialize(&self) -> Result<(), MedmeError> {
         let map = self.applied_seq_map()?;
         let entries = self.log.read_all()?;
+        // 墓碑集:从**全部**事件(不只本次 pending)收集被删文档的锚点 hash。用它抑制
+        // 对应的 DocumentAdded/OcrAdded/ImagingInstanceAdded —— 这样即便删除事件因时钟偏移
+        // 排在 add 之前(多设备/NTP 回退),重放也不会把已删文档复活(评审 Important)。
+        let tombstones: HashSet<String> = entries
+            .iter()
+            .filter_map(|e| match &e.event {
+                Event::DocumentDeleted {
+                    source_file_hash, ..
+                } => Some(source_file_hash.clone()),
+                _ => None,
+            })
+            .collect();
         let pending: Vec<&LogEntry> = entries
             .iter()
             .filter(|e| e.seq > map.get(&e.device_id).copied().unwrap_or(0))
@@ -100,7 +112,7 @@ impl Vault {
             if stopped.contains(&entry.device_id) {
                 continue;
             }
-            match apply_event(&tx, self, &entry.event)? {
+            match apply_event(&tx, self, &entry.event, &tombstones)? {
                 ApplyOutcome::Applied => {
                     let cur = new_map.entry(entry.device_id.clone()).or_insert(0);
                     if entry.seq > *cur {
@@ -327,7 +339,12 @@ fn sanitize_mime_type(mime: &str) -> String {
     }
 }
 
-fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOutcome, MedmeError> {
+fn apply_event(
+    tx: &Transaction,
+    vault: &Vault,
+    event: &Event,
+    tombstones: &HashSet<String>,
+) -> Result<ApplyOutcome, MedmeError> {
     match event {
         Event::FileImported {
             content_hash,
@@ -378,6 +395,10 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             page_count,
             created_at,
         } => {
+            // 被墓碑标记的文档不投影(哪怕删除事件因时钟偏移排在本 add 之前)。
+            if tombstones.contains(source_file_hash) {
+                return Ok(ApplyOutcome::Applied);
+            }
             // A forged event — or a legitimately not-yet-synced FileImported — may
             // reference a source_file that isn't in the DB. Defer instead of letting
             // `QueryReturnedNoRows` abort the whole materialize / `Vault::open` (the
@@ -413,6 +434,10 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             confidence,
             created_at,
         } => {
+            // 文档被墓碑标记 → 跳过(不 defer,否则会永远等一个不会出现的文档、卡住该设备段)。
+            if tombstones.contains(&document_ref.source_file_hash) {
+                return Ok(ApplyOutcome::Applied);
+            }
             // Defer (not abort) when the referenced document isn't materialized yet —
             // a forged ref or a not-yet-synced DocumentAdded — mirroring the missing
             // source_file / missing CAS-blob handling.
@@ -515,6 +540,10 @@ fn apply_event(tx: &Transaction, vault: &Vault, event: &Event) -> Result<ApplyOu
             instance_number,
             created_at: _,
         } => {
+            // study 文档被墓碑标记 → 跳过(同 OcrAdded,别 defer 卡段)。
+            if tombstones.contains(&document_ref.source_file_hash) {
+                return Ok(ApplyOutcome::Applied);
+            }
             // Defer (not abort) when either referenced row isn't materialized yet —
             // a forged ImagingInstanceAdded ref or a not-yet-synced document /
             // source_file — mirroring the DocumentAdded / OcrAdded branches. A bare
@@ -1110,6 +1139,64 @@ mod tests {
 
         // Deleting a non-existent doc id is a harmless no-op.
         v.delete_document(9999).unwrap();
+    }
+
+    /// 墓碑防复活:即便 `DocumentDeleted` 因时钟偏移排在它的 `DocumentAdded` **之前**,
+    /// 重放也不能把文档复活(旧行为:delete 先 no-op、add 再重建 → 复活)。
+    #[test]
+    fn tombstone_suppresses_add_even_when_delete_sorts_first() {
+        use crate::event::{Event, LogEntry};
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let dev = v.device_id.clone();
+        let sfh = cas::sha256_hex(b"anchor-del-reorder");
+        let append = |seq: i64, ts: &str, ev: Event| {
+            v.log
+                .append(&LogEntry::new(seq, ts.into(), dev.clone(), ev).unwrap())
+                .unwrap();
+        };
+        append(
+            1,
+            "2024-01-01T00:00:10Z",
+            Event::FileImported {
+                content_hash: sfh.clone(),
+                original_name: "a.txt".into(),
+                mime_type: "text/plain".into(),
+                byte_size: 6,
+                imported_at: "2024-01-01T00:00:10Z".into(),
+            },
+        );
+        // DELETE 的 ts(:11)早于 ADD 的 ts(:12)→ 全局排序里 delete 在 add 前。
+        append(
+            2,
+            "2024-01-01T00:00:11Z",
+            Event::DocumentDeleted {
+                source_file_hash: sfh.clone(),
+                deleted_at: "2024-01-01T00:00:11Z".into(),
+            },
+        );
+        append(
+            3,
+            "2024-01-01T00:00:12Z",
+            Event::DocumentAdded {
+                source_file_hash: sfh.clone(),
+                doc_type: "lab_report".into(),
+                doc_date: None,
+                doc_date_end: None,
+                title: Some("t".into()),
+                language: None,
+                page_count: 1,
+                created_at: "2024-01-01T00:00:12Z".into(),
+            },
+        );
+
+        v.rebuild_from_log().unwrap();
+        assert_eq!(
+            v.debug_count("document"),
+            0,
+            "被墓碑标记的文档不能因 add 排在 delete 后而复活"
+        );
+        assert_eq!(v.debug_count("source_file"), 1, "原始 source_file 保留");
     }
 
     // ---- hardening: forged / dangling references + malformed hashes ---------


### PR DESCRIPTION
code-reviewer 对近期新代码(多档案 / 删除事件溯源 / 确认流 / 清空)评审后的修复。

## 🔴 Critical — `wipeAllData` 漏删 root 的 iCloud 容器副本(数据清不干净 + 会复活)
root 成员有**两处** vault:本机 `<docs>/vault` 与 iCloud `<container>/Documents/vault`(关 iCloud 时容器副本被保留)。原 `wipeAllData` 只用 `resetVault` 清活跃那处 + 删 `profiles/`,**漏了 root 的非活跃副本**。场景:开→关 iCloud → 清空 → 容器里整份病历还在 → 再开 iCloud 被 adopt 回来。
修:`resetVault` 干净清活跃 root(连接正常关 + db/wal 删)后,按 `icloudStatus().enabled` 显式删非活跃那处 + 所有子成员 `profiles/`(本机 + 容器)。

## 🟠 删除墓碑防复活(事件溯源正确性)
重放按墙钟 `ts` 排序;多设备时钟偏移 / NTP 回退时 `DocumentDeleted` 可能排在其 `DocumentAdded` **之前** → 旧行为:delete 先 no-op、add 再重建 = **复活**。项目对 `OcrAdded` 已有防时钟回退,删除路径原本不一致。
修:`materialize` 重放前从**全部**事件收集墓碑 hash,抑制对应 `DocumentAdded`/`OcrAdded`/`ImagingInstanceAdded`(跳过、不 defer)。+ 乱序回归测试。

## 🟠 就诊组显示条数错
部分文档待确认时 `_confirmedOnly` 重建组复用 FFI 按全量算的 `encounter.docCount` → 显示「3 份记录」但展开只 2 份。改用 `docs.length`。

## 🟢 展开态错位
`_expanded` 按列表下标存,删除/导入后下标错位到别的组。改按 `encounter.id`。

## 验证
`cargo test -p core-model` 78 passed(含新墓碑乱序测试);`flutter analyze` 干净。⚠️ wipeAllData 的 iCloud 路径未真机验(逻辑按 icloudStatus 分支),建议真机测一次「开 iCloud→关→清空→重开 iCloud」确认不复活。