### PR TITLE
fix(mobile): 修文档扫描器「点了没反应」—— present 时序 + 超时兜底(v24)

### DIFF
--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -64,6 +64,14 @@ Future<void> showImportSheet(BuildContext context) async {
   );
   if (choice == null || !context.mounted) return;
 
+  // 等 bottom sheet 的关闭动画播完再拉起原生采集器。文档扫描器
+  // (VNDocumentCameraViewController)靠 rootViewController.present 弹出;若 sheet
+  // 尚未完全消失,present 会被正在退场的 sheet 挡下、静默失败,method channel 永不
+  // 回调 —— 表现就是「点了没反应」。ImagePicker 内部自己处理了这个时序,这个扫描器
+  // 插件没有,所以在这里补一帧等待。
+  await Future<void>.delayed(const Duration(milliseconds: 350));
+  if (!context.mounted) return;
+
   final items = await _pick(choice);
   if (items.isEmpty || !context.mounted) return;
   await _runImport(context, items);
@@ -79,9 +87,11 @@ Future<List<PendingImport>> _pick(_ImportChoice choice) async {
       // 回整行。随手斜拍是最常见的输入,这一步质量提升值一次多余的对框操作。
       // 扫描器不可用(部分设备/权限)时回退到普通拍照,不阻断采集。
       try {
+        // 加超时兜底:万一原生侧仍无响应(极端时序 / 未来插件回归),挂起 12s 即抛,
+        // 落到下面回退分支走普通拍照,不让用户干等。
         final paths = await CunningDocumentScanner.getPictures(
           scannerSource: ScannerSource.camera,
-        );
+        ).timeout(const Duration(seconds: 12));
         if (paths == null || paths.isEmpty) return const [];
         return [
           for (final p in paths)

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.5+23
+version: 1.2.6+24
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
真机 iOS 点「拍照」无反应。

## 诊断过程(先排除了错误假设)

我一开始怀疑是 SPM 集成没把插件原生代码带进包(2.6.0 是纯 SPM)。**发了诊断构建到 CI，结论推翻了这个假设**:

```
✅ cunning 已注册进 GeneratedPluginRegistrant
```

打包和原生 handler 都正常。根因不在这里。

## 真正的根因:弹出时序

采集菜单是 `showModalBottomSheet`。它的 `await` 在**选中项后就返回**，但 sheet 的**关闭动画还没播完**。

文档扫描器(`VNDocumentCameraViewController`)靠 `rootViewController.present(...)` 弹出。此刻 `rootViewController` 仍被**正在退场的 sheet** 占着 → `present` 被静默挡下 → method channel 永不回调 → **点了没反应**。

`ImagePicker` 没这问题，因为它内部自己处理了这个时序；这个扫描器插件没有。

## 修法

- **等 sheet 关闭动画**:选中后 `delay 350ms` 再拉起原生采集器
- **超时兜底**:`getPictures` 加 12s timeout，极端时序/未来回归时挂起即抛，落回退分支走普通拍照，不让用户干等

## 验证

`flutter analyze` 干净。诊断分支已删，未污染 main。**真机验收**:点拍照应正常弹出扫描框。v24。

🤖 Generated with [Claude Code](https://claude.com/claude-code)