### PR TITLE
fix(mobile): 扫描版 PDF 的 OCR 质量 —— 渲染提到 300 DPI + 页间空行分隔

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ fuzz/artifacts/
 
 # 上游安全报告草稿:含未公开的漏洞细节,提交前不入库
 docs/upstream-dicom-rs-report.md
+
+# 真机测试素材:3 个无文本层扫描 PDF,用于验证移动端 OCR 回填(体积小但属测试数据)
+scratch_test_pdfs/

--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -204,11 +205,24 @@ Future<void> _runImport(BuildContext context, List<PendingImport> items) async {
   progress.dispose();
 }
 
-/// 扫描版 PDF 补 OCR:用 `pdfx` 逐页渲染成 PNG(2× 分辨率提升识别率),走原生图片
-/// OCR([recognizeImageText],iOS Vision / 安卓 ML Kit),合并各页文本 + 平均置信度。
+/// 扫描版 PDF 补 OCR:用 `pdfx` 逐页渲染成 PNG,走原生图片 OCR
+/// ([recognizeImageText],iOS Vision / 安卓 ML Kit),合并各页文本 + 平均置信度。
 /// 任何一步失败/无文本都安全返回(空文本 → 调用方不回填,保持「仅存原件」)。
 /// 页数封顶 [_kMaxPdfOcrPages] 防超大 PDF 卡死。
 const int _kMaxPdfOcrPages = 20;
+
+/// 渲染目标解析度。pdfx 的 `page.width/height` 单位是 **point**(1/72 英寸),
+/// 所以缩放倍数 = 目标 DPI / 72。
+///
+/// 300 DPI 是中文 OCR 的通行下限 —— 笔画密的字(参考值那一列的小字号、繁体、
+/// 生僻字)在更低解析度下会糊成一团。此前用的 2×(= 144 DPI)是拍脑袋定的,
+/// 真机实测识别质量明显不足;作为对比,用手机直接拍一张 A4 约合 360 DPI,
+/// 反而比我们渲染的清晰一倍有余。
+const double _kOcrTargetDpi = 300;
+
+/// 单页渲染的像素上限。超大幅面(如拼接的 X 光报告)按 300 DPI 展开可能到几亿
+/// 像素,直接 OOM。命中上限时按比例缩回,宁可这一页识别差些,也不能让导入崩掉。
+const double _kMaxRenderPixels = 40e6;
 
 Future<OcrResult> _ocrScannedPdf(String path) async {
   final buf = StringBuffer();
@@ -224,9 +238,15 @@ Future<OcrResult> _ocrScannedPdf(String path) async {
     for (var i = 1; i <= pages; i++) {
       final page = await doc.getPage(i);
       try {
+        // 按目标 DPI 计算缩放,再按像素上限回退 —— 见 _kOcrTargetDpi / _kMaxRenderPixels。
+        var scale = _kOcrTargetDpi / 72.0;
+        final pixels = page.width * scale * page.height * scale;
+        if (pixels > _kMaxRenderPixels) {
+          scale *= math.sqrt(_kMaxRenderPixels / pixels);
+        }
         final img = await page.render(
-          width: page.width * 2,
-          height: page.height * 2,
+          width: page.width * scale,
+          height: page.height * scale,
           format: PdfPageImageFormat.png,
         );
         if (img == null) continue;
@@ -234,7 +254,10 @@ Future<OcrResult> _ocrScannedPdf(String path) async {
         await f.writeAsBytes(img.bytes);
         final ocr = await recognizeImageText(f.path);
         if (ocr.text.trim().isNotEmpty) {
-          buf.writeln(ocr.text);
+          // 页间必须空行分隔:OCR 已用 `\n\n` 分块(Layer-0),若这里只写一个
+          // 换行,上一页的末块会和下一页的首块粘成同一块,下游按段分块就错位。
+          if (buf.isNotEmpty) buf.write('\n\n');
+          buf.write(ocr.text.trim());
           confs.add(ocr.confidence);
         }
       } finally {


### PR DESCRIPTION
真机反馈「内容不对,排版问题更大」。查下来两个原因,都是我这边的。

## ① 渲染解析度不足(内容不对)

`pdfx` 的 `page.width/height` 单位是 **point**(1/72 英寸),此前写死 `* 2`:

| | 折合 DPI |
|---|---|
| **改前(2×)** | **144 DPI** |
| 改后(300/72 ≈ 4.17×) | 300 DPI |
| 手机直接拍一张 A4 | ~360 DPI |
| 中文 OCR 通行下限 | 300 DPI |

那个 `2` 是我拍脑袋定的,没有依据。144 DPI 下笔画密的字(参考值列的小字号、繁体、生僻字)会糊成一团 —— **用手机拍反而比我们渲染的清晰一倍有余**,所以「为什么不干脆拍照」这个疑问在效果上确实成立。

加了单页 40MP 的像素上限:超大幅面按 300 DPI 展开可能上亿像素直接 OOM,命中上限按比例缩回 —— 宁可那一页识别差些,也不能让导入崩掉。

## ② 页与页粘连(排版问题)

OCR 本身是保留块结构的(Layer-0,块间 `\n\n`,多栏化验单各栏不串栏),但这里用 `writeln` 只写**一个**换行,于是**上一页的末块和下一页的首块被当成同一块**,下游按段分块随之错位。改为页间空行分隔。

## 验证

`flutter analyze` 干净。**但识别质量的真正验收在真机** —— 同一批 `scratch_test_pdfs` 重新导入,看内容与分块是否改善。改完需要出一版 TestFlight。

🤖 Generated with [Claude Code](https://claude.com/claude-code)