### PR TITLE
fix(mobile): 修相机权限被拒 —— Podfile 补 permission_handler 权限宏(v25)

### DIFF
--- a/apps/mobile_flutter/ios/Podfile
+++ b/apps/mobile_flutter/ios/Podfile
@@ -50,6 +50,17 @@ post_install do |installer|
       # 模拟器是 arm64 会链接失败。对模拟器排除 arm64(改跑 x86_64/Rosetta);
       # 真机(device/TestFlight)构建不受影响,仍用 arm64。
       config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
+
+      # permission_handler 在 CocoaPods 下靠这些预处理宏决定编译哪些权限的实现:
+      # 没打开的权限会被编成「永远返回 denied」的桩,`.request()` 直接拒绝、不弹框。
+      # cunning_document_scanner 走相机权限,不加 PERMISSION_CAMERA=1 就永远
+      # permission_denied、系统设置里也不出现 MedMe 的相机项 —— 真机实测就是如此。
+      # (README 说 SPM 集成会自动扫 Info.plist,但本工程是 CocoaPods,得手动加。)
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+        'PERMISSION_PHOTOS=1',
+      ]
     end
   end
 end

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.6+24
+version: 1.2.7+25
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 一击定位

v25 诊断版给拍照路埋了屏幕可见探针(读不到真机日志,就让 App 把状态弹给用户看)。用户点一次拍照,屏幕直接显示:

```
④ 扫描器异常/超时,回退普通相机:
CunningDocumentScannerException(permission_denied): Camera permission not granted
```

而且**系统设置里根本没有 MedMe 的相机项** —— 权限请求从未真正发出。

## 根因(permission_handler 官方文档确认)

> Since version 8.0.0, the permission_handler plugin **excludes all permissions by default**. Developers are only required to enable the specific permissions... by modifying `GCC_PREPROCESSOR_DEFINITIONS` in the Podfile.

自 8.0.0 起,permission_handler 在 CocoaPods 下**默认关闭所有权限**,未打开的权限被编成「永远返回 denied」的桩:`.request()` 直接拒绝、**不弹框**,iOS 从没看到请求,设置里也就没有相机项。

`cunning_document_scanner` 依赖它走相机权限,而我们 Podfile 一个权限宏都没有。

## 修法

Podfile 的 `post_install` 补:

```ruby
config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
  '$(inherited)',
  'PERMISSION_CAMERA=1',
  'PERMISSION_PHOTOS=1',
]
```

写法与官方 README 一致,只开这两个、其余保持默认关闭。

## 复盘

v22–v24 三版方向全错(先猜时序、再猜 SPM),根子是**读不到真机日志就盲改**。这次改用屏幕可见探针拿到确切异常,一次定位 —— 教训:拿数据,别猜。

## 验证

真机验收:点拍照应先弹**相机权限请求框**,授权后进扫描界面。v25。

🤖 Generated with [Claude Code](https://claude.com/claude-code)