### PR TITLE
chore(mobile): 版本号 1.2.2+20(v20:面对面二维码分享)

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.1+19
+version: 1.2.2+20
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
出 TestFlight 用。v20 相对 v19 的变化:

- **新增「当面给医生看」** —— 生成二维码,医生用自己手机扫即可看到在治疾病、关键指标趋势、在用药物(#164 #166)
- v19 之后合入的:扫描版 PDF 走 OCR 回填、安卓 OCR 失败不丢照片、summary 门槛放宽、病理渲染、查看器字段名修复(#160)

上一次触发 iOS 构建时只传了 `platform=ios`,没开 `testflight` 开关(默认 false),所以只产出 IPA artifact、没上传 —— 这也是 TestFlight 里看不到新版本的原因。这次合并后会带 `testflight=true` 重新触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)