### PR TITLE
chore(mobile): 版本号 1.2.5+23(v23:系统文档扫描器)

### DIFF
--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.4+22
+version: 1.2.5+23
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
出 TestFlight 用。v23 相对 v22:

- **拍照采集走系统文档扫描器**(#177)—— iOS VisionKit / 安卓 ML Kit Document Scanner,自动画框 + 透视校正。斜拍的化验单拉正后,OCR 才拼得回整行。扫描器不可用时回退普通拍照。

验收:斜拍一张化验单,看是否弹扫描框、对角拉正后识别内容与分块是否改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)