### PR TITLE
feat(parser): 用药/诊断提取 + 跨文档聚合(阶段 B ②③,#37)

### DIFF
--- a/packages/parser/src/aggregate.rs
+++ b/packages/parser/src/aggregate.rs
@@ -1,0 +1,533 @@
+//! Cross-document clinical aggregation (stage B, slice ③).
+//!
+//! Folds the per-document extractions ([`extract_labs`], [`extract_meds`],
+//! [`extract_conditions`]) across MANY source documents into a small "derived
+//! layer": analyte trends, medication spans, and a deduped condition list. This
+//! is the structure a doctor-summary is later assembled from (slice ④, not this
+//! module). Pure in-memory folding: no network, no LLM, no re-parsing of text
+//! beyond calling the sibling extractors.
+//!
+//! ## What this layer does NOT do (kept lean, honest)
+//! - **Dates are supplied by the caller**, one per document (e.g. from
+//!   [`crate::guess_date`]). We never re-derive a document's clinical date here,
+//!   and we never attribute a date to an individual row inside a document — every
+//!   row inherits its document's date.
+//! - **Medication start/stop/restart is NOT inferred.** `status` is always
+//!   `"active"`; there is not enough signal in free-text mentions to detect
+//!   discontinuation without inventing it. The proper start/stop/restart fold
+//!   (docs/030 §4) is deferred to when the event log carries explicit stop
+//!   actions — only then can "stopped" be asserted rather than guessed.
+//! - **No cross-synonym merging of conditions.** The dictionary has no condition
+//!   category, so conditions are deduped by exact (trimmed) raw text only; two
+//!   spellings of the same disease stay separate rather than be laundered.
+//! - Unmatched analytes/drugs are kept separate from matched ones (grouped by
+//!   raw name) and never merged into a coded series — honest about what resolved.
+
+use crate::{extract_conditions, extract_labs, extract_meds, MedObservation};
+use chrono::NaiveDate;
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+
+/// One source document to aggregate over. `date` is the document's clinical date
+/// (caller supplies it, e.g. from [`crate::guess_date`]); `None` if unknown.
+pub struct SourceDoc<'a> {
+    /// Stable index back into the caller's record list (kept for evidence).
+    pub index: usize,
+    pub date: Option<NaiveDate>,
+    pub text: &'a str,
+}
+
+/// One measured value of an analyte, tagged with the document it came from.
+#[derive(Debug, Clone)]
+pub struct LabPoint {
+    pub date: Option<NaiveDate>,
+    /// `value_canonical` if the observation had one, else `value_num`.
+    pub value: f64,
+    /// `unit_canonical` if present, else `unit_raw`.
+    pub unit: Option<String>,
+    pub flag: Option<String>,
+    /// The [`SourceDoc::index`] this point came from.
+    pub source: usize,
+}
+
+/// A single analyte's trend across all documents.
+#[derive(Debug, Clone)]
+pub struct AnalyteSeries {
+    /// `Some` for a resolved analyte; `None` when grouped by raw name (unmatched
+    /// analytes are kept separate, never merged with matched ones).
+    pub analyte_key: Option<String>,
+    /// Display/grouping label: canonical name if resolved, else the raw name.
+    pub group_name: String,
+    pub loinc: Option<String>,
+    /// Chronological; `None`-dated points sort last, preserving input order.
+    pub points: Vec<LabPoint>,
+    /// True if any point is flagged "H" or "L".
+    pub any_abnormal: bool,
+}
+
+/// A medication's span across all documents that mention it.
+#[derive(Debug, Clone)]
+pub struct MedSpan {
+    /// `Some` for a resolved drug; `None` when grouped by raw name.
+    pub drug_key: Option<String>,
+    /// Canonical name if resolved, else the raw name.
+    pub name: String,
+    pub atc: Option<String>,
+    /// e.g. "0.5g bid", taken from the most recent mention (fallback: any).
+    pub latest_dose: Option<String>,
+    /// Earliest dated mention (`None` if no mention carried a date).
+    pub start: Option<NaiveDate>,
+    /// Latest dated mention.
+    pub end: Option<NaiveDate>,
+    /// Always "active" — see the module header: discontinuation is not inferred.
+    pub status: String,
+    /// All [`SourceDoc::index`] that mention it, deduped, ascending.
+    pub sources: Vec<usize>,
+}
+
+/// A deduped condition mention across documents.
+#[derive(Debug, Clone)]
+pub struct AggregatedCondition {
+    pub raw_text: String,
+    /// Earliest dated mention (`None` if no mention carried a date).
+    pub onset: Option<NaiveDate>,
+    /// All [`SourceDoc::index`] that mention it, deduped, ascending.
+    pub sources: Vec<usize>,
+}
+
+/// The derived clinical layer: analyte trends, med spans, and conditions.
+#[derive(Debug, Clone)]
+pub struct AggregatedClinical {
+    pub labs: Vec<AnalyteSeries>,
+    pub meds: Vec<MedSpan>,
+    pub conditions: Vec<AggregatedCondition>,
+}
+
+/// Grouping key. `Matched`/`Raw` live in separate namespaces so a resolved item
+/// never merges with an unmatched one that happens to share a display string.
+#[derive(PartialEq, Eq, Hash, Clone)]
+enum GroupKey {
+    Matched(String),
+    Raw(String),
+}
+
+/// Order two optional dates with `None` sorting *after* any `Some` (unknown
+/// dates last). Used for both point ordering and output ordering.
+fn cmp_date_none_last(a: &Option<NaiveDate>, b: &Option<NaiveDate>) -> Ordering {
+    match (a, b) {
+        (Some(x), Some(y)) => x.cmp(y),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn min_date(cur: Option<NaiveDate>, new: Option<NaiveDate>) -> Option<NaiveDate> {
+    match (cur, new) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, b) => b,
+    }
+}
+
+fn max_date(cur: Option<NaiveDate>, new: Option<NaiveDate>) -> Option<NaiveDate> {
+    match (cur, new) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, b) => b,
+    }
+}
+
+/// Render a mention's dose + frequency, e.g. "0.5g bid". `None` if the mention
+/// carries neither a dose nor a frequency.
+fn dose_string(m: &MedObservation) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    match (m.dose_num, &m.dose_unit) {
+        (Some(n), Some(u)) => parts.push(format!("{n}{u}")),
+        (Some(n), None) => parts.push(format!("{n}")),
+        _ => {}
+    }
+    if let Some(f) = &m.frequency {
+        parts.push(f.clone());
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+struct LabBuilder {
+    analyte_key: Option<String>,
+    group_name: String,
+    loinc: Option<String>,
+    /// Whether `group_name`/`loinc` were taken from a matched observation yet.
+    meta_from_match: bool,
+    points: Vec<LabPoint>,
+    any_abnormal: bool,
+}
+
+struct MedBuilder {
+    drug_key: Option<String>,
+    name: String,
+    atc: Option<String>,
+    meta_from_match: bool,
+    start: Option<NaiveDate>,
+    end: Option<NaiveDate>,
+    sources: BTreeSet<usize>,
+    /// Dose/date of the mention currently winning "most recent".
+    best_dose: Option<String>,
+    best_date: Option<NaiveDate>,
+    has_best: bool,
+}
+
+struct CondBuilder {
+    raw_text: String,
+    onset: Option<NaiveDate>,
+    sources: BTreeSet<usize>,
+}
+
+/// Aggregate per-document extractions across `docs` into the derived layer.
+pub fn aggregate(docs: &[SourceDoc<'_>]) -> AggregatedClinical {
+    let mut labs: HashMap<GroupKey, LabBuilder> = HashMap::new();
+    let mut meds: HashMap<GroupKey, MedBuilder> = HashMap::new();
+    let mut conds: HashMap<String, CondBuilder> = HashMap::new();
+
+    for doc in docs {
+        // --- labs ---
+        for obs in extract_labs(doc.text) {
+            let matched = obs.analyte_key.is_some();
+            let key = match &obs.analyte_key {
+                Some(k) => GroupKey::Matched(k.clone()),
+                None => GroupKey::Raw(obs.raw_name.clone()),
+            };
+            let point = LabPoint {
+                date: doc.date,
+                value: obs.value_canonical.unwrap_or(obs.value_num),
+                unit: obs.unit_canonical.clone().or_else(|| obs.unit_raw.clone()),
+                flag: obs.flag.clone(),
+                source: doc.index,
+            };
+            let abnormal = matches!(obs.flag.as_deref(), Some("H") | Some("L"));
+            let b = labs.entry(key).or_insert_with(|| LabBuilder {
+                analyte_key: obs.analyte_key.clone(),
+                group_name: obs.raw_name.clone(),
+                loinc: None,
+                meta_from_match: false,
+                points: Vec::new(),
+                any_abnormal: false,
+            });
+            // First matched observation supplies the display name + LOINC.
+            if !b.meta_from_match && matched {
+                if let Some(name) = &obs.canonical_name {
+                    b.group_name = name.clone();
+                }
+                b.loinc = obs.loinc.clone();
+                b.meta_from_match = true;
+            }
+            b.any_abnormal |= abnormal;
+            b.points.push(point);
+        }
+
+        // --- meds ---
+        for obs in extract_meds(doc.text) {
+            let matched = obs.drug_key.is_some();
+            let key = match &obs.drug_key {
+                Some(k) => GroupKey::Matched(k.clone()),
+                None => GroupKey::Raw(obs.raw_name.clone()),
+            };
+            let this_dose = dose_string(&obs);
+            let b = meds.entry(key).or_insert_with(|| MedBuilder {
+                drug_key: obs.drug_key.clone(),
+                name: obs.raw_name.clone(),
+                atc: None,
+                meta_from_match: false,
+                start: None,
+                end: None,
+                sources: BTreeSet::new(),
+                best_dose: None,
+                best_date: None,
+                has_best: false,
+            });
+            if !b.meta_from_match && matched {
+                if let Some(name) = &obs.canonical_name {
+                    b.name = name.clone();
+                }
+                b.atc = obs.atc.clone();
+                b.meta_from_match = true;
+            }
+            b.start = min_date(b.start, doc.date);
+            b.end = max_date(b.end, doc.date);
+            b.sources.insert(doc.index);
+            // Keep the dose of the most-recently-dated mention; ties/undated keep
+            // the first seen (stable). Fallback: any mention (the first one).
+            let replace = if !b.has_best {
+                true
+            } else {
+                match (doc.date, b.best_date) {
+                    (Some(m), Some(cur)) => m > cur,
+                    (Some(_), None) => true,
+                    (None, _) => false,
+                }
+            };
+            if replace {
+                b.best_date = doc.date;
+                b.best_dose = this_dose;
+                b.has_best = true;
+            }
+        }
+
+        // --- conditions ---
+        for c in extract_conditions(doc.text) {
+            let raw = c.raw_text.trim().to_string();
+            if raw.is_empty() {
+                continue;
+            }
+            let b = conds.entry(raw.clone()).or_insert_with(|| CondBuilder {
+                raw_text: raw,
+                onset: None,
+                sources: BTreeSet::new(),
+            });
+            b.onset = min_date(b.onset, doc.date);
+            b.sources.insert(doc.index);
+        }
+    }
+
+    // --- finalize labs: chronological points, deterministic series order ---
+    let mut lab_out: Vec<AnalyteSeries> = labs
+        .into_values()
+        .map(|mut b| {
+            b.points
+                .sort_by(|x, y| cmp_date_none_last(&x.date, &y.date));
+            AnalyteSeries {
+                analyte_key: b.analyte_key,
+                group_name: b.group_name,
+                loinc: b.loinc,
+                points: b.points,
+                any_abnormal: b.any_abnormal,
+            }
+        })
+        .collect();
+    // (group_name, analyte_key) fully determinizes order despite HashMap.
+    lab_out.sort_by(|a, b| {
+        a.group_name
+            .cmp(&b.group_name)
+            .then_with(|| a.analyte_key.cmp(&b.analyte_key))
+    });
+
+    let mut med_out: Vec<MedSpan> = meds
+        .into_values()
+        .map(|b| MedSpan {
+            drug_key: b.drug_key,
+            name: b.name,
+            atc: b.atc,
+            latest_dose: b.best_dose,
+            start: b.start,
+            end: b.end,
+            status: "active".to_string(),
+            sources: b.sources.into_iter().collect(),
+        })
+        .collect();
+    med_out.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.drug_key.cmp(&b.drug_key))
+    });
+
+    let mut cond_out: Vec<AggregatedCondition> = conds
+        .into_values()
+        .map(|b| AggregatedCondition {
+            raw_text: b.raw_text,
+            onset: b.onset,
+            sources: b.sources.into_iter().collect(),
+        })
+        .collect();
+    cond_out.sort_by(|a, b| {
+        cmp_date_none_last(&a.onset, &b.onset).then_with(|| a.raw_text.cmp(&b.raw_text))
+    });
+
+    AggregatedClinical {
+        labs: lab_out,
+        meds: med_out,
+        conditions: cond_out,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> Option<NaiveDate> {
+        NaiveDate::from_ymd_opt(y, m, day)
+    }
+
+    #[test]
+    fn same_analyte_across_docs_forms_one_sorted_series() {
+        // 肌酐 (creatinine) in three docs, dates out of order; one abnormal (H).
+        let docs = vec![
+            SourceDoc {
+                index: 0,
+                date: d(2023, 6, 1),
+                text: "肌酐 96 μmol/L 59-104",
+            },
+            SourceDoc {
+                index: 1,
+                date: d(2022, 1, 1),
+                text: "肌酐 88 μmol/L 59-104",
+            },
+            SourceDoc {
+                index: 2,
+                date: d(2023, 1, 1),
+                text: "肌酐 120 μmol/L 59-104", // > 104 -> H
+            },
+        ];
+        let agg = aggregate(&docs);
+        assert_eq!(agg.labs.len(), 1);
+        let s = &agg.labs[0];
+        assert_eq!(s.analyte_key.as_deref(), Some("creatinine"));
+        assert!(s.loinc.is_some());
+        assert_eq!(s.points.len(), 3);
+        // Sorted ascending by date.
+        assert_eq!(s.points[0].date, d(2022, 1, 1));
+        assert_eq!(s.points[1].date, d(2023, 1, 1));
+        assert_eq!(s.points[2].date, d(2023, 6, 1));
+        assert_eq!(s.points[0].source, 1);
+        assert!(s.any_abnormal, "the 120 point is flagged H");
+    }
+
+    #[test]
+    fn matched_and_unmatched_analytes_do_not_merge() {
+        let docs = vec![
+            SourceDoc {
+                index: 0,
+                date: d(2024, 1, 1),
+                text: "肌酐 88 μmol/L 59-104",
+            },
+            SourceDoc {
+                index: 1,
+                date: d(2024, 2, 1),
+                text: "神秘指标XYZ 12.3 mg/L 0-5",
+            },
+        ];
+        let agg = aggregate(&docs);
+        assert_eq!(agg.labs.len(), 2);
+        let matched = agg
+            .labs
+            .iter()
+            .find(|s| s.analyte_key.is_some())
+            .expect("matched series");
+        assert_eq!(matched.analyte_key.as_deref(), Some("creatinine"));
+        let unmatched = agg
+            .labs
+            .iter()
+            .find(|s| s.analyte_key.is_none())
+            .expect("unmatched series");
+        assert_eq!(unmatched.group_name, "神秘指标XYZ");
+        assert!(unmatched.loinc.is_none());
+        assert_eq!(unmatched.points.len(), 1);
+    }
+
+    #[test]
+    fn same_drug_across_docs_forms_one_span() {
+        let docs = vec![
+            SourceDoc {
+                index: 3,
+                date: d(2023, 1, 1),
+                text: "二甲双胍 0.5g bid",
+            },
+            SourceDoc {
+                index: 7,
+                date: d(2024, 3, 1),
+                text: "二甲双胍 0.85g tid",
+            },
+        ];
+        let agg = aggregate(&docs);
+        assert_eq!(agg.meds.len(), 1);
+        let m = &agg.meds[0];
+        assert_eq!(m.drug_key.as_deref(), Some("metformin"));
+        assert_eq!(m.start, d(2023, 1, 1));
+        assert_eq!(m.end, d(2024, 3, 1));
+        assert_eq!(m.sources, vec![3, 7]);
+        assert_eq!(m.status, "active");
+        // Dose from the later mention.
+        assert_eq!(m.latest_dose.as_deref(), Some("0.85g tid"));
+    }
+
+    #[test]
+    fn conditions_dedup_with_earliest_onset_and_merged_sources() {
+        let docs = vec![
+            SourceDoc {
+                index: 0,
+                date: d(2024, 5, 1),
+                text: "出院诊断:2型糖尿病",
+            },
+            SourceDoc {
+                index: 1,
+                date: d(2023, 2, 1),
+                text: "入院诊断:2型糖尿病",
+            },
+        ];
+        let agg = aggregate(&docs);
+        assert_eq!(agg.conditions.len(), 1);
+        let c = &agg.conditions[0];
+        assert_eq!(c.raw_text, "2型糖尿病");
+        assert_eq!(c.onset, d(2023, 2, 1)); // earliest
+        assert_eq!(c.sources, vec![0, 1]);
+    }
+
+    #[test]
+    fn none_dated_lab_point_sorts_last_but_is_kept() {
+        let docs = vec![
+            SourceDoc {
+                index: 0,
+                date: None,
+                text: "肌酐 88 μmol/L 59-104",
+            },
+            SourceDoc {
+                index: 1,
+                date: d(2024, 1, 1),
+                text: "肌酐 90 μmol/L 59-104",
+            },
+        ];
+        let agg = aggregate(&docs);
+        assert_eq!(agg.labs.len(), 1);
+        let s = &agg.labs[0];
+        assert_eq!(s.points.len(), 2);
+        assert_eq!(s.points[0].date, d(2024, 1, 1));
+        assert_eq!(s.points[1].date, None); // undated point last, retained
+        assert_eq!(s.points[1].source, 0);
+    }
+
+    #[test]
+    fn output_vectors_are_in_deterministic_order() {
+        // Labs ordered by group_name, meds by name, conditions by onset then text.
+        let docs = vec![SourceDoc {
+            index: 0,
+            date: d(2024, 1, 1),
+            text: "\
+肌酐 88 μmol/L 59-104
+血红蛋白 140 g/L 130-175
+二甲双胍 0.5g bid
+阿托伐他汀钙片 20mg qn
+出院诊断:高血压病；2型糖尿病
+",
+        }];
+        let agg = aggregate(&docs);
+
+        let lab_names: Vec<&str> = agg.labs.iter().map(|s| s.group_name.as_str()).collect();
+        let mut sorted_labs = lab_names.clone();
+        sorted_labs.sort();
+        assert_eq!(lab_names, sorted_labs, "labs must be sorted by group_name");
+
+        let med_names: Vec<&str> = agg.meds.iter().map(|m| m.name.as_str()).collect();
+        let mut sorted_meds = med_names.clone();
+        sorted_meds.sort();
+        assert_eq!(med_names, sorted_meds, "meds must be sorted by name");
+
+        // Both conditions share the doc's onset, so they order by raw_text.
+        let cond_texts: Vec<&str> = agg.conditions.iter().map(|c| c.raw_text.as_str()).collect();
+        let mut sorted_conds = cond_texts.clone();
+        sorted_conds.sort();
+        assert_eq!(cond_texts, sorted_conds, "conditions must be sorted");
+    }
+}

--- a/packages/parser/src/conditions.rs
+++ b/packages/parser/src/conditions.rs
@@ -1,0 +1,205 @@
+//! Deterministic diagnosis extraction (stage B).
+//!
+//! Pulls diagnosis terms out of labeled sections of a clinical note and keeps
+//! them as honest raw strings. Pure string work: no network, no LLM. There is
+//! **no** condition/diagnosis category in the terminology dictionary, so — unlike
+//! labs and meds — nothing here is normalized to a code (ICD or otherwise). Any
+//! ICD code that happens to be printed alongside a term is *dropped*, not
+//! trusted: we don't verify it and won't launder it into structured data.
+//!
+//! ## Row shapes handled
+//! Section label (optionally after a list number) + `:`/`：`, then either:
+//! ```text
+//! 出院诊断:2型糖尿病；高血压病3级          <- inline, split on ；;，,、 and numbers
+//! 出院诊断:                                <- label then a numbered block:
+//!   1. 2型糖尿病(E11.9)                    <- numbering stripped, ICD code dropped
+//!   2. 高血压病3级
+//! ```
+//! Recognized labels: 诊断 初步诊断 入院诊断 出院诊断 主要诊断 其他诊断 病理诊断 临床诊断.
+//! A numbered block is consumed until a blank line or a non-numbered line.
+//!
+//! ## Deliberately NOT handled (kept lean)
+//! - Diagnoses in free prose with no section label.
+//! - Negation / history qualifiers (`否认…`, `既往…`) — the term is kept verbatim.
+//! - Splitting one term into disease + stage/laterality (`高血压病3级` stays whole).
+//! - Any normalization / de-duplication across synonyms — only exact
+//!   (raw_text, section) duplicates are collapsed.
+
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+/// One diagnosis term as written, tagged with the section label it came under.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConditionMention {
+    pub raw_text: String,
+    pub section: Option<String>,
+}
+
+/// A diagnosis-section label line: optional list marker, a known label, a colon,
+/// then the (possibly empty) inline remainder. Longer labels precede `诊断` so a
+/// specific section name wins over the generic one.
+fn section_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(出院诊断|入院诊断|初步诊断|主要诊断|其他诊断|病理诊断|临床诊断|诊断)\s*[:：]\s*(.*)$",
+        )
+        .expect("section re")
+    })
+}
+
+/// A numbered list item: `1. xxx` / `2、xxx` / `①xxx`. Captures the content after
+/// the marker. A delimiter after the digits is required, so a bare `2型糖尿病`
+/// (no delimiter) is NOT mistaken for a numbered item.
+fn numbered_item_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}])\s*(.+)$").expect("numbered item re")
+    })
+}
+
+/// Trailing ICD-style code in (), （）, [], 【】: `(E11.9)`, `[I10]`. Inner content
+/// must start with a letter+digit — the ICD-10 shape — so a genuine parenthetical
+/// like `高血压(3级)` is left intact.
+fn icd_paren_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"\s*[(（\[【]\s*[A-Za-z]\d[0-9A-Za-z.\-]*\s*[)）\]】]\s*$").expect("icd re")
+    })
+}
+
+/// Split an inline diagnosis string on separators, clean each part, keep order.
+fn split_inline(s: &str) -> Vec<String> {
+    s.split(['；', ';', '，', ',', '、'])
+        .filter_map(clean_dx)
+        .collect()
+}
+
+/// Normalize one diagnosis term: strip any leading list numbering, drop a
+/// trailing ICD code, trim punctuation/space. Returns `None` for empties.
+fn clean_dx(raw: &str) -> Option<String> {
+    let mut s = numbered_item_re()
+        .captures(raw)
+        .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+        .unwrap_or_else(|| raw.to_string());
+    s = icd_paren_re().replace(&s, "").to_string();
+    let s = s
+        .trim()
+        .trim_matches(|c: char| {
+            c.is_whitespace()
+                || matches!(c, '.' | '。' | '、' | '，' | ',' | ';' | '；' | ':' | '：')
+        })
+        .to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Extract diagnosis mentions from labeled sections. De-dups identical
+/// (raw_text, section) pairs; keeps raw strings (no terminology normalization).
+pub fn extract_conditions(text: &str) -> Vec<ConditionMention> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let Some(caps) = section_re().captures(lines[i]) else {
+            i += 1;
+            continue;
+        };
+        let section = caps.get(1).expect("label group").as_str().to_string();
+        let inline = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+
+        let mut push = |dx: String, out: &mut Vec<ConditionMention>| {
+            if seen.insert((dx.clone(), section.clone())) {
+                out.push(ConditionMention {
+                    raw_text: dx,
+                    section: Some(section.clone()),
+                });
+            }
+        };
+
+        // Inline diagnoses after the label.
+        for dx in split_inline(inline) {
+            push(dx, &mut out);
+        }
+
+        // A following numbered block belongs to this section; stop at a blank or
+        // non-numbered line.
+        let mut j = i + 1;
+        while j < lines.len() {
+            if lines[j].trim().is_empty() || !numbered_item_re().is_match(lines[j]) {
+                break;
+            }
+            if let Some(dx) = clean_dx(lines[j]) {
+                push(dx, &mut out);
+            }
+            j += 1;
+        }
+        i = j.max(i + 1);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_split_and_section_captured() {
+        let obs = extract_conditions("出院诊断:2型糖尿病；高血压病3级");
+        assert_eq!(obs.len(), 2);
+        assert_eq!(obs[0].raw_text, "2型糖尿病");
+        assert_eq!(obs[0].section.as_deref(), Some("出院诊断"));
+        assert_eq!(obs[1].raw_text, "高血压病3级");
+        assert_eq!(obs[1].section.as_deref(), Some("出院诊断"));
+    }
+
+    #[test]
+    fn numbered_block_and_icd_code_stripped() {
+        let text = "\
+出院诊断:
+1. 2型糖尿病(E11.9)
+2. 高血压病3级
+
+医师签名:王五
+";
+        let obs = extract_conditions(text);
+        assert_eq!(obs.len(), 2);
+        // ICD code dropped, disease-leading digit (2型) preserved.
+        assert_eq!(obs[0].raw_text, "2型糖尿病");
+        assert_eq!(obs[0].section.as_deref(), Some("出院诊断"));
+        assert_eq!(obs[1].raw_text, "高血压病3级");
+    }
+
+    #[test]
+    fn label_variants_and_dedup() {
+        // A different label is captured; duplicates within a section collapse.
+        let text = "\
+初步诊断：冠心病、冠心病
+其他诊断:高尿酸血症
+";
+        let obs = extract_conditions(text);
+        assert_eq!(obs.len(), 2);
+        assert_eq!(obs[0].raw_text, "冠心病");
+        assert_eq!(obs[0].section.as_deref(), Some("初步诊断"));
+        assert_eq!(obs[1].raw_text, "高尿酸血症");
+        assert_eq!(obs[1].section.as_deref(), Some("其他诊断"));
+    }
+
+    #[test]
+    fn bracket_icd_and_non_diagnosis_lines_ignored() {
+        let text = "\
+主诉:多饮多尿1年
+临床诊断:2型糖尿病[E11.9]
+血压:130/80
+";
+        let obs = extract_conditions(text);
+        assert_eq!(obs.len(), 1);
+        assert_eq!(obs[0].raw_text, "2型糖尿病");
+        assert_eq!(obs[0].section.as_deref(), Some("临床诊断"));
+    }
+}

--- a/packages/parser/src/lib.rs
+++ b/packages/parser/src/lib.rs
@@ -4,8 +4,16 @@ use regex::Regex;
 use std::path::Path;
 use std::sync::OnceLock;
 
+mod aggregate;
+mod conditions;
 mod labs;
+mod meds;
+pub use aggregate::{
+    aggregate, AggregatedClinical, AggregatedCondition, AnalyteSeries, LabPoint, MedSpan, SourceDoc,
+};
+pub use conditions::{extract_conditions, ConditionMention};
 pub use labs::{extract_labs, LabObservation};
+pub use meds::{extract_meds, MedObservation};
 
 pub struct Extracted {
     pub text: String,

--- a/packages/parser/src/meds.rs
+++ b/packages/parser/src/meds.rs
@@ -1,0 +1,313 @@
+//! Deterministic medication extraction (stage B).
+//!
+//! Turns a prescription / medication line into a structured [`MedObservation`]:
+//! drug name (normalized via `terminology::resolve_drug`), dose (number + unit)
+//! and a normalized frequency code. Pure string work: no network, no LLM. Coding
+//! is delegated to the `terminology` crate — this module only locates the parts
+//! of a line and asks terminology what the drug is. Unmatched-but-clearly-a-med
+//! lines are kept (drug_key = None, confidence 0.0); we never invent codes.
+//!
+//! ## Row shapes handled
+//! One medication per line, name-first, with dose / frequency / route trailing:
+//! ```text
+//! 二甲双胍 0.5g bid
+//! 阿托伐他汀钙片 20mg 每晚一次
+//! 1. 盐酸二甲双胍片 0.5g 每日两次口服
+//! 氨氯地平  5mg  qd  po
+//! 胰岛素 12U 三餐前
+//! ```
+//! - Leading list markers (`1.` `1、` `①` `-` `•`) are stripped.
+//! - Dose is the first `number+unit` token; units: g, mg, μg/ug/mcg, IU/U,
+//!   mL/ml, 片/粒/袋/支/丸/滴/单位. Glued (`20mg`) or spaced (`20 mg`).
+//! - Frequency maps English abbrevs AND Chinese to one code (qd/bid/tid/qid/qn/
+//!   q8h/q12h/prn/qw/"tid ac"); the original substring is kept in `frequency_raw`.
+//! - Trailing route words (口服/po/静滴/iv/皮下/sc …) are stripped off the name.
+//!
+//! ## Deliberately NOT handled (kept lean)
+//! - Multiple drugs on one line — one line, one drug.
+//! - Compound / tapering schedules (`早1片晚2片`, `逐渐减量`), ranges (`1-2片`).
+//! - Duration / total-quantity / dispense counts (`共14天`, `×7`, `14盒`).
+//! - Dose written without a recognized unit, or glued to the name with no
+//!   separator; a name with neither a dose, a frequency, nor a drug match is not
+//!   treated as a medication line (skipped, not invented).
+
+use regex::Regex;
+use std::sync::OnceLock;
+use terminology::resolve_drug;
+
+/// One parsed medication line. Mapping is additive: the raw drug name is always
+/// kept even when terminology can't resolve it (upper layer decides trust).
+#[derive(Debug, Clone)]
+pub struct MedObservation {
+    pub raw_name: String,
+    pub drug_key: Option<String>,
+    pub canonical_name: Option<String>,
+    pub ingredient: Option<String>,
+    pub rxnorm: Option<String>,
+    pub atc: Option<String>,
+    pub dose_num: Option<f64>,
+    pub dose_unit: Option<String>,
+    /// Normalized code: "qd"|"bid"|"tid"|"qid"|"qn"|"q8h"|"q12h"|"prn"|"qw"|"tid ac".
+    pub frequency: Option<String>,
+    /// The original frequency substring as written (e.g. "每日两次").
+    pub frequency_raw: Option<String>,
+    /// 0.0 if unmatched; else the terminology `Match.confidence`.
+    pub confidence: f32,
+}
+
+/// Leading list marker: `1.` `1、` `1)` `①`..`⑩` `-` `•` `*` `·`.
+fn list_marker_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])\s*").expect("list marker re")
+    })
+}
+
+/// First `number+unit` dose token. Multi-char units precede single-char ones so
+/// `20mg` matches `mg` (not `g`) and `12iu` matches `iu` (not `u`).
+fn dose_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"(?i)(\d+(?:\.\d+)?)\s*(µg|μg|mcg|mg|iu|ml|ug|单位|g|u|片|粒|袋|支|丸|滴)")
+            .expect("dose re")
+    })
+}
+
+/// Frequency patterns in priority order: more specific first so `每晚一次` maps
+/// to `qn` (not `qd` via `一次`) and `三餐前` to `tid ac` (not `tid`). Each entry
+/// is `(code, pattern)`; the first pattern that matches the line wins.
+fn freq_patterns() -> &'static [(&'static str, Regex)] {
+    static R: OnceLock<Vec<(&'static str, Regex)>> = OnceLock::new();
+    R.get_or_init(|| {
+        let raw: &[(&str, &str)] = &[
+            ("qn", r"(?i)每晚一次|每晚|睡前|\bqn\b"),
+            ("tid ac", r"三餐前|餐前"),
+            ("qw", r"(?i)每周一次|每周1次|\bqw\b"),
+            ("q12h", r"(?i)每12小时|\bq12h\b"),
+            ("q8h", r"(?i)每8小时|\bq8h\b"),
+            (
+                "bid",
+                r"(?i)每日两次|每日2次|一日两次|一日2次|每天两次|\bbid\b",
+            ),
+            ("tid", r"(?i)每日三次|一日三次|每天三次|\btid\b"),
+            ("qid", r"(?i)每日四次|一日四次|每天四次|\bqid\b"),
+            ("qd", r"(?i)每日一次|一日一次|每天一次|每日1次|\bqd\b"),
+            ("prn", r"(?i)必要时|按需|\bprn\b"),
+        ];
+        raw.iter()
+            .map(|(code, pat)| (*code, Regex::new(pat).expect("freq re")))
+            .collect()
+    })
+}
+
+/// Trailing administration-route words to peel off the name. `qn`/`睡前` etc. are
+/// frequencies, not routes, and are handled elsewhere.
+const ROUTE_WORDS: &[&str] = &[
+    "口服",
+    "po",
+    "静滴",
+    "静脉滴注",
+    "静脉注射",
+    "静推",
+    "iv",
+    "皮下",
+    "sc",
+    "肌注",
+    "im",
+    "外用",
+    "含服",
+    "舌下",
+    "鼻饲",
+];
+
+/// Canonicalize a matched dose unit to a stable spelling. CJK units pass through.
+fn normalize_dose_unit(u: &str) -> String {
+    match u.to_lowercase().as_str() {
+        "mcg" | "ug" | "µg" | "μg" => "µg".to_string(),
+        "iu" => "IU".to_string(),
+        "u" => "U".to_string(),
+        "ml" => "mL".to_string(),
+        "mg" => "mg".to_string(),
+        "g" => "g".to_string(),
+        _ => u.to_string(),
+    }
+}
+
+/// Parse the first dose token: `(number, canonical_unit, byte_start_of_token)`.
+fn parse_dose(line: &str) -> Option<(f64, String, usize)> {
+    let caps = dose_re().captures(line)?;
+    let whole = caps.get(0)?;
+    let num: f64 = caps.get(1)?.as_str().parse().ok()?;
+    let unit = normalize_dose_unit(caps.get(2)?.as_str());
+    Some((num, unit, whole.start()))
+}
+
+/// Parse the frequency: `(code, raw_substring, byte_start)`. First priority-order
+/// pattern that matches wins (see [`freq_patterns`]).
+fn parse_frequency(line: &str) -> Option<(String, String, usize)> {
+    for (code, re) in freq_patterns() {
+        if let Some(m) = re.find(line) {
+            return Some((code.to_string(), m.as_str().to_string(), m.start()));
+        }
+    }
+    None
+}
+
+/// Strip trailing route words and dangling punctuation/space off the name token.
+fn strip_trailing_route(mut name: &str) -> &str {
+    loop {
+        let trimmed = name.trim_end_matches([' ', '\t', ',', '，', '、', ':', '：', '(', '（']);
+        let mut cut = trimmed;
+        for r in ROUTE_WORDS {
+            // Case-insensitive suffix match. The boundary check guards ASCII
+            // route words (`po`) from slicing into a preceding CJK char.
+            let start = trimmed.len().wrapping_sub(r.len());
+            if trimmed.len() >= r.len()
+                && trimmed.is_char_boundary(start)
+                && trimmed[start..].eq_ignore_ascii_case(r)
+            {
+                cut = &trimmed[..start];
+                break;
+            }
+        }
+        if cut.len() == name.len() {
+            return name.trim();
+        }
+        name = cut;
+    }
+}
+
+/// Extract medication observations, one per line. Unmatched-but-clearly-a-med
+/// lines (they carry a dose or a frequency) are kept with drug_key = None.
+pub fn extract_meds(text: &str) -> Vec<MedObservation> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        // 1) strip leading list marker.
+        let cleaned = list_marker_re().replace(line, "");
+        let cleaned = cleaned.trim();
+        if cleaned.is_empty() {
+            continue;
+        }
+
+        // 2) locate dose + frequency.
+        let dose = parse_dose(cleaned);
+        let freq = parse_frequency(cleaned);
+
+        // 3) name = everything before the earliest of dose/frequency; strip route.
+        let name_end = match (dose.as_ref().map(|d| d.2), freq.as_ref().map(|f| f.2)) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => cleaned.len(),
+        };
+        let name = strip_trailing_route(&cleaned[..name_end]);
+        // Need a real name token (a letter or CJK char), else it's not a med line.
+        if name.is_empty() || !name.chars().any(|c| c.is_alphabetic()) {
+            continue;
+        }
+
+        // 4) resolve the drug (prescription namespace).
+        let m = resolve_drug(name);
+
+        // Med-line gate: some evidence beyond a bare name — a dose, a frequency,
+        // or a drug match — else it's prose that merely mentions a word.
+        if dose.is_none() && freq.is_none() && m.is_none() {
+            continue;
+        }
+
+        out.push(MedObservation {
+            raw_name: name.to_string(),
+            drug_key: m.as_ref().map(|m| m.key.clone()),
+            canonical_name: m.as_ref().map(|m| m.canonical_name.clone()),
+            ingredient: m.as_ref().and_then(|m| m.ingredient.clone()),
+            rxnorm: m.as_ref().and_then(|m| m.codes.rxnorm.clone()),
+            atc: m.as_ref().and_then(|m| m.codes.atc.clone()),
+            dose_num: dose.as_ref().map(|d| d.0),
+            dose_unit: dose.as_ref().map(|d| d.1.clone()),
+            frequency: freq.as_ref().map(|f| f.0.clone()),
+            frequency_raw: freq.as_ref().map(|f| f.1.clone()),
+            confidence: m.as_ref().map_or(0.0, |m| m.confidence),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dose_and_freq_glued_and_spaced() {
+        // Glued 0.5g + English bid.
+        let o = &extract_meds("二甲双胍 0.5g bid")[0];
+        assert_eq!(o.drug_key.as_deref(), Some("metformin"));
+        assert_eq!(o.dose_num, Some(0.5));
+        assert_eq!(o.dose_unit.as_deref(), Some("g"));
+        assert_eq!(o.frequency.as_deref(), Some("bid"));
+        assert_eq!(o.rxnorm.as_deref(), Some("6809"));
+        assert!(o.confidence >= 0.8);
+
+        // Spaced 20 mg + English qd + trailing route po.
+        let o = &extract_meds("氨氯地平  20 mg  qd  po")[0];
+        assert_eq!(o.raw_name, "氨氯地平");
+        assert_eq!(o.drug_key.as_deref(), Some("amlodipine"));
+        assert_eq!(o.dose_num, Some(20.0));
+        assert_eq!(o.dose_unit.as_deref(), Some("mg"));
+        assert_eq!(o.frequency.as_deref(), Some("qd"));
+    }
+
+    #[test]
+    fn chinese_frequencies_normalize() {
+        // 每晚一次 -> qn (not qd), and dose still parses.
+        let o = &extract_meds("阿托伐他汀钙片 20mg 每晚一次")[0];
+        assert_eq!(o.drug_key.as_deref(), Some("atorvastatin"));
+        assert_eq!(o.frequency.as_deref(), Some("qn"));
+        assert_eq!(o.frequency_raw.as_deref(), Some("每晚一次"));
+        assert_eq!(o.dose_unit.as_deref(), Some("mg"));
+
+        // 每日两次 -> bid.
+        let o = &extract_meds("二甲双胍 0.5g 每日两次")[0];
+        assert_eq!(o.frequency.as_deref(), Some("bid"));
+        assert_eq!(o.frequency_raw.as_deref(), Some("每日两次"));
+    }
+
+    #[test]
+    fn list_numbered_line_strips_marker_and_route() {
+        let o = &extract_meds("1. 盐酸二甲双胍片 0.5g 每日两次口服")[0];
+        assert_eq!(o.raw_name, "盐酸二甲双胍片");
+        assert_eq!(o.drug_key.as_deref(), Some("metformin"));
+        assert_eq!(o.dose_num, Some(0.5));
+        assert_eq!(o.dose_unit.as_deref(), Some("g"));
+        assert_eq!(o.frequency.as_deref(), Some("bid"));
+        // stripped salt/form -> inference, not full confidence.
+        assert!((o.confidence - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn unmatched_but_has_dose_is_kept() {
+        let obs = extract_meds("某未知新药XR 5mg bid");
+        assert_eq!(obs.len(), 1);
+        let o = &obs[0];
+        assert_eq!(o.drug_key, None);
+        assert_eq!(o.canonical_name, None);
+        assert_eq!(o.rxnorm, None);
+        assert_eq!(o.confidence, 0.0);
+        assert_eq!(o.dose_num, Some(5.0));
+        assert_eq!(o.frequency.as_deref(), Some("bid"));
+    }
+
+    #[test]
+    fn non_med_prose_line_is_skipped() {
+        // No dose, no frequency, no drug match -> not a medication line.
+        assert!(extract_meds("患者一般情况可,继续观察。").is_empty());
+    }
+
+    #[test]
+    fn insulin_units_and_meal_timing() {
+        let o = &extract_meds("胰岛素 12U 三餐前")[0];
+        assert_eq!(o.dose_num, Some(12.0));
+        assert_eq!(o.dose_unit.as_deref(), Some("U"));
+        assert_eq!(o.frequency.as_deref(), Some("tid ac"));
+        assert_eq!(o.frequency_raw.as_deref(), Some("三餐前"));
+    }
+}


### PR DESCRIPTION
## 做了什么
阶段 B 的第②③块(接在 #134 化验提取之后),把医生视图从 demo 接向真实数据的**提取 + 聚合**地基。确定性、无网络、无 LLM。**按要求合成一个 PR。**

### ② 提取
- **`extract_meds`**:处方/用药行 → `{药名, drug_key?, ingredient, rxnorm, atc, dose_num, dose_unit, frequency(归一码), frequency_raw, confidence}`。频次中英归一(qd/bid/tid/qid/qn/q8h/q12h/prn/qw/tid ac,优先序:每晚→qn 不误成 qd);剂量多字符单位优先(20mg→mg);剥列表标记 + 尾部 route;门禁=剂量|频次|命中,不匹配保留(drug_key=None)。**修了 route 后缀切进 CJK 的 UTF-8 边界 bug**。
- **`extract_conditions`**:从具名段(诊断/初步/入院/出院/主要/其他/病理/临床诊断)抽诊断词,内联拆分 + 编号块;去编号、**丢印刷 ICD 码**(不核不洗进结构化);按 (raw_text, section) 去重。字典无诊断类 → 保留原始串,不臆造编码。

### ③ 聚合 `aggregate(docs) -> AggregatedClinical`
跨多文档把化验按 `analyte_key`、用药按 `drug_key` 聚成**趋势序列 / 用药区间**,诊断去重:
- matched/raw **双命名空间**,已归一与未匹配永不合并。
- 点按日期升序、None 日期排末(稳定);`any_abnormal`;series/med/cond 输出确定性排序(不受 HashMap 影响)。
- med `start=min / end=max / latest_dose=最近有日期的`;`sources` 去重升序。
- **med start/stop 折叠(docs/030 §4)先不做** —— 自由文本没有可靠停药信号,`status` 暂 `active` 并注明,待事件日志带显式停药动作再做,绝不猜「已停」。

## 门禁
`cargo fmt/clippy/test -p parser` 全绿,**37 passed**(含 ①的 6 个)。新增 16 个测试(meds 6 / conditions 4 / aggregate 6)。

## 范围
④「按 §3b 映射把化验/药归到问题名下 → 组装真实 `summary` 打进分享包」涉及**怎么分组/呈现**,会参考医生反馈再单独做。本 PR 只是纯确定性的提取+聚合地基,与版式无关。