### PR TITLE
fix(qr): 容量守卫按实际渲染的纠错等级 M(2331)而非 L(2953)

### DIFF
--- a/apps/mobile_flutter/lib/screens/qr_share_screen.dart
+++ b/apps/mobile_flutter/lib/screens/qr_share_screen.dart
@@ -118,6 +118,8 @@ class _QrShareScreenState extends State<QrShareScreen> {
               size: 280,
               backgroundColor: Colors.white,
               // 医生隔着距离扫,纠错等级留高一点更容易扫上。
+              // 注意:Rust 侧 `QR_BINARY_CAPACITY` 是按这个等级(M=2331 字节)定的,
+              // 改这里必须同步改那个常量,否则守卫会比实际容量宽 27%。
               errorCorrectionLevel: QrErrorCorrectLevel.M,
             ),
           ),

--- a/packages/share/src/qr.rs
+++ b/packages/share/src/qr.rs
@@ -17,8 +17,15 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
 use base64::Engine;
 use serde_json::{json, Value};
 
-/// 二维码二进制模式容量上限(version 40,纠错等级 L)。
-pub const QR_BINARY_CAPACITY: usize = 2953;
+/// 二维码二进制模式容量上限(version 40,**纠错等级 M**)。
+///
+/// 各等级容量:L=2953 · **M=2331** · Q=1663 · H=1273。这里取 M 而非理论最大的 L,
+/// 因为出码端实际就是按 M 渲染的(`qr_share_screen.dart` 的 `errorCorrectionLevel`)
+/// —— 医生隔着桌子扫,纠错留高一点更容易扫上。若判断按 L(2953)、渲染按 M,
+/// 守卫会比实际宽 27%:载荷一旦变大就会「判定装得下、实际扫不出来」。
+///
+/// 改渲染端的纠错等级时,**这个常量必须同步改**。
+pub const QR_BINARY_CAPACITY: usize = 2331;
 
 /// AEAD 绑定串:与整份分享(`medme-share-v1`)区分开,避免两种载荷被互相当成对方解。
 const QR_AAD: &[u8] = b"medme-qr-v1";


### PR DESCRIPTION
出码端渲染用**纠错等级 M**(`qr_share_screen.dart` 的 `errorCorrectionLevel`),而 Rust 侧 `fits_qr` 按**等级 L** 的 2953 字节判断 —— 守卫比实际容量**宽 27%**。

各等级容量:L=2953 · **M=2331** · Q=1663 · H=1273。

## 为什么现在没暴露、但必须修

当前载荷 1734 字符,两种口径下都装得下。但 `QrLimits` 的默认值明说了是**待临床反馈后要调的** —— 一旦放宽到 2331~2953 之间,`fits_qr` 会判定「装得下」,而医生现场**实际扫不出来**。

那是最难查的一类问题:代码说没事,现场就是不行,而且只在特定患者的数据量上复现。

## 改了什么

- `QR_BINARY_CAPACITY` 2953 → **2331**
- 两侧都加注释:改渲染端的纠错等级,必须同步改这个常量(反之亦然)

## 来源

由写 blog 卡片的 subagent 在核对公开文案里的数字时发现 —— 它去查「2953 这个数从哪来」,发现和渲染端对不上。

## 验证

`cargo test -p medme-share qr::` 5 通过 · `fmt` 干净 · `flutter analyze` 无问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)