### PR TITLE
chore(mobile): 版本号 1.2.3+21(v21:扫描版 PDF 识别质量修复)

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.2+20
+version: 1.2.3+21
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
出 TestFlight 用。v21 相对 v20 的变化:

- **扫描版 PDF 渲染解析度 144 → 300 DPI**(#173)。此前的 `2×` 是拍脑袋定的;300 DPI 是中文 OCR 通行下限,作为对比手机直接拍一张 A4 约合 360 DPI。
- **页间改空行分隔**(#173)。原来上一页末块与下一页首块会粘成同一块,下游按段分块随之错位。
- **二维码出示页自动调亮屏幕**(#170)。

验收重点:同一批 `scratch_test_pdfs` 里的 3 个无文本层扫描 PDF 重新导入,看识别内容与分块是否改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)