### PR TITLE
feat(mobile): 出示二维码时自动调亮屏幕

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ web/hosted-viewer/demo-payload.json
 fuzz/target/
 fuzz/corpus/*/[0-9a-f]*
 fuzz/artifacts/
+
+# 上游安全报告草稿:含未公开的漏洞细节,提交前不入库
+docs/upstream-dicom-rs-report.md

--- a/apps/mobile_flutter/lib/screens/qr_share_screen.dart
+++ b/apps/mobile_flutter/lib/screens/qr_share_screen.dart
@@ -9,6 +9,7 @@
 // 空壳查看器,病历数据全程只在两台手机之间。
 import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:screen_brightness/screen_brightness.dart';
 
 import '../src/rust/api/dto.dart';
 import '../src/rust/api/vault.dart';
@@ -28,10 +29,40 @@ class _QrShareScreenState extends State<QrShareScreen> {
   QrShareDto? _share;
   String? _error;
 
+  // 自动调亮是否成功:成功了就不用再提示患者手动调亮。失败(部分设备/权限
+  // 限制)保持 false,页面照常显示二维码,退回原来的手动提示文案。
+  bool _brightnessBoosted = false;
+
   @override
   void initState() {
     super.initState();
     _generate();
+    _boostBrightness();
+  }
+
+  @override
+  void dispose() {
+    // 只调了 app 内亮度,不影响系统亮度;离开页面时恢复,覆盖用户中途按
+    // home 键切走再回来的情况(setApplicationScreenBrightness 只在此页
+    // 生效,退到后台时插件自身也会按生命周期自动重置,双保险)。
+    // dispose 是同步的,恢复调用不 await;失败也不阻塞退出,但要接住
+    // 异常,不然是一个未处理的 Future 错误。
+    if (_brightnessBoosted) {
+      ScreenBrightness.instance
+          .resetApplicationScreenBrightness()
+          .catchError((_) {});
+    }
+    super.dispose();
+  }
+
+  Future<void> _boostBrightness() async {
+    try {
+      await ScreenBrightness.instance.setApplicationScreenBrightness(1.0);
+      if (mounted) setState(() => _brightnessBoosted = true);
+    } catch (_) {
+      // 调亮失败(部分设备/权限限制)不影响二维码本身显示,静默降级为
+      // 手动提示即可,不弹错误打断医患当面这个流程。
+    }
   }
 
   Future<void> _generate() async {
@@ -99,9 +130,10 @@ class _QrShareScreenState extends State<QrShareScreen> {
             style: TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
           ),
           const SizedBox(height: 6),
-          const Text(
-            '把屏幕亮度调高,对着医生的手机相机',
-            style: TextStyle(fontSize: 13.5, color: MedMe.faint),
+          Text(
+            // 自动调亮成功了就别再让患者做一遍已经做了的事。
+            _brightnessBoosted ? '对着医生的手机相机' : '把屏幕亮度调高,对着医生的手机相机',
+            style: const TextStyle(fontSize: 13.5, color: MedMe.faint),
           ),
           const SizedBox(height: 20),
           // 白底 + 留白是二维码可扫性的硬要求,别加装饰。

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -827,6 +827,62 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  screen_brightness:
+    dependency: "direct main"
+    description:
+      name: screen_brightness
+      sha256: e0edf92c08889e8f493cde291e7c687db2b4a1471f2371c074070b75d7c7d79b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.11"
+  screen_brightness_android:
+    dependency: transitive
+    description:
+      name: screen_brightness_android
+      sha256: "2008ad8e9527cc968f7a4de1ec58b476d495b3c612a149dbd6550c4f046da147"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  screen_brightness_ios:
+    dependency: transitive
+    description:
+      name: screen_brightness_ios
+      sha256: "352d355e8523a186ba1e494b74218e5ca96e51975a0630b8ed89fbb7ff609762"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_macos:
+    dependency: transitive
+    description:
+      name: screen_brightness_macos
+      sha256: b0957237b842d846a84363b69f229b339a8f91faced55041e245b2ebff7b0142
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_ohos:
+    dependency: transitive
+    description:
+      name: screen_brightness_ohos
+      sha256: "569a2c97909a50894b81487619eb7654f5358443a5af05f840c19261f49c0940"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_brightness_platform_interface
+      sha256: "2de60c0ba569b898950029cc1f7e9dd72bda44a22beb5054aac331cb6fce2ff2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  screen_brightness_windows:
+    dependency: transitive
+    description:
+      name: screen_brightness_windows
+      sha256: "368b9c822e1671de81616e48150006e39eff2a434957e47ee638b09a32b2297c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   share_plus:
     dependency: "direct main"
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -50,6 +50,11 @@ dependencies:
   pdfx: ^2.9.2
   share_plus: ^11.0.0
   url_launcher: ^6.3.2
+  # 出示二维码时自动调亮屏幕:只调 app 内亮度(不动系统亮度),安卓不需要
+  # WRITE_SETTINGS 权限;内置 app 生命周期自动重置,切后台/被系统回收也不会
+  # 把亮度锁死在最高。pub.dev 满分维护度、165 赞、月下载 18万+,选成熟包
+  # 而不是自己写 platform channel。
+  screen_brightness: ^2.1.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
医生隔着桌子扫,屏幕暗就扫不上。原来只是文案提示患者「把亮度调高」—— 那是让用户替我们做本该自动做的事。

## 选包理由

`screen_brightness`(MIT,pub.dev 满分维护度)。关键是它只调 **app 内亮度**、不动系统亮度:

- **安卓不需要 `WRITE_SETTINGS` 权限** → 少一个失败面(申请系统亮度权限是会被拒的)
- 离开页面即恢复,**不会把用户的系统亮度锁在最高**
- 内置 app 生命周期自动重置,加上我们在 `dispose` 里显式恢复 —— 双保险覆盖「中途按 home 键切走」

## 失败处理

调亮失败(部分设备/权限)**静默降级**:二维码照常显示,文案退回手动提示。**绝不因为调亮失败打断医患当面这个流程** —— 那一刻患者正把手机递给医生。

## 文案随状态变

调亮成功 → 「对着医生的手机相机」
调亮失败 → 「把屏幕亮度调高,对着医生的手机相机」

别让人做已经做过的事。

## 顺带

`.gitignore` 排除上游安全报告草稿(含未公开的漏洞细节,不该随仓库公开)。

## 验证

`flutter analyze` 无问题;未跑 release / 全 ABI 构建(遵守 `apps/mobile_flutter/CLAUDE.md` 的构建纪律)。真机效果需你在下一版 TestFlight 上确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)