### PR TITLE
site(landing): 医生查看器卖点上墙 —— 加密分享打开=理好的病历

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,19 @@
   .st.soon{background:#f1f5f9;color:#64748b}
   .st.src{background:var(--blue-50);color:#1560a8}
   .doctor-cta{display:flex;align-items:center;justify-content:center;gap:14px;flex-wrap:wrap;margin-top:28px;color:var(--muted);font-size:15px}
+  /* 医生这端看到什么(卖点:查看器≠一堆文件,是理好的病历) */
+  .doc-view{max-width:560px;margin:34px auto 0}
+  .dv-card{background:linear-gradient(155deg,#e6f6fa,#f8fafc);border:1px solid #c8ebf1;border-radius:18px;padding:22px 24px}
+  .dv-head{display:flex;gap:12px;align-items:flex-start;margin-bottom:15px}
+  .dv-head .ic{width:40px;height:40px;border-radius:11px;background:#fff;border:1px solid #c8ebf1;color:var(--blue);
+    display:flex;align-items:center;justify-content:center;flex:0 0 auto}
+  .dv-head .ic svg{width:21px;height:21px}
+  .dv-head b{font-size:16px;display:block}
+  .dv-head span{color:var(--muted);font-size:14px}
+  .dv-list{list-style:none;margin:0 0 16px;padding:0;display:flex;flex-direction:column;gap:9px}
+  .dv-list li{position:relative;padding-left:25px;font-size:14.5px;color:var(--ink);line-height:1.5}
+  .dv-list li::before{content:"✓";position:absolute;left:2px;top:0;color:var(--blue);font-weight:800}
+  .dv-card .btn.ghost{width:100%;justify-content:center;background:#fff}
   .storebadge{display:inline-flex;align-items:center;gap:9px;background:#000;color:#fff;
     border-radius:10px;padding:8px 16px;margin-bottom:10px}
   .storebadge svg{width:24px;height:24px}
@@ -302,9 +315,20 @@
         </div>
       </div>
     </div>
-    <div class="doctor-cta">
-      <span>医生收到加密分享文件?无需安装 ——</span>
-      <a class="btn ghost" href="viewer/" target="_blank" rel="noopener">打开在线查看器 →</a>
+    <div class="doc-view">
+      <div class="dv-card">
+        <div class="dv-head">
+          <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 15l2 2 4-4"/></svg></span>
+          <div><b>在线查看器 · 医生无需安装</b><span>打开病人发来的加密分享,看到的不是一堆文件 ——</span></div>
+        </div>
+        <ul class="dv-list">
+          <li>病程时间轴 + 在治疾病 / 用药一目了然</li>
+          <li>点开看化验趋势,近期变化自动标出</li>
+          <li>📋 一键复制成病历文本,直接粘进你的系统</li>
+          <li>影像按部位跨时间 · 诊断级阅片;原件随时逐份核对</li>
+        </ul>
+        <a class="btn ghost" href="viewer/" target="_blank" rel="noopener">打开在线查看器 →</a>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## 做了什么

落地页此前把托管查看器只描述成「加密网页,凭口令查看」,而查看器实际已 ship 一整套结构化能力(疾病泳道时间轴、化验趋势、近期变化、一键复制成病历文本、影像按部位跨时间 + 诊断级阅片)。这些对医生的真价值在页面上完全隐形。

把下载区的医生 CTA 就地升级成一张紧凑的「医生这端看到什么」能力卡:
- 病程时间轴 + 在治疾病 / 用药一目了然
- 点开看化验趋势,近期变化标出
- 📋 一键复制成病历文本
- 影像按部位跨时间 · 诊断级阅片;原件随时核对

文案逐条对齐 `viewer/index.html` 实际渲染的标签,不发明功能。不新增大节、不改版式(最小 diff:+27/-3)。已本地 Playwright 截图确认渲染正常、风格一致。

## 有意没做

**没有**加「查看器示例 → `viewer/?demo`」链接。原因见 #141:`?demo` 的内置数据是手写占位,且真管线对真实多文档病例的产出目前严重失真(诊断名污染、关键趋势丢失)。等 #141 达标、demo 改由真管线产出后,再单独 PR 补这个链接。

## 范围

仅改 `index.html`(gh-pages)。PR base = `gh-pages`(落地页源头分支;`viewer/` 由 deploy-viewer 从 main 同步)。
