### PR TITLE
fix(parser): 医生 summary 质量止血 —— 六缺陷规则修复(#141)

### DIFF
--- a/packages/parser/src/aggregate.rs
+++ b/packages/parser/src/aggregate.rs
@@ -149,6 +149,23 @@ fn max_date(cur: Option<NaiveDate>, new: Option<NaiveDate>) -> Option<NaiveDate>
     }
 }
 
+/// Whether this document should be mined for **labs**. Only lab reports —
+/// running `extract_labs` over prescriptions/imaging/prose mis-reads drug doses
+/// and sentence fragments as "labs" (`二甲双胍 0.5g` → analyte, CT text → analyte).
+/// `None`/unknown stays permissive so callers that don't classify still work
+/// (and to keep the low-level aggregate unit tests type-agnostic). Quality dim 3/4.
+fn wants_labs(doc_type: Option<&str>) -> bool {
+    doc_type.is_none_or(|t| t.contains("lab"))
+}
+
+/// Whether this document should be mined for **meds**. Only prescriptions —
+/// running `extract_meds` over lab reports/prose mis-reads lab rows and prose as
+/// "meds" (`肌酐 112 umol/L` → 112U, 病历散文 → 剂量). `None`/unknown stays
+/// permissive (see [`wants_labs`]). Quality dim 3/4.
+fn wants_meds(doc_type: Option<&str>) -> bool {
+    doc_type.is_none_or(|t| t.contains("prescription"))
+}
+
 /// Render a mention's dose + frequency, e.g. "0.5g bid". `None` if the mention
 /// carries neither a dose nor a frequency.
 fn dose_string(m: &MedObservation) -> Option<String> {
@@ -210,8 +227,12 @@ pub fn aggregate(docs: &[SourceDoc<'_>]) -> AggregatedClinical {
     let mut conds: HashMap<String, CondBuilder> = HashMap::new();
 
     for doc in docs {
-        // --- labs ---
-        for obs in extract_labs(doc.text) {
+        let dt = doc.doc_type.as_deref();
+        // --- labs (only from lab reports; see wants_labs) ---
+        for obs in wants_labs(dt)
+            .then(|| extract_labs(doc.text))
+            .unwrap_or_default()
+        {
             let matched = obs.analyte_key.is_some();
             let key = match &obs.analyte_key {
                 Some(k) => GroupKey::Matched(k.clone()),
@@ -268,8 +289,11 @@ pub fn aggregate(docs: &[SourceDoc<'_>]) -> AggregatedClinical {
             b.points.push(point);
         }
 
-        // --- meds ---
-        for obs in extract_meds(doc.text) {
+        // --- meds (only from prescriptions; see wants_meds) ---
+        for obs in wants_meds(dt)
+            .then(|| extract_meds(doc.text))
+            .unwrap_or_default()
+        {
             let matched = obs.drug_key.is_some();
             let key = match &obs.drug_key {
                 Some(k) => GroupKey::Matched(k.clone()),

--- a/packages/parser/src/aggregate.rs
+++ b/packages/parser/src/aggregate.rs
@@ -229,10 +229,12 @@ pub fn aggregate(docs: &[SourceDoc<'_>]) -> AggregatedClinical {
     for doc in docs {
         let dt = doc.doc_type.as_deref();
         // --- labs (only from lab reports; see wants_labs) ---
-        for obs in wants_labs(dt)
-            .then(|| extract_labs(doc.text))
-            .unwrap_or_default()
-        {
+        let doc_labs = if wants_labs(dt) {
+            extract_labs(doc.text)
+        } else {
+            Vec::new()
+        };
+        for obs in doc_labs {
             let matched = obs.analyte_key.is_some();
             let key = match &obs.analyte_key {
                 Some(k) => GroupKey::Matched(k.clone()),
@@ -290,10 +292,12 @@ pub fn aggregate(docs: &[SourceDoc<'_>]) -> AggregatedClinical {
         }
 
         // --- meds (only from prescriptions; see wants_meds) ---
-        for obs in wants_meds(dt)
-            .then(|| extract_meds(doc.text))
-            .unwrap_or_default()
-        {
+        let doc_meds = if wants_meds(dt) {
+            extract_meds(doc.text)
+        } else {
+            Vec::new()
+        };
+        for obs in doc_meds {
             let matched = obs.drug_key.is_some();
             let key = match &obs.drug_key {
                 Some(k) => GroupKey::Matched(k.clone()),

--- a/packages/parser/src/conditions.rs
+++ b/packages/parser/src/conditions.rs
@@ -11,12 +11,19 @@
 //! Section label (optionally after a list number) + `:`/`：`, then either:
 //! ```text
 //! 出院诊断:2型糖尿病；高血压病3级          <- inline, split on ；;，,、 and numbers
+//! 出院诊断:1. 急性脑梗死 2. 高血压3级 3. 2型糖尿病  <- inline w/ in-line numbering
 //! 出院诊断:                                <- label then a numbered block:
 //!   1. 2型糖尿病(E11.9)                    <- numbering stripped, ICD code dropped
 //!   2. 高血压病3级
 //! ```
-//! Recognized labels: 诊断 初步诊断 入院诊断 出院诊断 主要诊断 其他诊断 病理诊断 临床诊断.
+//! Recognized labels: 诊断 初步诊断 入院诊断 出院诊断 主要诊断 其他诊断 临床诊断.
 //! A numbered block is consumed until a blank line or a non-numbered line.
+//!
+//! ## 病理诊断 is deliberately NOT a diagnosis label here
+//! 病理 reports write a *narrative* impression (`(胃窦)慢性活动性胃炎,伴轻度肠上皮
+//! 化生,Hp 阳性(++)。未见异型增生及恶性证据。`) that must never be comma-split into
+//! fake "diagnoses" — it is surfaced as a pathology **conclusion** by the summary
+//! layer (docs/030, quality dim 6), not as problems.
 //!
 //! ## Deliberately NOT handled (kept lean)
 //! - Diagnoses in free prose with no section label.
@@ -43,7 +50,7 @@ fn section_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
     R.get_or_init(|| {
         Regex::new(
-            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(出院诊断|入院诊断|初步诊断|主要诊断|其他诊断|病理诊断|临床诊断|诊断)\s*[:：]\s*(.*)$",
+            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(出院诊断|入院诊断|初步诊断|主要诊断|其他诊断|临床诊断|诊断)\s*[:：]\s*(.*)$",
         )
         .expect("section re")
     })
@@ -69,9 +76,27 @@ fn icd_paren_re() -> &'static Regex {
     })
 }
 
-/// Split an inline diagnosis string on separators, clean each part, keep order.
+/// An **in-line** numbered marker: whitespace (or line start) then `N.`/`N、`/`N)`.
+/// The delimiter after the digit is required, so `高血压 3 级` / `2 型糖尿病` (a digit
+/// glued to the disease name, no delimiter) is NOT treated as a marker.
+///
+/// 真 corpus 把多诊断写在一行:`出院诊断:1. 急性脑梗死 2. 高血压3级 3. 2型糖尿病`。
+/// 这些 ` 2.` ` 3.` 既不是标点分隔符也不是「独立成行」的编号块,过去整行塌成一条
+/// term。先按它切开,行内多诊断才拆得开(quality dim 1)。
+fn inline_number_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // Whitespace (or end) MUST follow the delimiter, so a decimal measurement inside
+    // a diagnosis (`甲状腺结节 1.2cm`) is not split at the `.` — the corpus always
+    // writes list markers as `1. ` / `2. ` with a trailing space.
+    R.get_or_init(|| Regex::new(r"(?:^|\s)\d+\s*[.、)）](?:\s+|$)").expect("inline number re"))
+}
+
+/// Split an inline diagnosis string, clean each part, keep order. Two passes:
+/// first on in-line numbered markers (` 2.` ` 3.`), then on `；;，,、`.
 fn split_inline(s: &str) -> Vec<String> {
-    s.split(['；', ';', '，', ',', '、'])
+    inline_number_re()
+        .split(s)
+        .flat_map(|seg| seg.split(['；', ';', '，', ',', '、']))
         .filter_map(clean_dx)
         .collect()
 }
@@ -156,6 +181,26 @@ mod tests {
         assert_eq!(obs[0].section.as_deref(), Some("出院诊断"));
         assert_eq!(obs[1].raw_text, "高血压病3级");
         assert_eq!(obs[1].section.as_deref(), Some("出院诊断"));
+    }
+
+    #[test]
+    fn inline_numbered_multi_diagnosis_splits() {
+        // 真 corpus 出院诊断:一行内用 `1. .. 2. .. 3. ..` 串三个诊断,须拆成三条,
+        // 且 term 里不含行内编号标记(`2.`/`3.`),病名内的空格保留(逐字)。
+        let obs = extract_conditions("出院诊断:1. 急性脑梗死  2. 高血压 3 级(很高危)  3. 2 型糖尿病");
+        let terms: Vec<&str> = obs.iter().map(|o| o.raw_text.as_str()).collect();
+        assert_eq!(terms, ["急性脑梗死", "高血压 3 级(很高危)", "2 型糖尿病"]);
+        assert!(obs.iter().all(|o| !o.raw_text.contains(" 2.")
+            && !o.raw_text.contains(" 3.")
+            && !o.raw_text.contains('。')));
+    }
+
+    #[test]
+    fn decimal_measurement_in_diagnosis_is_not_split() {
+        // 病名带尺寸的小数(`1.2cm`)不得被行内编号切分成 `["甲状腺结节","2cm"]`。
+        let obs = extract_conditions("诊断:甲状腺结节 1.2cm");
+        let terms: Vec<&str> = obs.iter().map(|o| o.raw_text.as_str()).collect();
+        assert_eq!(terms, ["甲状腺结节 1.2cm"]);
     }
 
     #[test]

--- a/packages/parser/src/conditions.rs
+++ b/packages/parser/src/conditions.rs
@@ -187,7 +187,8 @@ mod tests {
     fn inline_numbered_multi_diagnosis_splits() {
         // 真 corpus 出院诊断:一行内用 `1. .. 2. .. 3. ..` 串三个诊断,须拆成三条,
         // 且 term 里不含行内编号标记(`2.`/`3.`),病名内的空格保留(逐字)。
-        let obs = extract_conditions("出院诊断:1. 急性脑梗死  2. 高血压 3 级(很高危)  3. 2 型糖尿病");
+        let obs =
+            extract_conditions("出院诊断:1. 急性脑梗死  2. 高血压 3 级(很高危)  3. 2 型糖尿病");
         let terms: Vec<&str> = obs.iter().map(|o| o.raw_text.as_str()).collect();
         assert_eq!(terms, ["急性脑梗死", "高血压 3 级(很高危)", "2 型糖尿病"]);
         assert!(obs.iter().all(|o| !o.raw_text.contains(" 2.")

--- a/packages/parser/src/handoff.rs
+++ b/packages/parser/src/handoff.rs
@@ -18,7 +18,9 @@
 //!   Pathology impressions and the viewer's `care_facility` field stay out of
 //!   scope. Only problems / labs / meds / allergies / notable_changes / imaging.
 
-use crate::aggregate::{aggregate, AnalyteSeries, MedSpan, SourceDoc};
+use crate::aggregate::{
+    aggregate, AggregatedCondition, AnalyteSeries, LabPoint, MedSpan, SourceDoc,
+};
 use chrono::NaiveDate;
 use regex::Regex;
 use serde::Deserialize;
@@ -83,10 +85,124 @@ fn entry_for(disease: &str) -> Option<&'static MapEntry> {
     problem_map().iter().find(|e| e.disease == disease)
 }
 
+/// Curated disease **stems** for merging clinical variants the mapped-disease table
+/// (problem_map) doesn't cover. A stem folds acute/stage/laterality variants to one
+/// lane: `急性脑梗死` / `急性脑梗死(左侧基底节区)` / `脑梗死恢复期` / `陈旧性脑梗死` all
+/// share `脑梗死` → one problem (quality dim 2). Kept tiny and explicit — only
+/// well-known chronic problems whose variant spellings obviously mean one disease.
+const DISEASE_STEMS: &[&str] = &["脑梗死", "脑梗塞", "脑出血", "脑卒中"];
+
+/// A condition's **normalization key** — the identity that same-problem variants
+/// merge on. A mapped chronic disease collapses to its mapped name (`高血压 3 级
+/// (很高危)` / `高血压` → `高血压`); otherwise a known stem; otherwise the cleaned
+/// raw text (distinct problems stay distinct). Deterministic, no fuzzy matching.
+fn condition_key(raw: &str) -> String {
+    if let Some(d) = match_disease(raw) {
+        return d.to_string();
+    }
+    for stem in DISEASE_STEMS {
+        if raw.contains(stem) {
+            return (*stem).to_string();
+        }
+    }
+    raw.trim().to_string()
+}
+
+/// One clinical problem after merging variant mentions across documents.
+struct MergedProblem {
+    /// Clean, verbatim display term (a real mention, never a mashed line).
+    term: String,
+    onset: Option<NaiveDate>,
+    sources: Vec<usize>,
+}
+
+/// Fold `conditions` (already exact-deduped by [`crate::aggregate`]) into clinical
+/// problems: mentions with the same [`condition_key`] collapse into one lane with
+/// the earliest onset and merged evidence (quality dim 2). The display `term` is
+/// the **shortest** raw mention in the group — the shortest is the cleanest and
+/// avoids a mashed multi-diagnosis line (`2型糖尿病 糖尿病肾病(早期) 高血压3级`)
+/// winning over a plain `2型糖尿病`. Output is sorted by (onset, term) so the
+/// summary stays deterministic.
+fn merge_conditions(conditions: &[AggregatedCondition]) -> Vec<MergedProblem> {
+    // key → (candidate display terms, earliest onset, merged sources)
+    let mut groups: BTreeMap<String, (Vec<String>, Option<NaiveDate>, BTreeSet<usize>)> =
+        BTreeMap::new();
+    for c in conditions {
+        let key = condition_key(&c.raw_text);
+        let g = groups.entry(key).or_default();
+        g.0.push(c.raw_text.clone());
+        g.1 = match (g.1, c.onset) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+        g.2.extend(c.sources.iter().copied());
+    }
+    let mut out: Vec<MergedProblem> = groups
+        .into_values()
+        .map(|(mut terms, onset, sources)| {
+            // Shortest mention wins; tie-break lexicographically for determinism.
+            terms.sort_by(|a, b| {
+                a.chars()
+                    .count()
+                    .cmp(&b.chars().count())
+                    .then_with(|| a.cmp(b))
+            });
+            MergedProblem {
+                term: terms.into_iter().next().unwrap_or_default(),
+                onset,
+                sources: sources.into_iter().collect(),
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| match (a.onset, b.onset) {
+        (Some(x), Some(y)) => x.cmp(&y).then_with(|| a.term.cmp(&b.term)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.term.cmp(&b.term),
+    });
+    out
+}
+
 /// Format a value without a trailing `.0` for whole numbers (`88.0` → `"88"`,
 /// `7.9` → `"7.9"`), for the human-readable `notable_changes` strings.
 fn fmt_num(v: f64) -> String {
     format!("{v}")
+}
+
+/// The first and last **dated** points of a series (falling back to the first/last
+/// raw point when none carry a date). `None` only for an empty series.
+fn first_last_point(s: &AnalyteSeries) -> Option<(&LabPoint, &LabPoint)> {
+    let first = s
+        .points
+        .iter()
+        .find(|p| p.date.is_some())
+        .or_else(|| s.points.first())?;
+    let last = s
+        .points
+        .iter()
+        .rev()
+        .find(|p| p.date.is_some())
+        .or_else(|| s.points.last())?;
+    Some((first, last))
+}
+
+/// Rank key for `notable_changes`: `(crosses_threshold, |fractional change|)`.
+/// A normal↔abnormal crossing between the first and last point is the clinically
+/// notable event (a value entering or leaving its reference band); magnitude is the
+/// tiebreak. Both are computed only from grounded values/flags — no invented trend.
+fn change_significance(s: &AnalyteSeries) -> (bool, f64) {
+    let Some((first, last)) = first_last_point(s) else {
+        return (false, 0.0);
+    };
+    let is_abn = |f: &Option<String>| matches!(f.as_deref(), Some("H") | Some("L"));
+    let crosses = is_abn(&first.flag) != is_abn(&last.flag);
+    let frac = if first.value != 0.0 {
+        (last.value - first.value).abs() / first.value.abs()
+    } else {
+        (last.value - first.value).abs()
+    };
+    (crosses, frac)
 }
 
 /// `[["YYYY-MM", value], …]` for the dated points, chronological. Undated points
@@ -208,14 +324,27 @@ fn imaging_label_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
     R.get_or_init(|| {
         Regex::new(
-            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(影像所见|检查所见|超声所见|诊断意见|影像诊断|超声提示|影像提示|检查提示|印象|结论|意见|所见)\s*[:：]\s*(.*)$",
+            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(影像所见|检查所见|超声所见|诊断意见|影像诊断|超声提示|影像提示|检查提示|心电图诊断|印象|结论|意见|所见)\s*[:：]\s*(.*)$",
         )
         .expect("imaging label re")
     })
 }
 
-/// Whether a label names an *impression/conclusion* (preferred) vs a raw 所见
-/// finding (fallback). Both are copied verbatim — neither is interpreted.
+/// A pathology report's section-label line. `病理诊断` is the impression/conclusion
+/// (preferred); 镜下所见/肉眼所见 are raw findings (fallback). Pathology impressions
+/// are surfaced as a conclusion, never split into problems (quality dim 6).
+fn pathology_label_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"^\s*(?:\d+\s*[.、)）]|[\u{2460}-\u{2473}]|[-•*·])?\s*(病理诊断|病理所见|免疫组化|镜下所见|肉眼所见)\s*[:：]\s*(.*)$",
+        )
+        .expect("pathology label re")
+    })
+}
+
+/// Whether an imaging label names an *impression/conclusion* (preferred) vs a raw
+/// 所见 finding (fallback). Both are copied verbatim — neither is interpreted.
 fn is_impression_label(label: &str) -> bool {
     matches!(
         label,
@@ -224,10 +353,16 @@ fn is_impression_label(label: &str) -> bool {
             | "超声提示"
             | "影像提示"
             | "检查提示"
+            | "心电图诊断"
             | "印象"
             | "结论"
             | "意见"
     )
+}
+
+/// Whether a pathology label names the conclusion (`病理诊断`) vs a raw finding.
+fn is_pathology_impression_label(label: &str) -> bool {
+    label == "病理诊断"
 }
 
 /// Lines that end an impression/findings block even without a blank separator:
@@ -261,12 +396,31 @@ fn is_impression_terminator(line: &str) -> bool {
 /// headers between labels are not treated as boundaries (a stray `检查方法:` line
 /// after 所见 would be swallowed) — reports put 结论 last, so this is rare.
 fn imaging_impression(text: &str) -> Option<String> {
+    labeled_impression(text, imaging_label_re(), is_impression_label)
+}
+
+/// Pull a pathology report's **conclusion** (`病理诊断` narrative, else 镜下/肉眼所见).
+/// Same block-scan as imaging; the narrative stays a single verbatim conclusion and
+/// is NEVER comma-split into problems (quality dim 6).
+fn pathology_impression(text: &str) -> Option<String> {
+    labeled_impression(text, pathology_label_re(), is_pathology_impression_label)
+}
+
+/// Shared labeled-block extractor for imaging/pathology conclusions. Scans for
+/// `label_re` line starts; a block is the inline remainder plus following non-empty
+/// lines up to a blank line or the next labeled section (an `is_impression` label
+/// wins over a raw 所见 fallback). Returns the trimmed text, or `None`.
+fn labeled_impression(
+    text: &str,
+    label_re: &Regex,
+    is_impression: impl Fn(&str) -> bool,
+) -> Option<String> {
     let lines: Vec<&str> = text.lines().collect();
     let mut impression: Option<String> = None;
     let mut findings: Option<String> = None;
     let mut i = 0;
     while i < lines.len() {
-        let Some(caps) = imaging_label_re().captures(lines[i]) else {
+        let Some(caps) = label_re.captures(lines[i]) else {
             i += 1;
             continue;
         };
@@ -287,7 +441,7 @@ fn imaging_impression(text: &str) -> Option<String> {
                 j += 1;
                 continue;
             }
-            if imaging_label_re().is_match(lines[j]) || is_impression_terminator(t) {
+            if label_re.is_match(lines[j]) || is_impression_terminator(t) {
                 break;
             }
             parts.push(t.to_string());
@@ -295,7 +449,7 @@ fn imaging_impression(text: &str) -> Option<String> {
         }
         let block = parts.join("\n").trim().to_string();
         if !block.is_empty() {
-            if is_impression_label(label) {
+            if is_impression(label) {
                 impression.get_or_insert(block);
             } else {
                 findings.get_or_insert(block);
@@ -403,17 +557,19 @@ pub fn assemble_summary(docs: &[SourceDoc<'_>]) -> Value {
     // the leftovers fall into the synthetic「其他」bucket instead of vanishing.
     let mut placed_labs = vec![false; agg.labs.len()];
     let mut placed_meds = vec![false; agg.meds.len()];
-    // Grouped-and-abnormal series (with ≥2 points) feed notable_changes.
-    let mut changes_pool: Vec<&AnalyteSeries> = Vec::new();
+    // Indices (into agg.labs) of grouped-and-abnormal series with ≥2 points; a
+    // BTreeSet dedups a series that maps to several problems (quality dim 5).
+    let mut changed: BTreeSet<usize> = BTreeSet::new();
 
     let mut problems: Vec<Value> = Vec::new();
-    // agg.conditions is already sorted by (onset, raw_text) — deterministic.
-    for c in &agg.conditions {
+    // Merge same-problem variants first (quality dim 2), then attach labs/meds by
+    // the mapped disease of the (clean) display term.
+    for c in merge_conditions(&agg.conditions) {
         let mut labs_json = Vec::new();
         let mut meds_json = Vec::new();
         let mut warn = false;
 
-        if let Some(disease) = match_disease(&c.raw_text) {
+        if let Some(disease) = match_disease(&c.term) {
             let entry = entry_for(disease).expect("matched disease is in the map");
             let loincs: BTreeSet<&str> = entry.labs.iter().map(|l| l.loinc.as_str()).collect();
             let prefixes: Vec<&str> = entry
@@ -427,7 +583,7 @@ pub fn assemble_summary(docs: &[SourceDoc<'_>]) -> Value {
                     placed_labs[i] = true;
                     warn |= s.any_abnormal;
                     if s.any_abnormal && s.points.len() >= 2 {
-                        changes_pool.push(s);
+                        changed.insert(i);
                     }
                     labs_json.push(series_to_json(s));
                 }
@@ -444,7 +600,7 @@ pub fn assemble_summary(docs: &[SourceDoc<'_>]) -> Value {
         }
 
         let mut prob = Map::new();
-        prob.insert("term".into(), json!(c.raw_text));
+        prob.insert("term".into(), json!(c.term));
         if let Some(onset) = c.onset {
             prob.insert("onset".into(), json!(onset.format("%Y-%m").to_string()));
         }
@@ -484,15 +640,24 @@ pub fn assemble_summary(docs: &[SourceDoc<'_>]) -> Value {
         }));
     }
 
-    // ── notable_changes: short "指标 first→last unit" for abnormal trends ──
-    // Deterministic: changes_pool follows agg.labs order (sorted by group_name);
-    // cap at 4 to keep it a glance, not a dump.
-    let notable_changes: Vec<String> = changes_pool
+    // ── notable_changes: short "指标 first→last unit" for the abnormal trends that
+    // matter most. Deduped by series (changed is a set) and ranked by clinical
+    // significance — a normal↔abnormal threshold crossing first (LDL 他汀达标↓,
+    // 肌酐↑, 尿酸达标↓), then by fractional change magnitude — so the real story
+    // surfaces instead of the smallest wiggle. Cap at 4 (quality dim 5).
+    let mut ranked: Vec<&AnalyteSeries> = changed.iter().map(|&i| &agg.labs[i]).collect();
+    ranked.sort_by(|a, b| {
+        let (ca, fa) = change_significance(a);
+        let (cb, fb) = change_significance(b);
+        cb.cmp(&ca)
+            .then(fb.total_cmp(&fa))
+            .then(a.group_name.cmp(&b.group_name))
+    });
+    let notable_changes: Vec<String> = ranked
         .iter()
         .take(4)
         .filter_map(|s| {
-            let first = s.points.first()?;
-            let last = s.points.last()?;
+            let (first, last) = first_last_point(s)?;
             let unit = last.unit.clone().unwrap_or_default();
             Some(format!(
                 "{} {}→{}{}",
@@ -558,14 +723,49 @@ pub fn assemble_summary(docs: &[SourceDoc<'_>]) -> Value {
         })
         .collect();
 
+    // ── pathology: each 病理 report's verbatim conclusion, never split into
+    // problems (quality dim 6). Qualify ONLY on doc_type == pathology (same
+    // discipline as imaging); the narrative is copied, not interpreted.
+    let mut pathology: Vec<(Option<NaiveDate>, Value)> = Vec::new();
+    for doc in docs {
+        let is_path = doc
+            .doc_type
+            .as_deref()
+            .is_some_and(|t| t.contains("pathology"));
+        if !is_path {
+            continue;
+        }
+        let Some(conclusion) = pathology_impression(doc.text) else {
+            continue;
+        };
+        pathology.push((
+            doc.date,
+            json!({
+                "date": doc.date.map(|d| d.format("%Y-%m").to_string()),
+                "conclusion": conclusion,
+                "evidence": [doc.index],
+            }),
+        ));
+    }
+    pathology.sort_by(|a, b| match (a.0, b.0) {
+        (Some(x), Some(y)) => x.cmp(&y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+    let pathology: Vec<Value> = pathology.into_iter().map(|(_, v)| v).collect();
+
     let mut summary = json!({
         "problems": problems,
         "allergies": allergies,
         "notable_changes": notable_changes,
     });
-    // Attach imaging only when present (老分享/无影像 keeps the key absent).
+    // Attach imaging/pathology only when present (老分享/无 keeps the key absent).
     if !imaging.is_empty() {
         summary["imaging"] = json!(imaging);
+    }
+    if !pathology.is_empty() {
+        summary["pathology"] = json!(pathology);
     }
     summary
 }
@@ -815,6 +1015,47 @@ mod tests {
         assert_eq!(studies[1]["date"], "2025-01");
         assert_eq!(studies[1]["finding"], "右肺上叶小结节,较前稳定。");
         assert_eq!(studies[1]["evidence"], json!([1]));
+    }
+
+    #[test]
+    fn assemble_summary_surfaces_pathology_conclusion_not_as_problems() {
+        // 真 corpus doc11 的病理叙事:过去被逗号拆成 3 条假「诊断」。现在整段作为一条
+        // pathology 结论浮出,且绝不进 problems(quality dim 6)。
+        let docs = vec![SourceDoc {
+            index: 11,
+            doc_type: Some("pathology".into()),
+            title: Some("胃镜活检病理".into()),
+            date: d(2024, 9, 1),
+            text: "病理诊断:(胃窦)慢性活动性胃炎,伴轻度肠上皮化生,Hp阳性(++)。未见异型增生及恶性证据。",
+        }];
+        let sm = assemble_summary(&docs);
+        assert!(
+            sm["problems"].as_array().expect("problems").is_empty(),
+            "病理叙事绝不进 problems"
+        );
+        let path = sm["pathology"].as_array().expect("pathology present");
+        assert_eq!(path.len(), 1);
+        assert_eq!(path[0]["date"], "2024-09");
+        assert_eq!(
+            path[0]["conclusion"],
+            "(胃窦)慢性活动性胃炎,伴轻度肠上皮化生,Hp阳性(++)。未见异型增生及恶性证据。"
+        );
+        assert_eq!(path[0]["evidence"], json!([11]));
+    }
+
+    #[test]
+    fn assemble_summary_omits_pathology_when_none() {
+        let docs = vec![SourceDoc {
+            index: 0,
+            doc_type: Some("lab_report".into()),
+            title: Some("血常规".into()),
+            date: d(2024, 1, 1),
+            text: "白细胞 10.5",
+        }];
+        assert!(
+            assemble_summary(&docs).get("pathology").is_none(),
+            "no pathology key when empty"
+        );
     }
 
     #[test]

--- a/packages/parser/src/handoff.rs
+++ b/packages/parser/src/handoff.rs
@@ -125,8 +125,8 @@ struct MergedProblem {
 /// summary stays deterministic.
 fn merge_conditions(conditions: &[AggregatedCondition]) -> Vec<MergedProblem> {
     // key → (candidate display terms, earliest onset, merged sources)
-    let mut groups: BTreeMap<String, (Vec<String>, Option<NaiveDate>, BTreeSet<usize>)> =
-        BTreeMap::new();
+    type Group = (Vec<String>, Option<NaiveDate>, BTreeSet<usize>);
+    let mut groups: BTreeMap<String, Group> = BTreeMap::new();
     for c in conditions {
         let key = condition_key(&c.raw_text);
         let g = groups.entry(key).or_default();

--- a/packages/parser/src/labs.rs
+++ b/packages/parser/src/labs.rs
@@ -65,17 +65,32 @@ fn row_re() -> &'static Regex {
     })
 }
 
+// Reference-range regexes match ANYWHERE in the trailing columns (not anchored),
+// and tolerate spaces around the comparator/dash. 真 corpus 把参考写成带空格的
+// `< 5.20`、`> 90`、`3.9 - 6.1` —— 逐 token 分类会把 `<` 和 `5.20` 拆成两个各自作废
+// 的 token,单边参考(LDL/TC/eGFR)与带空格的双边参考就全丢了(quality dim 4/5)。
 fn range_two_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
-    R.get_or_init(|| Regex::new(r"^(\d+(?:\.\d+)?)[-~](\d+(?:\.\d+)?)$").expect("range re"))
+    R.get_or_init(|| {
+        Regex::new(r"(\d+(?:\.\d+)?)\s*[-~]\s*(\d+(?:\.\d+)?)").expect("range re")
+    })
 }
 fn range_high_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
-    R.get_or_init(|| Regex::new(r"^[<≤]=?(\d+(?:\.\d+)?)$").expect("high re"))
+    R.get_or_init(|| Regex::new(r"[<≤]=?\s*(\d+(?:\.\d+)?)").expect("high re"))
 }
 fn range_low_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
-    R.get_or_init(|| Regex::new(r"^[>≥]=?(\d+(?:\.\d+)?)$").expect("low re"))
+    R.get_or_init(|| Regex::new(r"[>≥]=?\s*(\d+(?:\.\d+)?)").expect("low re"))
+}
+/// A dash-separated `YYYY-MM-DD` date. Only the dash form matters: the range regex
+/// keys on `[-~]`, so slash/dot dates never look like a range in the first place.
+/// A real reference range has a single dash (`3.9-6.1`); a date has two — so this
+/// blanks a trailing 采样/报告日期 (`… 2024-01-05`) without ever eating a range,
+/// stopping it from being misread as `2024-1` and fabricating a flag. Quality dim 4/5.
+fn date_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\d{2,4}-\d{1,2}-\d{1,2}").expect("date re"))
 }
 
 /// Fold the full-width comparison/range punctuation a report might use into the
@@ -92,30 +107,50 @@ fn fold_range_punct(tok: &str) -> String {
         .collect()
 }
 
-/// Parse one token as a reference range. Returns `(low, high)`:
-/// `59-104` → (Some, Some); `<6.5`/`≤6.5` → (None, Some); `>130`/`≥130` → (Some, None).
-/// Returns `None` when the token is not a range at all.
-fn parse_range(tok: &str) -> Option<(Option<f64>, Option<f64>)> {
-    let s = fold_range_punct(tok);
-    if let Some(c) = range_two_re().captures(&s) {
-        let lo = c.get(1)?.as_str().parse().ok()?;
-        let hi = c.get(2)?.as_str().parse().ok()?;
-        return Some((Some(lo), Some(hi)));
+/// Locate the reference range anywhere in the trailing columns. Returns
+/// `(low, high, byte_span_in_folded)`: `59-104`/`3.9 - 6.1` → both bounds;
+/// `< 5.20`/`≤6.5` → high only; `> 90`/`≥130` → low only. Two-sided wins over
+/// single-sided. `None` when no range is present. `folded` must already be
+/// punctuation-folded so `＜`/`～`/`－` read as `<`/`~`/`-`.
+fn find_range(folded: &str) -> Option<(Option<f64>, Option<f64>, (usize, usize))> {
+    if let Some(c) = range_two_re().captures(folded) {
+        let lo = c.get(1)?.as_str().parse().ok();
+        let hi = c.get(2)?.as_str().parse().ok();
+        let m = c.get(0)?;
+        return Some((lo, hi, (m.start(), m.end())));
     }
-    if let Some(c) = range_high_re().captures(&s) {
-        return Some((None, Some(c.get(1)?.as_str().parse().ok()?)));
+    if let Some(c) = range_high_re().captures(folded) {
+        let hi = c.get(1)?.as_str().parse().ok();
+        let m = c.get(0)?;
+        return Some((None, hi, (m.start(), m.end())));
     }
-    if let Some(c) = range_low_re().captures(&s) {
-        return Some((Some(c.get(1)?.as_str().parse().ok()?), None));
+    if let Some(c) = range_low_re().captures(folded) {
+        let lo = c.get(1)?.as_str().parse().ok();
+        let m = c.get(0)?;
+        return Some((lo, None, (m.start(), m.end())));
     }
     None
 }
 
-/// Parse the trailing `单位 参考范围 [↑/↓]` columns. Order-independent: every
-/// whitespace token is classified as flag / range / unit / (ignored label).
+/// Parse the trailing `单位 参考范围 [↑/↓]` columns. The reference range is matched
+/// on the whole (punctuation-folded) string first — so a spaced `< 5.20` or
+/// `3.9 - 6.1` parses as one range — then blanked out; unit and flag are read from
+/// what remains, order-independently.
 fn parse_rest(rest: &str) -> (Option<String>, Option<f64>, Option<f64>, Option<String>) {
-    let (mut unit, mut low, mut high, mut flag) = (None, None, None, None);
-    for raw in rest.split_whitespace() {
+    let folded = fold_range_punct(rest);
+    // Blank any embedded date so the unanchored range scan can't read it as a range.
+    let folded = date_re().replace_all(&folded, " ").into_owned();
+    let (mut low, mut high) = (None, None);
+    let mut scan = folded.clone();
+    if let Some((lo, hi, (s, e))) = find_range(&folded) {
+        low = lo;
+        high = hi;
+        // Blank the range so its digits can't be re-read as a unit token.
+        scan.replace_range(s..e, " ");
+    }
+
+    let (mut unit, mut flag) = (None, None);
+    for raw in scan.split_whitespace() {
         let tok =
             raw.trim_matches(|c| matches!(c, '(' | ')' | '（' | '）' | '[' | ']' | '【' | '】'));
         if tok.is_empty() {
@@ -128,15 +163,6 @@ fn parse_rest(rest: &str) -> (Option<String>, Option<f64>, Option<f64>, Option<S
         }
         if raw.contains('↓') || tok == "L" || tok == "低" || tok == "偏低" {
             flag = Some("L".to_string());
-            continue;
-        }
-        if let Some((lo, hi)) = parse_range(tok) {
-            if lo.is_some() {
-                low = lo;
-            }
-            if hi.is_some() {
-                high = hi;
-            }
             continue;
         }
         // Label noise inside inline `(参考 …)` / `正常范围` etc.
@@ -166,6 +192,15 @@ pub fn extract_labs(text: &str) -> Vec<LabObservation> {
         let raw_name = caps.name("name").expect("name group").as_str().trim();
         // Need a real name token — rejects date/number-only lines.
         if raw_name.is_empty() || !raw_name.chars().any(|c| c.is_alphabetic()) {
+            continue;
+        }
+        // A real analyte name has no *sentence* punctuation. This rejects narrative
+        // fragments that a mis-routed prose/imaging line would otherwise smuggle in
+        // as a "lab" (`右肺上叶尖段磨玻璃结节(GGN),大小约` value 8 …) — quality dim 3.
+        if raw_name
+            .chars()
+            .any(|c| matches!(c, '，' | ',' | '。' | '；' | ';' | '、'))
+        {
             continue;
         }
         let Ok(value_num) = caps
@@ -277,6 +312,46 @@ mod tests {
         assert_eq!(ldl.ref_high, Some(3.4));
         assert_eq!(ldl.ref_low, None);
         assert_eq!(ldl.flag.as_deref(), Some("H"));
+    }
+
+    #[test]
+    fn spaced_single_sided_and_two_sided_refs_parse() {
+        // 真 corpus 的写法:单边参考带空格 `< 5.20` / `> 90`,双边参考带空格 `3.9 - 6.1`。
+        // 过去逐 token 分类把它们拆碎全丢;现在都要解析出 refLow/refHigh。
+        let text = "\
+TC         总胆固醇 Cholesterol   6.05     mmol/L      < 5.20          ↑
+eGFR       估算肾小球滤过率      72       ml/min/1.73m2   > 90         ↓
+GLU        空腹血糖 Glucose       7.1      mmol/L      3.9 - 6.1       ↑
+";
+        let obs = extract_labs(text);
+        let tc = find(&obs, "cholesterol");
+        assert_eq!(tc.ref_high, Some(5.20));
+        assert_eq!(tc.ref_low, None);
+        assert_eq!(tc.unit_raw.as_deref(), Some("mmol/L"));
+        assert_eq!(tc.flag.as_deref(), Some("H"));
+        let egfr = find(&obs, "egfr");
+        assert_eq!(egfr.ref_low, Some(90.0));
+        assert_eq!(egfr.ref_high, None);
+        assert_eq!(egfr.flag.as_deref(), Some("L"));
+        let glu = find(&obs, "glucose");
+        assert_eq!(glu.ref_low, Some(3.9));
+        assert_eq!(glu.ref_high, Some(6.1));
+    }
+
+    #[test]
+    fn trailing_report_date_is_not_read_as_a_reference_range() {
+        // 行尾的采样/报告日期(`2024-01-05`)不得被无锚点的范围扫描当成参考范围
+        // `2024-1`,否则会伪造 refLow/refHigh 并派生出假异常 flag。
+        let obs = extract_labs("葡萄糖 Glucose 5.0 mmol/L 2024-01-05");
+        let glu = find(&obs, "glucose");
+        assert_eq!(glu.ref_low, None);
+        assert_eq!(glu.ref_high, None);
+        assert_eq!(glu.flag, None);
+        // 真参考范围与行尾日期并存时,仍解析出参考范围,且不被日期污染。
+        let obs2 = extract_labs("葡萄糖 Glucose 7.1 mmol/L 3.9 - 6.1 ↑ 2024-01-05");
+        let glu2 = find(&obs2, "glucose");
+        assert_eq!(glu2.ref_low, Some(3.9));
+        assert_eq!(glu2.ref_high, Some(6.1));
     }
 
     #[test]

--- a/packages/parser/src/labs.rs
+++ b/packages/parser/src/labs.rs
@@ -71,9 +71,7 @@ fn row_re() -> &'static Regex {
 // 的 token,单边参考(LDL/TC/eGFR)与带空格的双边参考就全丢了(quality dim 4/5)。
 fn range_two_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
-    R.get_or_init(|| {
-        Regex::new(r"(\d+(?:\.\d+)?)\s*[-~]\s*(\d+(?:\.\d+)?)").expect("range re")
-    })
+    R.get_or_init(|| Regex::new(r"(\d+(?:\.\d+)?)\s*[-~]\s*(\d+(?:\.\d+)?)").expect("range re"))
 }
 fn range_high_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();

--- a/packages/parser/src/labs.rs
+++ b/packages/parser/src/labs.rs
@@ -105,12 +105,15 @@ fn fold_range_punct(tok: &str) -> String {
         .collect()
 }
 
+/// A located reference range: `(low, high, byte_span_in_folded)`.
+type RangeMatch = (Option<f64>, Option<f64>, (usize, usize));
+
 /// Locate the reference range anywhere in the trailing columns. Returns
 /// `(low, high, byte_span_in_folded)`: `59-104`/`3.9 - 6.1` → both bounds;
 /// `< 5.20`/`≤6.5` → high only; `> 90`/`≥130` → low only. Two-sided wins over
 /// single-sided. `None` when no range is present. `folded` must already be
 /// punctuation-folded so `＜`/`～`/`－` read as `<`/`~`/`-`.
-fn find_range(folded: &str) -> Option<(Option<f64>, Option<f64>, (usize, usize))> {
+fn find_range(folded: &str) -> Option<RangeMatch> {
     if let Some(c) = range_two_re().captures(folded) {
         let lo = c.get(1)?.as_str().parse().ok();
         let hi = c.get(2)?.as_str().parse().ok();

--- a/packages/parser/src/meds.rs
+++ b/packages/parser/src/meds.rs
@@ -141,8 +141,15 @@ fn normalize_dose_unit(u: &str) -> String {
 fn parse_dose(line: &str) -> Option<(f64, String, usize)> {
     for caps in dose_re().captures_iter(line) {
         let whole = caps.get(0)?;
-        if line[whole.end()..].starts_with('/') {
+        let after = &line[whole.end()..];
+        if after.starts_with('/') {
             continue; // 浓度单位(g/L、mg/L…),不是剂量
+        }
+        // 单位后紧跟字母 = 这个「单位」其实是更长词的前缀,不是剂量:化验行
+        // `肌酐 112 umol/L` 的 `112 u`(u 属于 umol)绝不能当成 112U 的剂量,否则化验
+        // 会漏进「用药」(quality dim 3/4)。
+        if after.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            continue;
         }
         let num: f64 = caps.get(1)?.as_str().parse().ok()?;
         let unit = normalize_dose_unit(caps.get(2)?.as_str());
@@ -212,6 +219,21 @@ pub fn extract_meds(text: &str) -> Vec<MedObservation> {
         let name = strip_trailing_route(&cleaned[..name_end]);
         // Need a real name token (a letter or CJK char), else it's not a med line.
         if name.is_empty() || !name.chars().any(|c| c.is_alphabetic()) {
+            continue;
+        }
+        // 处方里的「剂量/用法说明行」不是药,却常带 dose+freq,过去被当未知药留下污染
+        // 「用药」(quality dim 3):
+        //  - `用法:口服,一次 1 片(0.5g),一日 2 次` → 名字含整句标点(:,,) → 弃。
+        //  - `一次1片 一日2次 随餐`(处方续行)→ 名字以说明词起头(一次/每次/用法…) → 弃。
+        // 真药名既不含整句标点,也不会以这些说明词开头。
+        if name
+            .chars()
+            .any(|c| matches!(c, '，' | ',' | '。' | '；' | ';' | '、' | '：' | ':'))
+        {
+            continue;
+        }
+        const USAGE_PREFIXES: &[&str] = &["用法", "用量", "一次", "每次", "服法", "Sig", "sig"];
+        if USAGE_PREFIXES.iter().any(|p| name.starts_with(p)) {
             continue;
         }
 
@@ -303,6 +325,23 @@ mod tests {
         assert_eq!(o.confidence, 0.0);
         assert_eq!(o.dose_num, Some(5.0));
         assert_eq!(o.frequency.as_deref(), Some("bid"));
+    }
+
+    #[test]
+    fn lab_umol_row_and_usage_lines_are_not_meds() {
+        // 化验行:`112 umol/L` 的 u 属于 umol,不得当成 112U 的剂量 → 不是药。
+        assert!(extract_meds("肌酐 Creatinine 112 umol/L 57 - 97").is_empty());
+        assert!(extract_meds("尿酸 UA 405 umol/L 208 - 428").is_empty());
+        // 处方说明/续行:虽带 dose+freq,但名字是说明词/整句碎片 → 不是药。
+        assert!(extract_meds("用法:口服,一次 1 片,一日 2 次(餐后)").is_empty());
+        assert!(extract_meds("  一次1片 一日2次 随餐").is_empty());
+        // 真处方行仍正常解析。
+        assert_eq!(
+            extract_meds("1.盐酸二甲双胍缓释片 0.5g×60片")[0]
+                .drug_key
+                .as_deref(),
+            Some("metformin")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 做什么

对真实多文档保险箱跑真管线 `parser::assemble_summary` 时产出的严重失真做**规则层止血**,按 #141 定义的 7 维质量标准逐条修完 6 个缺陷。

| 缺陷 | 修复 | 文件 |
|---|---|---|
| 1 诊断保真 | 行内编号(` 2.` ` 3.`)先切分再走标点;编号点后要求空格,避免误切小数 `1.2cm` | conditions.rs |
| 2 去重/归一 | `merge_conditions` 折叠同病变体,取最早 onset、合并证据、显示取最短 term | handoff.rs |
| 3 病理归位 | 移除 `病理诊断` label(不再逗号拆假诊断);接线 `pathology_impression`,整段结论作 `pathology[]` 浮出,不进 problems | conditions.rs / handoff.rs |
| 4 labs/meds 串味 | 按 `doc_type` 路由(labs 仅 lab_report、meds 仅 prescription)+ 行级 guard(整句标点名、umol 前缀剂量、说明词行) | aggregate.rs / labs.rs / meds.rs |
| 5 参考值 | 范围正则去锚点容空格,单边 `< 5.20` / `> 90` 与带空格双边 `3.9 - 6.1` 都解析;抹掉横杠日期避免行尾日期伪造异常 | labs.rs |
| 6 趋势 | `notable_changes` 按 series 去重 + 按跨阈/幅度排序再 take(4) | handoff.rs |

## 测试

parser 55 个通过(本次 +4 回归)。库层全绿(core-model / terminology / pipeline / share)。

## 定位:这是止血,不是长久答案

本 PR 是**规则层止血**,让当前 demo 达标。规则法对任意真实排版是结构性脆弱的——对抗性验证显示,同样三个诊断换 `①②③` / `一、二、` / `(1)(2)` / 无标签散文等排版,6 种里 5 种崩。诊断层对真实病历的鲁棒性由后续 NER 方案处理(见跟进 issue)。

## 评审

经 code-reviewer 评审,修掉两处评审发现的真 bug(行尾日期被当参考范围、编号切分误伤小数),均带回归测试。
