### PR TITLE
fix(mobile): 安卓隐藏 iCloud 同步节(iOS 原生能力,安卓无)

### DIFF
--- a/apps/mobile_flutter/lib/screens/settings_screen.dart
+++ b/apps/mobile_flutter/lib/screens/settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
@@ -157,24 +159,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ],
           ),
-          _SectionLabel('iCloud 同步(实验性)'),
-          _SettingsGroup(
-            children: [
-              _SettingsRow(
-                icon: (_icloud?.enabled ?? false)
-                    ? Icons.cloud_done_outlined
-                    : Icons.cloud_outlined,
-                title: 'iCloud 同步',
-                subtitle: _icloudSubtitle(),
-                trailing: Switch(
-                  value: _icloud?.enabled ?? false,
-                  onChanged: (_busy || !_icloudAvailable)
-                      ? null
-                      : _toggleIcloud,
+          // iCloud 同步是 iOS 原生能力(苹果设备间同步),安卓无 iCloud——不显示这一节,
+          // 否则安卓用户会看到一个永远开不了、还叫他「去系统设置登录 iCloud」的死开关。
+          // 与 OCR 一样,属于「各平台用自己的原生方案」的有意差异(安卓云同步见路线图 1.3)。
+          if (Platform.isIOS) ...[
+            _SectionLabel('iCloud 同步(实验性)'),
+            _SettingsGroup(
+              children: [
+                _SettingsRow(
+                  icon: (_icloud?.enabled ?? false)
+                      ? Icons.cloud_done_outlined
+                      : Icons.cloud_outlined,
+                  title: 'iCloud 同步',
+                  subtitle: _icloudSubtitle(),
+                  trailing: Switch(
+                    value: _icloud?.enabled ?? false,
+                    onChanged: (_busy || !_icloudAvailable)
+                        ? null
+                        : _toggleIcloud,
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
+          ],
           _SectionLabel('关于'),
           _SettingsGroup(
             children: [


### PR DESCRIPTION
## 背景
用户反馈「安卓比 iOS 落后很多、版本不对」。派 subagent 逐项审计 `apps/mobile_flutter` iOS vs 安卓后,**结论是:代码层安卓其实基本同步**(Flutter/Dart + Rust 核共享),并非落后很多。只找到**一处真分歧**并修复。

## 唯一真分歧(已修)
`lib/screens/settings_screen.dart`:「iCloud 同步(实验性)」设置节**没有平台门禁** → 安卓上渲染出一个永远开不了的死开关,副标题还写「请先在系统设置登录 iCloud」——安卓没 iCloud,纯误导。修复:`import 'dart:io'` + 用 `if (Platform.isIOS) ...[]` 包起来(安卓不显示)。与 OCR 一样属**有意的平台原生差异**(安卓云同步是路线图 1.3)。

## 审过、确认已同步(未虚构改动)
版本号(iOS/安卓都从 pubspec `1.2.0+18` 动态取,无硬编码/陈旧)· 包名 `com.medme.mobile` · OCR(iOS Vision / 安卓 ML Kit,有意)· 导入权限(安卓 SAF/PhotoPicker 免权限,和 iOS usage-string 模型对称,**不需加 CAMERA 权限**否则反而破坏 image_picker)· MIME/扩展名(file_picker 跨端)· 插件/gradle(ML Kit 依赖 + R8 规则在位)· Dart 平台分支(仅 OCR + 本次 iCloud 两处)。

## 说明
- `flutter analyze`:No issues found。
- 「版本不对」大概率是**分发出去的安卓 APK 是旧构建**,不是代码落后 —— 代码已在 1.2.0+18,补一次 `flutter build apk` 即可(CI/你做,未在此执行)。