### PR TITLE
ci(mobile): 安卓构建自动发布 APK 到 Release(落地页永远最新)

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -54,6 +54,8 @@ jobs:
   android-release:
     if: github.event_name == 'workflow_dispatch' && (inputs.platform == 'android' || inputs.platform == 'both')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # 发布 APK 到 GitHub Release(落地页指向 releases/latest,防公开下载停在旧版)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-java@v5 # TODO: SHA 钉版
@@ -90,6 +92,26 @@ jobs:
             ${{ env.WORKDIR }}/build/app/outputs/flutter-apk/app-release.apk
             ${{ env.WORKDIR }}/build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
+      # ── 关键:把 APK 发布到 GitHub Release,资产名与落地页链接一致(MedMe-Android.apk)。──
+      # 落地页指向 releases/latest/download/MedMe-Android.apk,所以只要每次构建都更新 latest
+      # release 的这个资产,公开下载就永远是最新版 —— 堵住"官网下到旧版"的系统性缺口。
+      # 用 gh CLI(runner 自带),不引第三方 action;仅 workflow_dispatch 触发,PR 不发布。
+      - name: 发布 APK 到 GitHub Release(落地页取 latest)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cp "${WORKDIR}/build/app/outputs/flutter-apk/app-release.apk" MedMe-Android.apk
+          cp "${WORKDIR}/build/app/outputs/bundle/release/app-release.aab" MedMe-Android.aab
+          VER="$(grep '^version:' "${WORKDIR}/pubspec.yaml" | sed 's/version:[[:space:]]*//; s/+.*//')"
+          TAG="v${VER}"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "MedMe 医我 ${VER}" \
+              --notes "自动发布(workflow_dispatch)· 安卓 APK/AAB。桌面/iOS 见各自渠道。" --latest
+          fi
+          gh release upload "$TAG" MedMe-Android.apk MedMe-Android.aab --clobber
+          gh release edit "$TAG" --latest
+          echo "已发布 $TAG:MedMe-Android.apk(落地页 releases/latest 即刻指向本包)"
 
   # ── iOS release:archive + 导出 IPA(可选上传 TestFlight)。需配签名 secrets(见文末) ──
   ios-release:


### PR DESCRIPTION
## 问题(用户实测)
从官网(落地页)下的安卓 APK 跑起来是 **v1.0.2**(远古),当前代码已 1.2.0+18。

根因不在落地页(它正确指向 `releases/latest/download/MedMe-Android.apk`),在 **release 层**:
- `mobile.yml` 构建只 `upload-artifact`(普通用户下不了),**从不发 GitHub Release**;
- 最新 release(v1.1.0)挂的 APK 资产是旧构建 → `releases/latest` 永远停在旧版。

## 修复(系统性,防复发)
`android-release` job 加 `permissions: contents: write` + 一步 `gh` CLI:构建后把 `app-release.apk` 重命名为落地页要的 `MedMe-Android.apk`,`gh release upload --clobber` 到当前 pubspec 版本的 release 并 `--latest`;`.aab` 一并传。**仅 workflow_dispatch 触发,PR 不发布**;用 runner 自带 gh,不引第三方 action。

以后每次出安卓包 → 公开下载即最新。**iOS 无需改**:落地页 iOS 是 TestFlight 稳定链接,审核后自动最新(慢一点但不离谱)。

## 待办(本 PR 外,我接着做)
- 落地页删 Linux(#56 已暂停,仍挂着)。
- 当前这个手动触发的安卓构建完成后,我先手工发一版 v1.2.0 release,让官网即刻不再是 v1.0.2。