### PR TITLE
chore: gitignore 真机测试素材目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ fuzz/artifacts/
 
 # 上游安全报告草稿:含未公开的漏洞细节,提交前不入库
 docs/upstream-dicom-rs-report.md
+
+# 真机测试素材:3 个无文本层扫描 PDF,用于验证移动端 OCR 回填(体积小但属测试数据)
+scratch_test_pdfs/


### PR DESCRIPTION
清理工作区的未跟踪文件。

- **保留但 gitignore**:`scratch_test_pdfs/`(3 个无文本层扫描 PDF)—— 它是「移动端扫描版 PDF 走 OCR 回填」那条修复的测试素材,**而那条至今没在真机上验过**,删了下次得重造。
- **删除**:两张临时截图(`doc-view-card.png` / `docview.png`)、一份过期的 `docs/plan-mobile-viewer-极致.md`。

后者的核心结论(「MedGemma 零样本抽取尚未过关,CMeEE 黄金 F1=0.52,不过关就不集成」)已在 `docs/log/2026-07-18-mobile-audit-extraction-strategy.md` 留存 —— 确认过才删的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)