### PR TITLE
feat(qr): 阶段一端到端 —— 手机出码、医生扫码看当下病情

### DIFF
--- a/apps/mobile_flutter/lib/screens/export_screen.dart
+++ b/apps/mobile_flutter/lib/screens/export_screen.dart
@@ -6,6 +6,8 @@ import 'package:mobile_flutter/src/rust/api/dto.dart';
 import 'package:mobile_flutter/src/rust/api/vault.dart';
 import 'package:mobile_flutter/theme.dart';
 
+import 'qr_share_screen.dart';
+
 /// 底部导航一级 tab「导出·分享」—— 把病历导出成可打印文件(可按日期区间筛选),或
 /// 端到端加密分享给医生。手机端只做「轻」的导出/筛选;全文搜索、趋势等「重」功能在
 /// 桌面端与医生查看器。导出/加密全在 Rust core(`medme_share`),这里只调 FFI + 分享。
@@ -346,6 +348,22 @@ class _ExportScreenState extends State<ExportScreen> {
           ListView(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
             children: [
+              // 门诊现场最高频的一步放最前:医生扫码,三十秒看懂当下病情。
+              _ActionCard(
+                icon: Icons.qr_code_2,
+                title: '当面给医生看',
+                subtitle: '生成二维码,医生用自己手机扫一下就能看到在治疾病、'
+                    '关键指标趋势与在用药物。不含原件,需要时你再当场翻给他。',
+                buttonLabel: '出示二维码',
+                onPressed: _busy
+                    ? null
+                    : () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const QrShareScreen(),
+                        ),
+                      ),
+              ),
+              const SizedBox(height: 14),
               _ActionCard(
                 icon: Icons.description_outlined,
                 title: '导出时间线',

--- a/apps/mobile_flutter/lib/screens/qr_share_screen.dart
+++ b/apps/mobile_flutter/lib/screens/qr_share_screen.dart
@@ -1,0 +1,178 @@
+// 面对面二维码分享:门诊里把手机递给医生扫,三十秒看懂当下病情。
+//
+// 与「加密分享文件」的分工:那个是整份病历(含原件、影像,医生带走);这个是
+// **当下病情** —— 在治的病、关键指标最近几个点、在用的药。要看原件或阅片,
+// 患者手机当场翻,不必把整份病历交出去。
+//
+// 载荷有界(Rust 侧 QrLimits),体积与病历总量无关,永远塞得进一张码。密钥在
+// URL 的 `#` 之后,按 HTTP 规范不会发给服务器 —— 医生扫码后只从静态页下载一个
+// 空壳查看器,病历数据全程只在两台手机之间。
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+import '../src/rust/api/dto.dart';
+import '../src/rust/api/vault.dart';
+import '../theme.dart';
+
+/// 医生扫码后打开的查看器地址。数据在 `#` 之后,不会随请求上行。
+const _viewerBase = 'https://chesterguan.github.io/medme/viewer/';
+
+class QrShareScreen extends StatefulWidget {
+  const QrShareScreen({super.key});
+
+  @override
+  State<QrShareScreen> createState() => _QrShareScreenState();
+}
+
+class _QrShareScreenState extends State<QrShareScreen> {
+  QrShareDto? _share;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _generate();
+  }
+
+  Future<void> _generate() async {
+    try {
+      final s = await buildQrShareUrl(baseUrl: _viewerBase);
+      if (mounted) setState(() => _share = s);
+    } catch (e) {
+      if (mounted) setState(() => _error = '$e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('给医生看'),
+        backgroundColor: Colors.white,
+        surfaceTintColor: Colors.transparent,
+      ),
+      body: SafeArea(child: Center(child: _body())),
+    );
+  }
+
+  Widget _body() {
+    if (_error != null) {
+      return Padding(
+        padding: const EdgeInsets.all(28),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 40, color: MedMe.danger),
+            const SizedBox(height: 12),
+            const Text('生成失败', style: TextStyle(fontWeight: FontWeight.w700)),
+            const SizedBox(height: 8),
+            Text(
+              _error!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 13, color: MedMe.faint),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: _generate, child: const Text('重试')),
+          ],
+        ),
+      );
+    }
+    final s = _share;
+    if (s == null) {
+      return const Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(),
+          SizedBox(height: 14),
+          Text('正在整理当下病情…', style: TextStyle(color: MedMe.faint, fontSize: 13)),
+        ],
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 28),
+      child: Column(
+        children: [
+          const Text(
+            '请医生扫这个码',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '把屏幕亮度调高,对着医生的手机相机',
+            style: TextStyle(fontSize: 13.5, color: MedMe.faint),
+          ),
+          const SizedBox(height: 20),
+          // 白底 + 留白是二维码可扫性的硬要求,别加装饰。
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: MedMe.line),
+            ),
+            child: QrImageView(
+              data: s.url,
+              version: QrVersions.auto,
+              size: 280,
+              backgroundColor: Colors.white,
+              // 医生隔着距离扫,纠错等级留高一点更容易扫上。
+              errorCorrectionLevel: QrErrorCorrectLevel.M,
+            ),
+          ),
+          const SizedBox(height: 18),
+          _summaryChip(s),
+          const SizedBox(height: 20),
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: MedMe.tealSoft,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '医生看到的是什么',
+                  style: TextStyle(fontWeight: FontWeight.w700, fontSize: 13.5),
+                ),
+                SizedBox(height: 6),
+                Text(
+                  '在治的疾病、关键化验的近期趋势、正在吃的药。'
+                  '不含原件、影像和更早的记录 —— 那些需要时你在自己手机上给他看。',
+                  style: TextStyle(fontSize: 12.5, height: 1.6, color: MedMe.ink),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  '这张码就是钥匙:被拍下就等于把这份摘要给了对方,'
+                  '看完收起手机即可,不必额外「撤回」。',
+                  style: TextStyle(fontSize: 12.5, height: 1.6, color: MedMe.faint),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _summaryChip(QrShareDto s) {
+    final text = s.problemCount > 0
+        ? '本码含 ${s.problemCount} 个在治问题'
+        : '暂未识别到在治问题,医生仍可看到用药与近期变化';
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Icon(Icons.lock_outline, size: 15, color: MedMe.faint),
+        const SizedBox(width: 6),
+        Flexible(
+          child: Text(
+            text,
+            style: const TextStyle(fontSize: 12.5, color: MedMe.faint),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile_flutter/lib/src/rust/api/dto.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/dto.dart
@@ -9,7 +9,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'dto.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `from_encounter`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
 
 /// 文档详情:类型/日期(在 document 里)+ 来源文件 + 识别文本。
 class DocumentDetailDto {
@@ -266,6 +266,32 @@ class PatientProfileDto {
           birthDate == other.birthDate &&
           age == other.age &&
           recordCount == other.recordCount;
+}
+
+/// 二维码分享结果:一条可直接编码成二维码的 URL、带上的疾病数、以及是否仍在
+/// 二维码容量内(按构造裁剪后应恒为 true,留作兜底提示)。
+class QrShareDto {
+  final String url;
+  final PlatformInt64 problemCount;
+  final bool fitsQr;
+
+  const QrShareDto({
+    required this.url,
+    required this.problemCount,
+    required this.fitsQr,
+  });
+
+  @override
+  int get hashCode => url.hashCode ^ problemCount.hashCode ^ fitsQr.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QrShareDto &&
+          runtimeType == other.runtimeType &&
+          url == other.url &&
+          problemCount == other.problemCount &&
+          fitsQr == other.fitsQr;
 }
 
 /// 加密分享生成结果:口令(单独告知医生)、记录数、文件字节数、分享文件路径。

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -129,6 +129,18 @@ Future<ImportOutcomeDto> ingestImageWithText({
 );
 
 /// 端到端加密分享:复用 `medme_share::share::build_encrypted_share`,把全部病历
+/// 面对面二维码分享:把「当下病情」压成一条 URL,由手机端渲染成二维码给医生扫。
+///
+/// 与 [`create_share`] 的分工:那个是**整份病历**(含原件、影像,给医生带走);
+/// 这个是**当下病情**(在治的病、关键指标最近几个点、在用的药),只够医生三十秒
+/// 看懂大局 —— 要看原件或阅片,患者手机当场翻。
+///
+/// 载荷有界(见 `medme_share::qr::QrLimits`),因此体积与病历总量无关,永远塞得进
+/// 一张二维码。密钥在 URL 的 `#` 之后,按 HTTP 规范不会发给服务器 —— 医生扫码后
+/// 只从我们的静态页下载一个空壳查看器,病历数据全程只在两台手机之间。
+Future<QrShareDto> buildQrShareUrl({required String baseUrl}) =>
+    RustLib.instance.api.crateApiVaultBuildQrShareUrl(baseUrl: baseUrl);
+
 /// 打包成自包含加密 HTML 写进保险箱 `shares/` 目录,返回口令、记录数、字节数与
 /// 文件路径。与桌面/Tauri 移动端同构;安全性说明见 `render_dicom_png` 的 doc
 /// (进程内 DICOM 渲染在移动端是安全的,`codecs` 特性已关)。

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 752330286;
+  int get rustContentHash => 1649105849;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -84,6 +84,8 @@ abstract class RustLibApi extends BaseApi {
     required String text,
     required double confidence,
   });
+
+  Future<QrShareDto> crateApiVaultBuildQrShareUrl({required String baseUrl});
 
   Future<ShareResultDto> crateApiVaultCreateShare({
     required PlatformInt64 expiresDays,
@@ -189,6 +191,37 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<QrShareDto> crateApiVaultBuildQrShareUrl({required String baseUrl}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(baseUrl, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_qr_share_dto,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiVaultBuildQrShareUrlConstMeta,
+        argValues: [baseUrl],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVaultBuildQrShareUrlConstMeta =>
+      const TaskConstMeta(
+        debugName: "build_qr_share_url",
+        argNames: ["baseUrl"],
+      );
+
+  @override
   Future<ShareResultDto> crateApiVaultCreateShare({
     required PlatformInt64 expiresDays,
   }) {
@@ -200,7 +233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -230,7 +263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -260,7 +293,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -288,7 +321,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -323,7 +356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -356,7 +389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -383,7 +416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -415,7 +448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -445,7 +478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -481,7 +514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -511,7 +544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -538,7 +571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -565,7 +598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -599,7 +632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -628,7 +661,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -656,7 +689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -684,7 +717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -711,7 +744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -741,7 +774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -987,6 +1020,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       birthDate: dco_decode_opt_String(arr[2]),
       age: dco_decode_opt_String(arr[3]),
       recordCount: dco_decode_i_64(arr[4]),
+    );
+  }
+
+  @protected
+  QrShareDto dco_decode_qr_share_dto(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return QrShareDto(
+      url: dco_decode_String(arr[0]),
+      problemCount: dco_decode_i_64(arr[1]),
+      fitsQr: dco_decode_bool(arr[2]),
     );
   }
 
@@ -1340,6 +1386,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  QrShareDto sse_decode_qr_share_dto(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_url = sse_decode_String(deserializer);
+    var var_problemCount = sse_decode_i_64(deserializer);
+    var var_fitsQr = sse_decode_bool(deserializer);
+    return QrShareDto(
+      url: var_url,
+      problemCount: var_problemCount,
+      fitsQr: var_fitsQr,
+    );
+  }
+
+  @protected
   ShareResultDto sse_decode_share_result_dto(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_passphrase = sse_decode_String(deserializer);
@@ -1670,6 +1729,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.birthDate, serializer);
     sse_encode_opt_String(self.age, serializer);
     sse_encode_i_64(self.recordCount, serializer);
+  }
+
+  @protected
+  void sse_encode_qr_share_dto(QrShareDto self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.url, serializer);
+    sse_encode_i_64(self.problemCount, serializer);
+    sse_encode_bool(self.fitsQr, serializer);
   }
 
   @protected

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
@@ -101,6 +101,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
 
   @protected
+  QrShareDto dco_decode_qr_share_dto(dynamic raw);
+
+  @protected
   ShareResultDto dco_decode_share_result_dto(dynamic raw);
 
   @protected
@@ -211,6 +214,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PatientProfileDto sse_decode_patient_profile_dto(
     SseDeserializer deserializer,
   );
+
+  @protected
+  QrShareDto sse_decode_qr_share_dto(SseDeserializer deserializer);
 
   @protected
   ShareResultDto sse_decode_share_result_dto(SseDeserializer deserializer);
@@ -354,6 +360,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     PatientProfileDto self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_qr_share_dto(QrShareDto self, SseSerializer serializer);
 
   @protected
   void sse_encode_share_result_dto(

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
@@ -103,6 +103,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
 
   @protected
+  QrShareDto dco_decode_qr_share_dto(dynamic raw);
+
+  @protected
   ShareResultDto dco_decode_share_result_dto(dynamic raw);
 
   @protected
@@ -213,6 +216,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PatientProfileDto sse_decode_patient_profile_dto(
     SseDeserializer deserializer,
   );
+
+  @protected
+  QrShareDto sse_decode_qr_share_dto(SseDeserializer deserializer);
 
   @protected
   ShareResultDto sse_decode_share_result_dto(SseDeserializer deserializer);
@@ -356,6 +362,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     PatientProfileDto self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_qr_share_dto(QrShareDto self, SseSerializer serializer);
 
   @protected
   void sse_encode_share_result_dto(

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -796,6 +796,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   record_use:
     dependency: transitive
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   file_picker: ^8.0.0
   google_mlkit_text_recognition: ^0.16.0
   photo_view: ^0.15.0
+  # 面对面二维码分享:把「当下病情」编成码给医生扫(纯本地绘制,不联网)
+  qr_flutter: ^4.1.0
   pdfx: ^2.9.2
   share_plus: ^11.0.0
   url_launcher: ^6.3.2

--- a/apps/mobile_flutter/rust/Cargo.lock
+++ b/apps/mobile_flutter/rust/Cargo.lock
@@ -2115,6 +2115,7 @@ dependencies = [
  "chrono",
  "core-model",
  "dicom",
+ "flate2",
  "getrandom 0.4.3",
  "parser",
  "pipeline",

--- a/apps/mobile_flutter/rust/src/api/dto.rs
+++ b/apps/mobile_flutter/rust/src/api/dto.rs
@@ -139,6 +139,15 @@ pub struct ShareResultDto {
     pub path: String,
 }
 
+/// 二维码分享结果:一条可直接编码成二维码的 URL、带上的疾病数、以及是否仍在
+/// 二维码容量内(按构造裁剪后应恒为 true,留作兜底提示)。
+#[derive(Debug, Clone)]
+pub struct QrShareDto {
+    pub url: String,
+    pub problem_count: i64,
+    pub fits_qr: bool,
+}
+
 /// 时间线导出结果:未加密、可打印的自包含 HTML。与 `ShareResultDto` 不同,
 /// 没有口令——导出内容不加密,靠系统「分享」sheet 直接交给医生 / 存下来打印。
 #[derive(Debug, Clone)]

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -597,6 +597,31 @@ pub fn ingest_image_with_text(
 }
 
 /// 端到端加密分享:复用 `medme_share::share::build_encrypted_share`,把全部病历
+/// 面对面二维码分享:把「当下病情」压成一条 URL,由手机端渲染成二维码给医生扫。
+///
+/// 与 [`create_share`] 的分工:那个是**整份病历**(含原件、影像,给医生带走);
+/// 这个是**当下病情**(在治的病、关键指标最近几个点、在用的药),只够医生三十秒
+/// 看懂大局 —— 要看原件或阅片,患者手机当场翻。
+///
+/// 载荷有界(见 `medme_share::qr::QrLimits`),因此体积与病历总量无关,永远塞得进
+/// 一张二维码。密钥在 URL 的 `#` 之后,按 HTTP 规范不会发给服务器 —— 医生扫码后
+/// 只从我们的静态页下载一个空壳查看器,病历数据全程只在两台手机之间。
+pub fn build_qr_share_url(base_url: String) -> anyhow::Result<QrShareDto> {
+    with_state(|state| {
+        let (url, qr) = medme_share::qr::build_qr_share(
+            &state.vault,
+            &base_url,
+            medme_share::qr::QrLimits::default(),
+        )
+        .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(QrShareDto {
+            url,
+            problem_count: qr.problem_count as i64,
+            fits_qr: qr.fits_qr(&base_url),
+        })
+    })
+}
+
 /// 打包成自包含加密 HTML 写进保险箱 `shares/` 目录,返回口令、记录数、字节数与
 /// 文件路径。与桌面/Tauri 移动端同构;安全性说明见 `render_dicom_png` 的 doc
 /// (进程内 DICOM 渲染在移动端是安全的,`codecs` 特性已关)。

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 752330286;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1649105849;
 
 // Section: executor
 
@@ -80,6 +80,41 @@ fn wire__crate__api__vault__backfill_pdf_text_impl(
                             api_text,
                             api_confidence,
                         )?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__vault__build_qr_share_url_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "build_qr_share_url",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_base_url = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::build_qr_share_url(api_base_url)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -1026,6 +1061,20 @@ impl SseDecode for crate::api::dto::PatientProfileDto {
     }
 }
 
+impl SseDecode for crate::api::dto::QrShareDto {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_url = <String>::sse_decode(deserializer);
+        let mut var_problemCount = <i64>::sse_decode(deserializer);
+        let mut var_fitsQr = <bool>::sse_decode(deserializer);
+        return crate::api::dto::QrShareDto {
+            url: var_url,
+            problem_count: var_problemCount,
+            fits_qr: var_fitsQr,
+        };
+    }
+}
+
 impl SseDecode for crate::api::dto::ShareResultDto {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -1108,27 +1157,28 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__vault__backfill_pdf_text_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__vault__create_share_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__vault__delete_document_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
-        11 => {
+        2 => wire__crate__api__vault__build_qr_share_url_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__vault__create_share_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__vault__delete_document_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__vault__disable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__vault__enable_icloud_sync_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__vault__export_timeline_html_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
+        12 => {
             wire__crate__api__vault__ingest_image_with_text_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
-        20 => {
+        13 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
+        21 => {
             wire__crate__api__vault__source_file_object_path_impl(port, ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -1315,6 +1365,25 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::dto::PatientProfileDto>
     for crate::api::dto::PatientProfileDto
 {
     fn into_into_dart(self) -> crate::api::dto::PatientProfileDto {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::dto::QrShareDto {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.url.into_into_dart().into_dart(),
+            self.problem_count.into_into_dart().into_dart(),
+            self.fits_qr.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::dto::QrShareDto {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::dto::QrShareDto>
+    for crate::api::dto::QrShareDto
+{
+    fn into_into_dart(self) -> crate::api::dto::QrShareDto {
         self
     }
 }
@@ -1590,6 +1659,15 @@ impl SseEncode for crate::api::dto::PatientProfileDto {
         <Option<String>>::sse_encode(self.birth_date, serializer);
         <Option<String>>::sse_encode(self.age, serializer);
         <i64>::sse_encode(self.record_count, serializer);
+    }
+}
+
+impl SseEncode for crate::api::dto::QrShareDto {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.url, serializer);
+        <i64>::sse_encode(self.problem_count, serializer);
+        <bool>::sse_encode(self.fits_qr, serializer);
     }
 }
 

--- a/packages/share/src/qr.rs
+++ b/packages/share/src/qr.rs
@@ -23,6 +23,9 @@ pub const QR_BINARY_CAPACITY: usize = 2953;
 /// AEAD 绑定串:与整份分享(`medme-share-v1`)区分开,避免两种载荷被互相当成对方解。
 const QR_AAD: &[u8] = b"medme-qr-v1";
 
+/// fragment 版本前缀。查看器据此区分二维码载荷与口令。
+pub const FRAGMENT_PREFIX: &str = "q1.";
+
 /// 裁剪参数。默认值是**工程占位**,临床上该带多少由医生侧反馈决定 —— 改这里即可,
 /// 不需要动管线。
 #[derive(Debug, Clone, Copy)]
@@ -56,7 +59,8 @@ impl Default for QrLimits {
 
 /// 已裁剪的载荷 + 其分享链接片段。
 pub struct QrShare {
-    /// `#` 之后的内容:`<base64url(nonce‖密文)>.<base64url(密钥)>`。
+    /// `#` 之后的内容:`q1.<base64url(nonce‖密文)>.<base64url(密钥)>`。
+    /// `q1.` 前缀让查看器一眼区分「二维码载荷」与「口令」两种 fragment。
     pub fragment: String,
     /// 加密后的字节数(不含 base64 膨胀),用于判断是否还塞得进二维码。
     pub cipher_len: usize,
@@ -197,10 +201,62 @@ pub fn build_qr_fragment(
     blob.extend_from_slice(&ct);
 
     Ok(QrShare {
-        fragment: format!("{}.{}", B64URL.encode(&blob), B64URL.encode(key_bytes)),
+        fragment: format!(
+            "{}{}.{}",
+            FRAGMENT_PREFIX,
+            B64URL.encode(&blob),
+            B64URL.encode(key_bytes)
+        ),
         cipher_len: blob.len(),
         problem_count,
     })
+}
+
+/// 从保险箱直接产出二维码分享:装配 summary → 按 [`QrLimits`] 裁剪 → 加密成
+/// fragment。随机源用 OS 熵(失败按错误上报,不 panic)。
+///
+/// 返回 `(完整 URL, QrShare)`;URL 形如 `<base_url>#q1.<密文>.<密钥>`,直接编成
+/// 二维码即可。密钥在 `#` 之后 —— 按 HTTP 规范不会发给服务器。
+pub fn build_qr_share(
+    v: &core_model::Vault,
+    base_url: &str,
+    lim: QrLimits,
+) -> Result<(String, QrShare), String> {
+    let records = crate::export::gather_records(v)?;
+    let profile = pipeline::patient_profile(v).map_err(|e| e.to_string())?;
+    let docs: Vec<parser::SourceDoc<'_>> = records
+        .iter()
+        .enumerate()
+        .map(|(i, rec)| parser::SourceDoc {
+            index: i,
+            date: rec.doc.doc_date.map(|dt| dt.date_naive()),
+            text: &rec.text,
+            doc_type: Some(rec.doc.doc_type.as_str().to_lowercase()),
+            title: rec.doc.title.clone(),
+        })
+        .collect();
+    let summary = parser::assemble_summary(&docs);
+    let trimmed = trim_summary(&summary, lim);
+
+    let mut key = [0u8; 32];
+    getrandom::fill(&mut key).map_err(|e| format!("OS RNG unavailable: {e}"))?;
+    let mut nonce = [0u8; 12];
+    getrandom::fill(&mut nonce).map_err(|e| format!("OS RNG unavailable: {e}"))?;
+
+    let patient = serde_json::json!({
+        "name": profile.name,
+        "gender": profile.gender,
+        "age": profile.age,
+    });
+    let qr = build_qr_fragment(
+        &trimmed,
+        &patient,
+        &chrono::Utc::now().to_rfc3339(),
+        key,
+        nonce,
+    )?;
+    let url = format!("{}#{}", base_url.trim_end_matches('#'), qr.fragment);
+    Ok((url, qr))
 }
 
 #[cfg(test)]
@@ -319,8 +375,10 @@ mod tests {
 
         let (blob_b64, key_b64) = qr
             .fragment
+            .strip_prefix(FRAGMENT_PREFIX)
+            .expect("应带版本前缀")
             .split_once('.')
-            .expect("fragment 应为 数据.密钥");
+            .expect("fragment 应为 q1.数据.密钥");
         let blob = B64URL.decode(blob_b64).unwrap();
         let key = B64URL.decode(key_b64).unwrap();
 
@@ -350,7 +408,8 @@ mod tests {
         // 整份分享用的是 medme-share-v1;两种载荷不该互相解开。
         let trimmed = trim_summary(&sample_summary(3, 4), QrLimits::default());
         let qr = build(&trimmed);
-        let (blob_b64, key_b64) = qr.fragment.split_once('.').unwrap();
+        let body = qr.fragment.strip_prefix(FRAGMENT_PREFIX).unwrap();
+        let (blob_b64, key_b64) = body.split_once('.').unwrap();
         let blob = B64URL.decode(blob_b64).unwrap();
         let key = B64URL.decode(key_b64).unwrap();
         let cipher = Aes256Gcm::new_from_slice(&key).unwrap();

--- a/web/hosted-viewer/index.html
+++ b/web/hosted-viewer/index.html
@@ -12,7 +12,7 @@
         a=d.find(o,i)
         if a<0:break
         a+=len(o);b=d.find(c,a);print(base64.b64encode(hashlib.sha256(d[a:b].encode()).digest()).decode());i=b" -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-7Z0+4VB3CnpMGP9NdEXdG4wifm/kpyirE2yqr+CEnyc=' 'sha256-J1H0VWFrSXHrv/qNRbQwBdey5DPvFugU/irSMShgWBM='; style-src 'unsafe-inline'; img-src data:; font-src data:; frame-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-7Z0+4VB3CnpMGP9NdEXdG4wifm/kpyirE2yqr+CEnyc=' 'sha256-27prsER3bOkVFEn3ViBFd04FplwSJPqo42mUyY/N8go='; style-src 'unsafe-inline'; img-src data:; font-src data:; frame-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'; frame-ancestors 'none'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MedMe 加密分享查看器</title>
 <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%201024%201024%22%3E%0A%3Cdefs%3E%3ClinearGradient%20id%3D%22g%22%20x1%3D%220%22%20y1%3D%220%22%20x2%3D%221%22%20y2%3D%221%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%232bc0d2%22%2F%3E%3Cstop%20offset%3D%220.52%22%20stop-color%3D%22%231789c1%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%231560a8%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%0A%3Crect%20width%3D%221024%22%20height%3D%221024%22%20rx%3D%22232%22%20fill%3D%22url%28%23g%29%22%2F%3E%0A%3Cpath%20transform%3D%22translate%2885.76%2C804.70%29%20scale%280.82760%2C-0.82760%29%22%20d%3D%22M326%20640C320%20672%20323%20688%20335%20688C431%20690%20535%20708%20650%20741C668%20748%20687%20734%20704%20699C720%20664%20716%20650%20691%20658C672%20666%20641%20663%20600%20651C557%20639%20509%20631%20458%20627C405%20623%20371%20615%20355%20605C342%20596%20332%20606%20326%20640ZM212%20393C226%20508%20234%20570%20236%20582C234%20600%20241%20605%20259%20600C274%20594%20292%20586%20310%20578C325%20568%20326%20555%20314%20537C283%20459%20266%20368%20260%20267C252%20165%20254%20101%20266%2075C271%2062%20321%2063%20413%2079C503%2095%20582%20104%20650%20106C717%20108%20757%20111%20772%20115C777%20117%20786%20110%20796%2095C804%2078%20813%2065%20822%2057C830%2047%20832%2034%20829%2020C825%204%20814%200%20798%2010C698%2035%20597%2043%20494%2033C391%2023%20324%2013%20296%203C267%20-6%20246%20-9%20234%20-4C229%20-1%20226%203%20226%2011C226%2018%20220%2040%20210%2077C196%20172%20196%20277%20212%20393ZM567%20292C558%20302%20561%20306%20578%20306C639%20287%20691%20265%20736%20237C740%20234%20741%20219%20737%20189C731%20160%20724%20144%20716%20140C706%20136%20699%20138%20695%20146C689%20154%20683%20165%20675%20179C628%20228%20593%20265%20567%20292ZM761%20328C702%20338%20636%20336%20561%20323C555%20322%20550%20321%20546%20321C538%20294%20525%20267%20509%20240C497%20216%20483%20198%20468%20188C450%20176%20444%20165%20449%20157C451%20149%20434%20142%20397%20135C358%20126%20331%20126%20315%20134C298%20142%20300%20148%20322%20154C324%20154%20335%20159%20355%20169C372%20178%20393%20190%20414%20208C434%20225%20453%20249%20471%20281C473%20291%20476%20300%20480%20309C429%20297%20387%20284%20355%20271C348%20266%20335%20274%20319%20298C302%20321%20310%20330%20342%20324C385%20338%20436%20352%20494%20367C498%20395%20499%20419%20497%20440C489%20438%20480%20435%20471%20431C457%20424%20450%20429%20449%20444C447%20454%20444%20463%20441%20473C422%20448%20400%20427%20377%20408C357%20396%20344%20391%20336%20393C326%20395%20329%20403%20346%20419C385%20473%20409%20513%20421%20540C433%20566%20438%20584%20439%20594C441%20611%20452%20613%20472%20601C489%20587%20502%20577%20511%20571C519%20565%20517%20559%20505%20552C497%20548%20490%20541%20484%20531C480%20525%20475%20517%20467%20507C504%20511%20537%20518%20566%20527C596%20537%20620%20543%20640%20546C649%20547%20656%20538%20660%20520C662%20500%20658%20488%20648%20485C619%20473%20592%20461%20568%20450C564%20449%20563%20448%20562%20447C558%20430%20555%20407%20554%20382C554%20382%20556%20382%20559%20383C598%20391%20635%20396%20671%20402C706%20406%20728%20409%20734%20413C740%20416%20745%20413%20750%20403C754%20394%20760%20387%20768%20383C773%20379%20777%20367%20778%20348C778%20328%20772%20321%20761%20328Z%22%20fill%3D%22%23ffffff%22%2F%3E%0A%3C%2Fsvg%3E">
@@ -1043,7 +1043,9 @@ function render(payload) {
     + '<svg viewBox="0 0 1024 1024" width="28" height="28" aria-hidden="true" style="flex-shrink:0" role="img"><defs><linearGradient id="mm-g-doc" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#2bc0d2"/><stop offset="0.52" stop-color="#1789c1"/><stop offset="1" stop-color="#1560a8"/></linearGradient></defs><rect width="1024" height="1024" rx="232" fill="url(#mm-g-doc)"/><path transform="translate(85.76,804.70) scale(0.82760,-0.82760)" d="M326 640C320 672 323 688 335 688C431 690 535 708 650 741C668 748 687 734 704 699C720 664 716 650 691 658C672 666 641 663 600 651C557 639 509 631 458 627C405 623 371 615 355 605C342 596 332 606 326 640ZM212 393C226 508 234 570 236 582C234 600 241 605 259 600C274 594 292 586 310 578C325 568 326 555 314 537C283 459 266 368 260 267C252 165 254 101 266 75C271 62 321 63 413 79C503 95 582 104 650 106C717 108 757 111 772 115C777 117 786 110 796 95C804 78 813 65 822 57C830 47 832 34 829 20C825 4 814 0 798 10C698 35 597 43 494 33C391 23 324 13 296 3C267 -6 246 -9 234 -4C229 -1 226 3 226 11C226 18 220 40 210 77C196 172 196 277 212 393ZM567 292C558 302 561 306 578 306C639 287 691 265 736 237C740 234 741 219 737 189C731 160 724 144 716 140C706 136 699 138 695 146C689 154 683 165 675 179C628 228 593 265 567 292ZM761 328C702 338 636 336 561 323C555 322 550 321 546 321C538 294 525 267 509 240C497 216 483 198 468 188C450 176 444 165 449 157C451 149 434 142 397 135C358 126 331 126 315 134C298 142 300 148 322 154C324 154 335 159 355 169C372 178 393 190 414 208C434 225 453 249 471 281C473 291 476 300 480 309C429 297 387 284 355 271C348 266 335 274 319 298C302 321 310 330 342 324C385 338 436 352 494 367C498 395 499 419 497 440C489 438 480 435 471 431C457 424 450 429 449 444C447 454 444 463 441 473C422 448 400 427 377 408C357 396 344 391 336 393C326 395 329 403 346 419C385 473 409 513 421 540C433 566 438 584 439 594C441 611 452 613 472 601C489 587 502 577 511 571C519 565 517 559 505 552C497 548 490 541 484 531C480 525 475 517 467 507C504 511 537 518 566 527C596 537 620 543 640 546C649 547 656 538 660 520C662 500 658 488 648 485C619 473 592 461 568 450C564 449 563 448 562 447C558 430 555 407 554 382C554 382 556 382 559 383C598 391 635 396 671 402C706 406 728 409 734 413C740 416 745 413 750 403C754 394 760 387 768 383C773 379 777 367 778 348C778 328 772 321 761 328Z" fill="#ffffff"/></svg>'
     + '<h1>MedMe 医我 · 加密病历分享</h1></div>';
   html += '<div class="patient">' + patientLine + "</div>";
-  html += '<div class="generated">生成时间:' + esc(gen) + " · 共 " + (p.record_count || 0) + " 份记录</div></header>";
+  // 二维码分享没有 record_count(载荷里没有记录数组)—— 别显示「共 0 份记录」。
+  const countPart = p.record_count ? " · 共 " + p.record_count + " 份记录" : "";
+  html += '<div class="generated">生成时间:' + esc(gen) + countPart + "</div></header>";
   html += '<div class="privacy-note">本页由 MedMe 端到端加密分享生成,数据在您的浏览器本地解密,未上传任何服务器。不构成医疗建议,以原件为准。</div>';
 
   // 复阅期限:仅为分享方给出的非强制提醒,绝不阻断查看(文件持有者始终可解密)。
@@ -1152,6 +1154,41 @@ async function decryptAndRender(passphrase) {
   render(payload);
 }
 
+// ── 二维码分享(面对面扫码)────────────────────────────────────────────
+// fragment 形如 `#q1.<base64url(nonce‖密文)>.<base64url(密钥)>`,由患者手机上的
+// 二维码携带。与整份分享的区别:载荷是**有界的当下病情**(在治的病、每个指标最近
+// 几个点、在用的药),没有原件与影像 —— 那些在患者手机上当场翻。
+//
+// 密钥同在 `#` 之后:面对面出示二维码本身即是「在场证明」,再让医生手输口令只是
+// 徒增摩擦。代价是截屏即等于拿到钥匙 —— 与患者把屏幕给别人看是同一量级的风险。
+const QR_PREFIX = "q1.";
+
+async function renderQrSummary(fragment) {
+  const [blobB64, keyB64] = fragment.slice(QR_PREFIX.length).split(".");
+  if (!blobB64 || !keyB64) throw new Error("二维码内容不完整");
+  const blob = b64urlToBytes(blobB64);
+  const key = await crypto.subtle.importKey(
+    "raw", b64urlToBytes(keyB64), { name: "AES-GCM" }, false, ["decrypt"]);
+  // AAD 必须与 Rust 端 QR_AAD 逐字节一致,且**刻意不同于**整份分享的
+  // medme-share-v1 —— 两种载荷不该被互相当成对方解开。
+  const aad = new TextEncoder().encode("medme-qr-v1");
+  const gz = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: blob.slice(0, 12), additionalData: aad }, key, blob.slice(12));
+  // gzip 解压用浏览器原生 DecompressionStream,不引任何前端库。
+  const stream = new Blob([gz]).stream().pipeThrough(new DecompressionStream("gzip"));
+  const payload = JSON.parse(await new Response(stream).text());
+  render(payload);
+  // 明示这是「当下病情」而非完整病历,免得医生以为看到了全部。
+  const note = document.createElement("div");
+  note.className = "notice";
+  note.style.cssText = "margin:12px 0";
+  note.textContent =
+    "本页来自患者当面出示的二维码,只包含当前在治的问题、关键指标与在用药物 —— "
+    + "不是完整病历。需要看原件、影像或更早的记录,请让患者在手机上出示。";
+  const app = document.getElementById("app");
+  app.insertBefore(note, app.firstChild ? app.firstChild.nextSibling : null);
+}
+
 const pw = document.getElementById("pw");
 const errEl = document.getElementById("err");
 const drop = document.getElementById("drop");
@@ -1234,9 +1271,24 @@ document.getElementById("go").addEventListener("click", submit);
 // 口令可随 URL fragment 送达:`#<口令>`。`#` 之后的内容按 HTTP 规范**不会**发给
 // 服务器,因此链接/二维码分享时,密钥始终只存在于收件人浏览器本地。到达即自动解密,
 // 免去手输;随后清掉 hash,避免口令留在地址栏与浏览历史里。
-(function passphraseFromHash() {
+(function fromHash() {
   const h = decodeURIComponent(location.hash.replace(/^#/, "")).trim();
-  if (!h || !selfContained) return;
+  if (!h) return;
+  const clearHashNow = () => {
+    if (location.hash) history.replaceState(null, "", location.pathname + location.search);
+  };
+  // 二维码载荷:数据与密钥都在 fragment 里,不需要内嵌分享文件。
+  if (h.startsWith(QR_PREFIX)) {
+    addEventListener("load", clearHashNow);
+    setTimeout(clearHashNow, 60);
+    renderQrSummary(h)
+      .catch(() => {
+        errEl.textContent = "二维码内容无法解析,请让患者重新出示。";
+      })
+      .finally(clearHashNow);
+    return;
+  }
+  if (!selfContained) return;
   // 解析期调用 replaceState 会被随后的片段导航覆盖(实测),故解密完成后再清,
   // 并在 load 时兜底一次 —— 口令绝不该留在地址栏和浏览历史里。
   const clearHash = () => {


### PR DESCRIPTION
阶段一打通到能上手测。门诊场景:医生用**自己的手机**扫患者屏幕上的码 —— 不经微信、不过医院网闸、医生不装任何东西。要看原件或阅片,患者手机当场翻。

## 四块接齐

| | 做了什么 |
|---|---|
| **Rust 高层 API** | `qr::build_qr_share`:保险箱 → 装配 summary → 按 `QrLimits` 裁剪 → gzip → AES-256-GCM → URL。fragment 加 `q1.` 版本前缀 |
| **移动端 FRB** | `build_qr_share_url` + `QrShareDto`(URL / 疾病数 / 是否仍在容量内) |
| **查看器** | 识别 `#q1.` 载荷,浏览器原生 `DecompressionStream` 解 gzip,复用同一套渲染 |
| **手机界面** | `QrShareScreen`:白底留白的码 + 说明 + 诚实提示;入口放导出屏最前 |

## 真实数据实测

示例数据集(16 份病历)→ **6 个疾病 · 密文 1248 字节 · URL 1734 字符**,上限 2953,余量充足。

浏览器端到端验证:扫码 URL → 自动解密 → 泳道时间轴 + 在治疾病(高血压 3 级、2 型糖尿病、急性脑梗死、高尿酸血症、糖尿病肾病)+ 近期变化(肌酐 95→112、尿酸 438→405、eGFR 72→63)+ 病理 + 影像结论,hash 用后即清。

## 设计上的两处刻意选择

- **AAD 用 `medme-qr-v1`**,与整份分享的 `medme-share-v1` 不同 —— 两种载荷不会被互相当成对方解开(有测试)。
- **密钥同在 fragment 里,不再要口令**:面对面出示二维码本身就是「在场证明」,再让医生手输口令只是徒增摩擦。代价写在界面上了:「这张码就是钥匙,被拍下就等于把这份摘要给了对方」。

## 顺带修

二维码载荷没有记录数组,抬头不该显示「共 0 份记录」。

## 待你上手后再定

`QrLimits` 默认值(6 个病 / 每病 2 条化验 / 每条 4 个点 / 3 种在用药 / 3 条近期变化)是工程占位。你测完 UI/UX 觉得医生该看到多少,改常量即可。

## 验证

`cargo test --workspace` 244 通过 · `clippy -D warnings` 干净 · `fmt` 干净 · `flutter analyze` 无问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)