### PR TITLE
revert(mobile): 撤掉文档扫描器,拍照回到普通相机(v27)

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -177,13 +177,6 @@ jobs:
         run: flutter pub get
       - name: 构建 IPA(release archive + 导出)
         working-directory: ${{ env.WORKDIR }}
-        # permission_handler(SPM 集成)靠环境变量决定编译哪些权限,优先级高于扫
-        # Info.plist —— 后者在 CI 干净环境下路径回溯不可靠(诊断实测:构建期扫不到
-        # 我们的 Info.plist,相机权限被默认关闭 → .request() 直接 denied、不弹框)。
-        # 显式 export 强制启用相机 + 相册,确定性,不依赖路径。
-        env:
-          PERMISSION_CAMERA: "1"
-          PERMISSION_PHOTOS: "1"
         run: flutter build ipa --release --export-options-plist=$RUNNER_TEMP/ExportOptions.plist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:cunning_document_scanner/cunning_document_scanner.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
@@ -64,14 +63,6 @@ Future<void> showImportSheet(BuildContext context) async {
   );
   if (choice == null || !context.mounted) return;
 
-  // 等 bottom sheet 的关闭动画播完再拉起原生采集器。文档扫描器
-  // (VNDocumentCameraViewController)靠 rootViewController.present 弹出;若 sheet
-  // 尚未完全消失,present 会被正在退场的 sheet 挡下、静默失败,method channel 永不
-  // 回调 —— 表现就是「点了没反应」。ImagePicker 内部自己处理了这个时序,这个扫描器
-  // 插件没有,所以在这里补一帧等待。
-  await Future<void>.delayed(const Duration(milliseconds: 350));
-  if (!context.mounted) return;
-
   final items = await _pick(choice);
   if (items.isEmpty || !context.mounted) return;
   await _runImport(context, items);
@@ -82,27 +73,12 @@ enum _ImportChoice { camera, gallery, files }
 Future<List<PendingImport>> _pick(_ImportChoice choice) async {
   switch (choice) {
     case _ImportChoice.camera:
-      // 走系统文档扫描器(iOS VisionKit / 安卓 ML Kit Document Scanner):自动
-      // 画框 + 透视校正,拿到已拉正的图 —— 斜着拍的表格变回横平竖直,OCR 才拼得
-      // 回整行。随手斜拍是最常见的输入,这一步质量提升值一次多余的对框操作。
-      // 扫描器不可用(部分设备/权限)时回退到普通拍照,不阻断采集。
-      try {
-        // 加超时兜底:万一原生侧仍无响应(极端时序 / 未来插件回归),挂起 12s 即抛,
-        // 落到下面回退分支走普通拍照,不让用户干等。
-        final paths = await CunningDocumentScanner.getPictures(
-          scannerSource: ScannerSource.camera,
-        ).timeout(const Duration(seconds: 12));
-        if (paths == null || paths.isEmpty) return const [];
-        return [
-          for (final p in paths)
-            PendingImport(name: p.split('/').last, path: p, isImage: true),
-        ];
-      } catch (e) {
-        debugPrint('[import] 文档扫描器不可用,回退普通拍照: $e');
-        final file = await ImagePicker().pickImage(source: ImageSource.camera);
-        if (file == null) return const [];
-        return [PendingImport(name: file.name, path: file.path, isImage: true)];
-      }
+      // 普通相机拍照(v20 起一直用、确定可用)。文档扫描器(自动纠偏)一度换进来,
+      // 但那个插件在 SPM 集成 / present 时序 / 相机权限上连环踩坑,六版未稳,已撤回。
+      // 纠偏改走更轻的路子(见 issue),不再阻塞采集。
+      final file = await ImagePicker().pickImage(source: ImageSource.camera);
+      if (file == null) return const [];
+      return [PendingImport(name: file.name, path: file.path, isImage: true)];
     case _ImportChoice.gallery:
       final files = await ImagePicker().pickMultiImage();
       return [

--- a/apps/mobile_flutter/pubspec.lock
+++ b/apps/mobile_flutter/pubspec.lock
@@ -177,14 +177,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
-  cunning_document_scanner:
-    dependency: "direct main"
-    description:
-      name: cunning_document_scanner
-      sha256: "5649144c7bf81b16686287fef2e817ce7b87a8a5eec450172c2f41405e7e8910"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -732,54 +724,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.2"
-  permission_handler:
-    dependency: transitive
-    description:
-      name: permission_handler
-      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.0.3"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.1"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.4.10"
-  permission_handler_html:
-    dependency: transitive
-    description:
-      name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3+5"
-  permission_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/apps/mobile_flutter/pubspec.yaml
+++ b/apps/mobile_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.8+26
+version: 1.2.9+27
 
 environment:
   sdk: ^3.12.2
@@ -42,9 +42,6 @@ dependencies:
   path_provider: ^2.1.6
   freezed_annotation: ^3.1.0
   image_picker: ^1.2.3
-  # 文档扫描器:封装 iOS VisionKit + 安卓 ML Kit Document Scanner(系统级自动画框
-  # 与透视校正,与 CamScanner 同级)。拍照采集走它,拿到已拉正的图 → OCR 行拼得回来。
-  cunning_document_scanner: ^2.6.0
   file_picker: ^8.0.0
   google_mlkit_text_recognition: ^0.16.0
   photo_view: ^0.15.0


### PR DESCRIPTION
文档扫描器 v23→v26 连修六版仍「点拍照没反应」。撤回到 v20-v22 确定可用的 ImagePicker 普通相机。纠偏诉求改走更轻的路子,不再阻塞采集。flutter analyze 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)