### PR TITLE
精简查看器:移除 2 处死 CSS(.expired / .sum-recs-h)

### DIFF
--- a/web/hosted-viewer/index.html
+++ b/web/hosted-viewer/index.html
@@ -122,9 +122,6 @@
   .dcm-notice { position: absolute; top: 16px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,.75); color: rgba(255,255,255,.9); font-size: 12px; padding: 8px 16px; border-radius: 8px; max-width: 80%; text-align: center; pointer-events: none; }
   .dcm-floathint { position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,.75); color: #fff; font-size: 14px; padding: 10px 20px; border-radius: 999px; pointer-events: none; }
   .statement { text-align: center; font-size: 11px; color: #94a3b8; margin-top: 24px; padding-top: 12px; border-top: 1px solid #e2e8f0; }
-  .expired { max-width: 480px; margin: 80px auto; text-align: center; background: #fff; border: 1px solid #fecdd3; border-radius: 16px; padding: 40px 28px; }
-  .expired h1 { font-size: 18px; color: #be123c; margin: 0 0 10px; }
-  .expired p { font-size: 14px; color: #64748b; line-height: 1.7; margin: 0; }
   @media print {
     body { background: #fff; }
     .record { border: 1px solid #cbd5e1; box-shadow: none; }
@@ -140,7 +137,6 @@
   .dz-file { font-size: 12px; color: #047857; margin-top: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; min-height: 16px; }
   /* 医生视图 summary — 疾病泳道时间轴 + 趋势(#37);仅当 payload.summary 存在时渲染 */
   .sum { margin-bottom: 22px; }
-  .sum-recs-h { font-size: 13px; font-weight: 700; color: #64748b; letter-spacing: .04em; margin: 26px 0 12px; }
   .sum-top { display: grid; grid-template-columns: 1.25fr 1fr; gap: 14px; margin-bottom: 16px; align-items: start; }
   @media (max-width: 700px) { .sum-top { grid-template-columns: 1fr; } }
   .sum-card { background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 16px 18px; box-shadow: 0 1px 3px rgba(30,41,59,.05); }


### PR DESCRIPTION
阶段性回溯(codebase 精简)。查看器本就精瘦,仅挖出 4 行死 CSS(grep 证明从未挂到任何元素):`.expired`(全屏过期面板,已被非阻断的行内过期提示 banner 取代)、`.sum-recs-h`(旧「全部报告」标题,已被 `<details class=allrecs><summary>` 取代)。无死 JS、无实质重复。CSP 未动(改的是 <style>,非 hash 脚本),`cargo test -p medme-share` 20 绿。移除从不挂元素的 class 不改渲染,免全量浏览器 E2E。