### PR TITLE
文档审计修正:docs 与代码现实对齐(OCR/DICOM/crate 路径/dwv/超期文档 + 补查看器&parser 说明)

### DIFF
--- a/docs/012_Viewers_and_Rendering.md
+++ b/docs/012_Viewers_and_Rendering.md
@@ -19,7 +19,7 @@
 | 格式 | mime | Viewer | 状态 |
 |---|---|---|---|
 | PDF | application/pdf | 内嵌 iframe / 全屏 | ✅ |
-| DICOM | application/dicom | **dwv**:窗宽窗位 / 缩放 / 平移 / 多帧滚动 | 🔧 |
+| DICOM | application/dicom | **自研 canvas 阅片器**(内联 cornerstonejs `dicom-parser` 1.8.12 解析 + `openDicomViewer` 画布:窗宽窗位 / 缩放 / 平移);分享查看器已上线 | ✅ 分享查看器 |
 | 图片 | image/* | 缩放/平移全屏灯箱 | ✅ |
 | 纯文本 | text/plain | 文本渲染 | ✅ |
 | DOCX | ...officedocument... | 文本抽取渲染(暂无版式) | 待 |
@@ -46,7 +46,13 @@
 ## 4. 详情页布局
 
 - **原件为附件**(缩略图/文件条 → 全屏 Viewer,维度 A)+ **结构化视图为主**(维度 B)。二者并存,按需切换。
-- 影像类:原件 Viewer(dwv)是主角;文本类:结构化视图是主角。
+- 影像类:原件 Viewer(自研 dicom-parser canvas 阅片器)是主角;文本类:结构化视图是主角。
+
+## 4a. 分享查看器(`web/hosted-viewer/index.html`)
+
+自包含加密分享页在原件列表之上还渲染**医生视图 summary**:疾病泳道时间轴 + 化验/用药趋势 + 一键复制的院外病历文本(`buildEMRFromSummary`),以及**影像检查分区**(「影像检查 · 按时间」,按部位分组,同部位跨时间看变化)。交互:浮动**「↑ 返回时间轴」**回顶按钮、**内嵌 PDF 预览**(`openPdfViewer`,CSP 仅放行 `frame-src data:`)、以及全屏图片灯箱(照片 / DICOM 关键切片 PNG,可切原始分辨率)。有 summary 时「全部原件」默认折叠,医生先看泳道 + 影像,原件按需展开、泳道证据可跳回对应原件。
+
+> 医生 summary 的数据契约与渲染规范由 [030_Clinical_Handoff](030_Clinical_Handoff.md) 拥有(此处只描述查看器如何呈现)。
 
 ## 5. 原则(定调)
 
@@ -57,5 +63,5 @@
 
 ## 6. 阶段
 
-- **现在**:补齐维度B 的 `renderByType`(处方用药清单 / 病理·影像·出院·病历·手术分节);完成维度A 的 DICOM viewer(dwv)。
+- **现在**:补齐维度B 的 `renderByType`(处方用药清单 / 病理·影像·出院·病历·手术分节);完成维度A 的 DICOM viewer(自研 dicom-parser canvas,已在分享查看器上线)。
 - 接续:化验趋势图;`source_span` 溯源高亮;DOCX 版式;结构化抽取(v0.2)驱动更准渲染。

--- a/docs/013_Mobile_App.md
+++ b/docs/013_Mobile_App.md
@@ -1,5 +1,7 @@
 # 013 · Mobile App & Desktop Sync · 手机端与桌面同步规划
 
+> ⚠️ **已被取代(历史文档)**:本文是 Flutter 转型前(Tauri 时代)「手机端要薄、以采集为主」的旧规划。当前手机端设计以 [020_Flutter_Mobile_Rewrite](020_Flutter_Mobile_Rewrite.md)(2026-07-12 Flutter 转型)为准,且当前范围已改为 **1.2 = 手机端做到极致**。此文仅作沿革参考,正文不再更新。
+
 > 目标:iOS / Android 手机 App,**采集为主、查看为辅**,与桌面**共享同一套 Rust 内核与存储**,做到"一处改动、两端同步更新"。手机与桌面通过**同一个事件溯源保险箱**(放在云同步文件夹)保持数据一致,零服务器。
 
 关联:[011_Storage_Sync](011_Storage_Sync.md) · [012_Viewers_and_Rendering](012_Viewers_and_Rendering.md) · 记忆 `medme-v1-milestone-and-decisions` `medme-real-data-sources`

--- a/docs/014_Imaging_Overhaul.md
+++ b/docs/014_Imaging_Overhaul.md
@@ -9,7 +9,7 @@
 ## 1. 病根(现状)
 
 - DICOM 每个 `.dcm` 存成**独立文档**;`study_uid`/`accession` 提取了但**没用来分组** → 真实 CT(几百切片)碎成几百文档,无法当一叠滚动看。
-- 查看器 dwv 基础:不能跨切片滚、无窗位预设、无测量;小样本上采样发糊。
+- 查看器仅自研 dicom-parser canvas 基础(窗宽窗位/缩放/平移):不能跨切片滚、无窗位预设、无测量;小样本上采样发糊。
 - **导出/分享里没有影像**(只文本)→ 医生看不到 CT/MR。**最致命。**
 - 普通图片(JPG)也偏糊:缩略图/灯箱未保证原分辨率呈现。
 
@@ -19,7 +19,10 @@
 - 导入**文件夹 / zip** 的一堆 `.dcm` → 一个 study(不是 N 个文档)。
 - 原始切片仍进 CAS(原件不灭);DB 加 `imaging_study` / `imaging_series` 派生表(可从事件日志重建)。时间线上一次检查 = 一张卡(可展开序列)。
 
-## 3. 本地查看器:dwv → Cornerstone3D
+## 3. 本地查看器:自研 dicom-parser canvas → Cornerstone3D
+
+> 现状澄清:**已上线的分享查看器不是 dwv**,而是内联 cornerstonejs `dicom-parser` 1.8.12 + 自研 `openDicomViewer` 画布(`web/hosted-viewer/index.html`,提供窗宽窗位 / 缩放 / 平移)。下文的 Cornerstone3D 是**将来的目标**(放射级序列滚动 / 测量 / MPR),非当前实现。
+
 
 放射级能力:**序列堆栈滚动**、**窗位预设**(脑/骨/肺/软组织/自定义)、缩放平移、**测量**(长度/角度/ROI)、反色、cine 播放;后续 MPR 三维重建、序列并排。
 - 512×512 是 CT 标准分辨率;Cornerstone3D 渲染比 dwv 锐利,配合真实切片解决"糊"。

--- a/docs/020_Flutter_Mobile_Rewrite.md
+++ b/docs/020_Flutter_Mobile_Rewrite.md
@@ -11,24 +11,24 @@
 ## 架构
 
 ```
-Flutter (Dart) UI  ──FRB──▶  crates/mobile_ffi (Rust)  ──▶  core-model / pipeline / share / dicom / parser
+Flutter (Dart) UI  ──FRB──▶  apps/mobile_flutter/rust  ──▶  core-model / pipeline / share / dicom / parser
    原生界面/导航/PDF查看/相机                薄封装:把 vault 操作暴露成 async Dart API
-   ML Kit 文字识别(离线中文)
+   OCR:iOS=Apple Vision 原生 / Android=ML Kit 插件(均离线中文)
 ```
 
 - **UI = Flutter**:所有屏幕、导航、PDF 查看(`pdfx`/`syncfusion` 等成熟插件)、图片查看、相机/相册/文件选择,全部原生组件。再无 WebView。
-- **数据核 = 现有 Rust crate**,经新增的 `crates/mobile_ffi` 薄封装暴露。**不重写保险箱**(否则同步断、且推倒最难最已测透的代码)。
-- **OCR = Flutter 插件 `google_mlkit_text_recognition`**(iOS+安卓离线中文)。Flutter 拍照/选图 → ML Kit 识别 → 把「原始字节 + 识别文本 + 置信度」交给 Rust `ingest_image_with_text` 落库。**不再维护 Rust 的 Vision/MLKit FFI 桥**。PDF 文本层抽取、DICOM 元数据仍在 Rust。
+- **数据核 = 现有 Rust crate**,经新增的 `apps/mobile_flutter/rust` 薄封装暴露。**不重写保险箱**(否则同步断、且推倒最难最已测透的代码)。
+- **OCR = 平台分流**:iOS 用 **Apple Vision**(原生 `VNRecognizeTextRequest`,经 `medme/ocr` MethodChannel 调用 —— 中文/HEIC 更强);Android 用 **`google_mlkit_text_recognition` 插件**(离线中文)。Flutter 拍照/选图 → 平台 OCR 识别 → 把「原始字节 + 识别文本 + 置信度」交给 Rust `ingest_image_with_text` 落库。**不再维护 Rust 的 Vision/MLKit FFI 桥**。PDF 文本层抽取、DICOM 元数据仍在 Rust。
 
 ## 复用 vs 新建
 - **复用(不动)**:`packages/core-model`(Vault/CAS/log/HMAC)、`packages/pipeline`(ingest 编排)、`packages/share`(加密分享+导出)、`packages/dicom`、`packages/parser`。桌面端继续用。
 - **新建**:
-  - `crates/mobile_ffi`:FRB 封装层。依赖上述 crate,暴露干净 async API。
+  - `apps/mobile_flutter/rust`:FRB 封装层(crate,FFI 在 `src/api/`)。依赖上述 crate,暴露干净 async API。
   - `apps/mobile_flutter/`:Flutter 工程(FRB 生成的 Dart 绑定 + UI)。
 - **已删除(功能对齐后,2026-07)**:`apps/mobile`(Tauri v2 移动端)。手机端只剩 `apps/mobile_flutter`。
 
-## FFI API 面(mobile_ffi 暴露给 Flutter)
-镜像现有 `apps/mobile/src-tauri/src/commands.rs` 的能力:
+## FFI API 面(`apps/mobile_flutter/rust` 暴露给 Flutter)
+参考已删除的旧 Tauri `apps/mobile/src-tauri/src/commands.rs`(设计蓝本,现已随 `apps/mobile` 一并移除);FFI 现落在 `apps/mobile_flutter/rust/src/api/`。能力:
 - `open_vault(docs_dir, data_dir, icloud_enabled) -> ()`(决定真相根:iCloud 容器 or 沙盒)
 - `load_archive() -> Vec<TimelineGroup>`
 - `get_document(id) -> DocumentDetail`
@@ -48,7 +48,7 @@ DTO 用 FRB 的镜像结构(Rust struct → Dart class 自动生成)。
 1. **导入导出**(用户明确要求提升为一级 tab):相机/相册/文件导入 + 导出(时间线 HTML,带日期区间筛选,后续可加更多筛选维度)。
 2. **健康档案**(时间线:就诊组 + 独立文档,点开详情)。
 3. **设置**(载入示例数据 / 清空重置 / iCloud 同步 / 加密分享入口 / 关于)。
-- 文档详情:内容感知渲染(化验表格/处方卡/病历)+ 原件查看(图片查看器 / PDF 插件 / DICOM 只显元信息文本)。
+- 文档详情:内容感知渲染(化验表格/处方卡/病历)+ 原件查看(图片查看器 / PDF 插件 / DICOM 渲染锚点切片为 PNG(`renderDicomPng`),不支持的压缩格式优雅降级(仍保存原件))。
 
 ## 同步(iCloud,iOS)
 真相(objects/+log/)放 iCloud ubiquity 容器,派生 db 留沙盒 —— 沿用现 Rust `icloud` 逻辑,
@@ -60,7 +60,7 @@ DTO 用 FRB 的镜像结构(Rust struct → Dart class 自动生成)。
 - Rust 库经 FRB 的 `cargokit` 在 flutter build 时自动编 iOS/安卓静态库并链接。
 
 ## 分阶段
-- **P1 骨架**:`crates/mobile_ffi` + `flutter create` + FRB init;跑通一个最小 Rust 调用(open_vault + record_count)在 iOS 模拟器显示。**验证工具链闭环**。
+- **P1 骨架**:`apps/mobile_flutter/rust` + `flutter create` + FRB init;跑通一个最小 Rust 调用(open_vault + record_count)在 iOS 模拟器显示。**验证工具链闭环**。
 - **P2 FFI 全量**:暴露上面全部 API + DTO。
 - **P3 UI**:三个 tab + 文档详情,还原设计。
 - **P4 OCR/PDF/图片**:ML Kit 识别 + PDF 插件 + HEIC/图片。

--- a/docs/030_Clinical_Handoff.md
+++ b/docs/030_Clinical_Handoff.md
@@ -142,6 +142,8 @@
 - **诊断/过敏/病程**(叙述性)→ LLM 结构化抽取更稳。隐私分叉:端上小模型(纯本地/弱) vs 服务器 LLM(强/OCR 文本出设备)。
 - **务实**:混合;且 **LLM 抽取只在「生成医生分享」那一刻跑**(用户已决定分享,是可接受一次 AI 调用的时机)。平时纯本地。
 - **MVP 不引入 LLM**:先用 parser/启发式从现有 `records` 抽 用药+化验+过敏,证明管线。
+- **CJK 部首字归一化**:OCR/抽取文本在匹配前先做部首字形折叠(`packages/parser/src/lib.rs` `normalize_cjk_radicals`,在 `extract` 里应用)—— 部分 PDF 会吐出康熙/CJK 部首码位而非统一汉字(如「意⻅」),折叠回统一汉字后词典/标签才匹配得上。确定性、无 LLM。
+- **影像分组(确定性)**:影像报告按**部位+类型**聚成 `summary.imaging`,组内按时间排列,每次检查的**结论/诊断意见逐字照抄**(`packages/parser/src/handoff.rs` `imaging_impression` / `imaging_group` / `assemble_summary`)—— 只分组、只搬运原文,不做放射学解读。
 
 ## 6. 与 Prometheno 的桥
 


### PR DESCRIPTION
阶段性回溯(doc/memory 查漏补缺)的 repo 文档部分。逐条按审计、改前均已核代码:
- docs/020:OCR 改「iOS=Apple Vision(medme/ocr channel)/安卓=ML Kit」;DICOM「渲染 PNG+降级」非「只显元信息」;`crates/mobile_ffi`→`apps/mobile_flutter/rust`,删已删的 apps/mobile 路径引用。
- docs/012+014:DICOM 查看器实为 vendored dicom-parser+自绘 canvas(非 dwv);Cornerstone3D 标为未来。
- docs/013:顶部加「已被 020 取代」历史横幅。
- docs/030 §5:补 CJK 部首折叠 + 影像分组两条(确定性、无 LLM)。
- docs/012:新增「分享查看器」小节(泳道/趋势/EMR/影像分区/返回/PDF内嵌/灯箱)+ 交叉链 030。
记忆侧(P5 iCloud 状态、OCR 分工、crate 路径)已在本地记忆同步修正。