### PR TITLE
修复:重导已存文档不再永久短路,补齐当初漏识别的 PDF 页(#63b)

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -58,6 +58,19 @@ fn main() -> anyhow::Result<()> {
                         "attach {} (DICOM slice merged into study, id={})",
                         o.name, o.source_file_id
                     ),
+                    pipeline::IngestStatus::Reindexed => {
+                        if o.pages_without_text.is_empty() {
+                            format!(
+                                "reindex {} (missing pages recovered, id={})",
+                                o.name, o.source_file_id
+                            )
+                        } else {
+                            format!(
+                                "reindex {} (still missing pages {:?}, id={})",
+                                o.name, o.pages_without_text, o.source_file_id
+                            )
+                        }
+                    }
                 };
                 println!("{line}");
             }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -277,6 +277,9 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcome {
                 pipeline::IngestStatus::Deduped => "deduped",
                 pipeline::IngestStatus::StoredNoText => "stored_no_text",
                 pipeline::IngestStatus::InstanceAttached => "instance_attached",
+                // 同一份文件再导一次、文档已存在但当年有页缺文本 → 这次顺手补上了
+                // (可能补全、也可能仍有页识别不出,见 `pages_without_text`)。
+                pipeline::IngestStatus::Reindexed => "reindexed",
             }
             .to_string();
             ImportOutcome {

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -86,7 +86,7 @@ pub struct DocumentDetail {
 pub struct ImportOutcome {
     pub name: String,
     pub source_file_id: i64,
-    pub status: String, // new|backfilled|deduped|stored_no_text
+    pub status: String, // new|backfilled|deduped|stored_no_text|instance_attached|reindexed
     pub doc_type: Option<String>,
 }
 

--- a/apps/desktop/src/components/ImportView.tsx
+++ b/apps/desktop/src/components/ImportView.tsx
@@ -26,6 +26,9 @@ const STATUS_META: Record<string, { label: string; cls: string }> = {
   deduped: { label: "已存在 · 去重", cls: "text-ink-2 bg-line-2" },
   stored_no_text: { label: "已保存 · 未识别到文字", cls: "text-high bg-high-wash" },
   instance_attached: { label: "已并入检查", cls: "text-seal-ink bg-seal-wash" },
+  // 同一份文件再导一次:文档已存在、但当年有页缺文本层,这次顺手补上了
+  // (见 pipeline::reindex_existing_document,#63b)。
+  reindexed: { label: "已补充识别", cls: "text-seal-ink bg-seal-wash" },
   failed: { label: "导入失败", cls: "text-critical bg-critical-wash" },
 };
 

--- a/apps/mobile_flutter/lib/screens/import_helpers.dart
+++ b/apps/mobile_flutter/lib/screens/import_helpers.dart
@@ -63,8 +63,8 @@ class ImportResultRow {
 }
 
 /// 把 `ImportOutcomeDto.status`(见 rust/src/api/dto.rs 注释:
-/// new|backfilled|deduped|stored_no_text|instance_attached|failed)映射成
-/// 老人能看懂的一行结果。
+/// new|backfilled|deduped|stored_no_text|instance_attached|reindexed|failed)
+/// 映射成老人能看懂的一行结果。
 ImportResultRow rowFromOutcome(ImportOutcomeDto outcome) {
   final typeLabel = outcome.docType == null
       ? null
@@ -73,6 +73,10 @@ ImportResultRow rowFromOutcome(ImportOutcomeDto outcome) {
     case 'new':
     case 'backfilled':
     case 'instance_attached':
+    // 'reindexed' 只会在 pagesWithoutText 已经补空的情况下走到这里(见调用方
+    // `rowForOutcome`:非空时它自己接管、不会退化到本函数)——即「同一份文件
+    // 再导一次,当年漏的页这次补齐了」,与「已识别入库」是同一件事。
+    case 'reindexed':
       return ImportResultRow(
         name: outcome.name,
         statusLabel: typeLabel != null ? '已识别入库 · $typeLabel' : '已识别入库',

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -384,6 +384,9 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 pipeline::IngestStatus::Deduped => "deduped",
                 pipeline::IngestStatus::StoredNoText => "stored_no_text",
                 pipeline::IngestStatus::InstanceAttached => "instance_attached",
+                // 同一份文件再导一次、文档已存在但当年有页缺文本 → 这次顺手
+                // 补上了(`pages_without_text` 带出补完之后仍缺的页,可能是空)。
+                pipeline::IngestStatus::Reindexed => "reindexed",
             }
             .to_string();
             let document_id = v

--- a/apps/mobile_flutter/rust/src/api/vault_ephemeral.rs
+++ b/apps/mobile_flutter/rust/src/api/vault_ephemeral.rs
@@ -130,6 +130,9 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
                 pipeline::IngestStatus::Deduped => "deduped",
                 pipeline::IngestStatus::StoredNoText => "stored_no_text",
                 pipeline::IngestStatus::InstanceAttached => "instance_attached",
+                // 同一份文件再导一次、文档已存在但当年有页缺文本 → 这次顺手
+                // 补上了(`pages_without_text` 带出补完之后仍缺的页,可能是空)。
+                pipeline::IngestStatus::Reindexed => "reindexed",
             }
             .to_string();
             let document_id = v

--- a/packages/core-model/src/query.rs
+++ b/packages/core-model/src/query.rs
@@ -598,6 +598,21 @@ impl Vault {
         Ok(row)
     }
 
+    /// 该文档已经落库的 OCR 页码集合(升序)。配合 `document.page_count` 就能算出
+    /// 「哪些页仍然缺文本」——reindex 补页(`pipeline::reindex_existing_document`)
+    /// 用它判断该重试哪些页、以及重试后是否补完了。
+    pub fn ocr_page_numbers(&self, document_id: i64) -> Result<Vec<i32>, MedmeError> {
+        let mut stmt = self.conn().prepare(
+            "SELECT page_no FROM ocr_result WHERE document_id = ?1 ORDER BY page_no ASC",
+        )?;
+        let rows = stmt.query_map([document_id], |r| r.get::<_, i32>(0))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
     pub fn ocr_text(&self, document_id: i64) -> Result<String, MedmeError> {
         let mut stmt = self
             .conn()
@@ -856,6 +871,43 @@ mod tests {
         })
         .unwrap();
         assert!(v.has_document(imp.source_file.id).unwrap());
+    }
+
+    /// `ocr_page_numbers` 是 `pipeline::reindex_existing_document` 判断"该补哪些
+    /// 页"的唯一依据——必须如实反映当前落库的页,升序,建档但没有任何一页
+    /// OCR 成功时返回空(而不是 panic 或返回 `page_count` 撑出来的假页码)。
+    #[test]
+    fn ocr_page_numbers_reflects_only_pages_actually_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let v = Vault::open(dir.path()).unwrap();
+        let imp = v.import("x.pdf", "application/pdf", b"pdfbytes").unwrap();
+        let doc = v
+            .add_document(NewDocument {
+                source_file_id: imp.source_file.id,
+                doc_type: DocType::LabReport,
+                doc_date: None,
+                doc_date_end: None,
+                title: None,
+                language: None,
+                page_count: 3,
+            })
+            .unwrap();
+        // 建档但还没有任何一页 OCR 成功:空,不是 [1,2,3]。
+        assert_eq!(v.ocr_page_numbers(doc.id).unwrap(), Vec::<i32>::new());
+
+        // 乱序写入第 3、1 页,验证返回值升序而不是插入顺序。
+        for page_no in [3, 1] {
+            v.add_ocr(NewOcr {
+                document_id: doc.id,
+                page_no,
+                backend: OcrBackendKind::Native,
+                model_version: "text-layer".into(),
+                text: format!("page {page_no}"),
+                confidence: None,
+            })
+            .unwrap();
+        }
+        assert_eq!(v.ocr_page_numbers(doc.id).unwrap(), vec![1, 3]);
     }
 
     #[test]

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -301,6 +301,11 @@ pub enum IngestStatus {
     StoredNoText,
     /// DICOM 切片并入了已存在的同 study 影像检查文档(未新建文档)。
     InstanceAttached,
+    /// dedup 命中(同一份文件再导一次)、document 也早已存在,但该文档还有页
+    /// 缺文本层——本次重新导入顺手把能恢复的 PDF 页补进了 `ocr_result`(见
+    /// `reindex_existing_document`)。`pages_without_text` 是补完之后**仍然**
+    /// 缺文本的页,可能是空(全补上了)也可能非空(部分页依旧识别不出)。
+    Reindexed,
 }
 
 #[derive(Debug, Clone)]
@@ -342,6 +347,9 @@ pub struct IngestOutcome {
 
 /// 导入一个文件:存 CAS(去重)→ 若尚无 document 则抽文本层并建 document/ocr。
 /// 抽取失败(如扫描图片)不致命 → StoredNoText(原文件已永存,留待后续 OCR 补索引)。
+/// 已去重且 document 已存在时不再无条件短路——见 [`reindex_existing_document`]:
+/// 这就是"留待后续 OCR 补索引"如何真正发生的地方,同一份文件再导一次即可补齐
+/// 当初漏掉的 PDF 页(#63b)。
 /// 可注入的 DICOM 元数据解析器。桌面端注入**隔离子进程**版本:按文件里声明的
 /// 长度分配内存发生在解析期,畸形文件可诱导数 GB 分配(模糊测试实测),隔离后
 /// 崩溃只波及短命子进程,不影响持有保险箱的主进程。
@@ -380,13 +388,7 @@ pub fn ingest_with_dicom_parser(
     let sid = imp.source_file.id;
 
     if imp.deduped && vault.has_document(sid)? {
-        return Ok(IngestOutcome {
-            source_file_id: sid,
-            name,
-            status: IngestStatus::Deduped,
-            doc_type: None,
-            pages_without_text: Vec::new(),
-        });
+        return reindex_existing_document(vault, sid, &name, is_pdf(path), &bytes);
     }
 
     // .dcm 走独立分支(不经 parser/OCR):DICOM 自带结构化元数据,免 OCR 即可
@@ -604,7 +606,32 @@ fn ingest_pdf(
         language: parser::detect_language(&text),
         page_count: mixed.page_count(),
     })?;
-    for page in &mixed.pages {
+    add_ocr_pages(vault, doc.id, mixed.pages.iter())?;
+    let status = if deduped {
+        IngestStatus::Backfilled
+    } else {
+        IngestStatus::New
+    };
+    Ok(IngestOutcome {
+        source_file_id: sid,
+        name: name.to_string(),
+        status,
+        doc_type: Some(doc_type),
+        pages_without_text,
+    })
+}
+
+/// 把 `recognize_pdf_mixed` 逐页判定的结果写进 `ocr_result`——`ingest_pdf`
+/// 建档时(全部页)与 `reindex_existing_document` 补页时(只挑 missing 的页)
+/// 共用同一段 match/落库逻辑,不许长成两份会走偏的拷贝。`Unrecognized` 的页
+/// 跳过不写(该页仍然没有文本,调用方自行从 `pages_without_text`/重新查库
+/// 得知)。
+fn add_ocr_pages<'a>(
+    vault: &Vault,
+    document_id: i64,
+    pages: impl Iterator<Item = &'a ocr::PdfPage>,
+) -> anyhow::Result<()> {
+    for page in pages {
         let (page_text, backend, model_version, confidence): (
             &str,
             OcrBackendKind,
@@ -625,7 +652,7 @@ fn ingest_pdf(
             ocr::PdfPageText::Unrecognized => continue,
         };
         vault.add_ocr(NewOcr {
-            document_id: doc.id,
+            document_id,
             page_no: page.page_no,
             backend,
             model_version: model_version.to_string(),
@@ -637,17 +664,97 @@ fn ingest_pdf(
             confidence,
         })?;
     }
-    let status = if deduped {
-        IngestStatus::Backfilled
-    } else {
-        IngestStatus::New
-    };
+    Ok(())
+}
+
+/// 给定 document 建档时定死的 `page_count` 与当前已落库的 `ocr_result.page_no`
+/// 集合,算出仍然缺文本的页码(1-based,升序)。纯函数,不碰库——
+/// `reindex_existing_document` 补页前后各调一次,分别得到「该补哪些页」和
+/// 「补完之后还缺哪些页」。
+fn missing_pages(page_count: i32, present: &[i32]) -> Vec<i32> {
+    let present: std::collections::HashSet<i32> = present.iter().copied().collect();
+    (1..=page_count).filter(|p| !present.contains(p)).collect()
+}
+
+/// dedup 命中(同一份文件字节再导一次)、且 document 早已存在时的处理:默认
+/// 什么都不做,原样报 `Deduped`;但如果这份文档还有页缺文本层
+/// (`pages_without_text` 当年非空)、这次拿到的又是 PDF,就顺手用这次重新读到
+/// 的原始字节把能恢复的页补进 `ocr_result`,状态改报 `Reindexed`。
+///
+/// **修的缺陷(#63b,GitHub 上被关早了)**:在这个改动之前,`ingest` 顶层看到
+/// `imp.deduped && vault.has_document(sid)?` 就直接短路返回 `Deduped`——不管
+/// 这份文档当初有没有页因为超出单次 OCR 上限、渲染失败、或"本次会话第一份
+/// 就是 PDF、OCR 模型还没落盘"而漏了文本。全仓没有任何别的入口能把这些页
+/// 补上,用户能做的只有删除整份、重新导入。现在:同一份文件再导一次,
+/// 如果它是 PDF 且还缺页,就顺带把缺的页重新识别一遍——不用户特地找一个
+/// "重新识别"按钮,今天最朴素的"再选一次这份文件导入"就能把缺的页找回来。
+///
+/// **为什么这样补不破坏 CAS 去重的幂等性 / 事件溯源的可重放性**:
+///
+/// 1. CAS 去重(`Vault::import` 命中已有 `content_hash` 就不再 append
+///    `FileImported`)保证的是「同一份**字节**不重复落库」——它从未是、也不该是
+///    「同一份文件不许再识别一次」的承诺。这里补的是全新的 `OcrAdded` 事件,
+///    不涉及 `FileImported`/`DocumentAdded`:不会有第二条 source_file、不会有
+///    第二个 document,CAS 的"一份内容一条记录"没有被动过。
+/// 2. 会不会补出重复的 `ocr_result` 行?不会:传进来的 `missing` 只包含**当前
+///    库里还没有 `ocr_result` 行**的页码(由 `missing_pages` 现查现算,不是
+///    沿用导入当年缓存的旧值),所以这里 append 的每一条 `OcrAdded` 事件在
+///    `materialize::apply_event` 眼里都是"这页第一次出现",按
+///    `UNIQUE(document_id, page_no)` 正常插入。万一用户手快、并发/重复触发了
+///    两次同样的补页(比如两次点了同一个"再导一次"),第二次 append 的
+///    `OcrAdded` 在 apply 时会撞上第一次已经写好的同一 `(document_id,
+///    page_no)`,`materialize.rs` 里那段 "Idempotency guard" 直接跳过插入和
+///    FTS 索引——不会长出两条 `ocr_result`。
+/// 3. `rebuild_from_log` 全量重放后是否与当前库一致?一致——因为"库里现在长
+///    什么样"完全由「日志里已经 append 了哪些事件」决定,不由「重放时是否
+///    调用过这个函数」决定。这个函数只负责**决定要不要 append 新的
+///    `OcrAdded` 事件**;一旦事件写进日志,它和任何其它 `OcrAdded` 一样,
+///    重放到哪个设备、多少次,都会投影出同一行(2 里说的幂等 guard 保证)。
+///    换句话说:补页 = 正常追加一批新事件,不是"回头改历史",重放规则完全
+///    不用为它开特例。
+///
+/// **只有 PDF 能补**:多页 TIFF 第 2 页起的缺页恢复需要新的逐帧解码路径
+/// (`ocr::decode_image_bounded` 目前只解第一帧,见 `ingest_image` 文档注释),
+/// 不在本次范围——非 PDF 或已完整的文档原样返回 `Deduped`,`pages_without_text`
+/// 留空,与改动前的行为逐字节一致(不引入新的字段语义)。
+fn reindex_existing_document(
+    vault: &Vault,
+    sid: i64,
+    name: &str,
+    is_pdf: bool,
+    bytes: &[u8],
+) -> anyhow::Result<IngestOutcome> {
+    let doc = vault.document_by_source_file_id(sid)?.ok_or_else(|| {
+        // has_document(sid) 刚判定为真,这里查不到是数据不一致(而非正常分支),
+        // 直接报错而不是悄悄退化成某个默认状态。
+        anyhow::anyhow!("has_document 为真但 document_by_source_file_id 查不到 document")
+    })?;
+    let present = vault.ocr_page_numbers(doc.id)?;
+    let missing = missing_pages(doc.page_count, &present);
+    if missing.is_empty() || !is_pdf {
+        return Ok(IngestOutcome {
+            source_file_id: sid,
+            name: name.to_string(),
+            status: IngestStatus::Deduped,
+            doc_type: Some(doc.doc_type),
+            pages_without_text: Vec::new(),
+        });
+    }
+    let want: std::collections::HashSet<i32> = missing.iter().copied().collect();
+    let mixed = ocr::recognize_pdf_mixed(bytes)?;
+    add_ocr_pages(
+        vault,
+        doc.id,
+        mixed.pages.iter().filter(|p| want.contains(&p.page_no)),
+    )?;
+    let present_after = vault.ocr_page_numbers(doc.id)?;
+    let still_missing = missing_pages(doc.page_count, &present_after);
     Ok(IngestOutcome {
         source_file_id: sid,
         name: name.to_string(),
-        status,
-        doc_type: Some(doc_type),
-        pages_without_text,
+        status: IngestStatus::Reindexed,
+        doc_type: Some(doc.doc_type),
+        pages_without_text: still_missing,
     })
 }
 
@@ -852,6 +959,191 @@ trailer\n<< /Root 1 0 R /Size 4 >>\n%%EOF\n";
         let mut bytes = Vec::new();
         doc.save_to(&mut bytes).expect("save PDF");
         bytes
+    }
+
+    /// Same shape as [`build_two_page_pdf_second_page_blank`], except page 2
+    /// also carries a real (Helvetica) text layer -- long enough to clear
+    /// `ocr::MIN_TEXT_LAYER_LEN` on its own, so recognizing it never touches
+    /// an OCR engine (deterministic on every machine/CI, unlike an
+    /// OCR-recovered scanned page). Used by the reindex test below to prove a
+    /// page gets recovered on retry *without* the test depending on which (if
+    /// any) OCR engine is linked -- the same reason
+    /// `multi_page_tiff_reports_the_pages_it_never_read_...` avoids asserting
+    /// on recognized text.
+    fn build_two_page_pdf_both_pages_have_text() -> Vec<u8> {
+        use lopdf::content::{Content, Operation};
+        use lopdf::{dictionary, Document as LoDocument, Object, Stream};
+
+        let mut doc = LoDocument::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+        });
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! { "F1" => font_id },
+        });
+        let page_of = |doc: &mut LoDocument, text: &str, parent, resources| {
+            let content = Content {
+                operations: vec![
+                    Operation::new("BT", vec![]),
+                    Operation::new("Tf", vec!["F1".into(), 12.into()]),
+                    Operation::new("Td", vec![20.into(), 700.into()]),
+                    Operation::new("Tj", vec![Object::string_literal(text)]),
+                    Operation::new("ET", vec![]),
+                ],
+            };
+            let content_id = doc.add_object(Stream::new(
+                dictionary! {},
+                content.encode().expect("encode content stream"),
+            ));
+            doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => parent,
+                "Contents" => content_id,
+                "Resources" => resources,
+            })
+        };
+        let page1_id = page_of(
+            &mut doc,
+            "Discharge summary printed page one clinical text",
+            pages_id,
+            resources_id,
+        );
+        let page2_id = page_of(
+            &mut doc,
+            "Lab report appended as page two clinical text",
+            pages_id,
+            resources_id,
+        );
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![page1_id.into(), page2_id.into()],
+                "Count" => 2,
+                "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        let mut bytes = Vec::new();
+        doc.save_to(&mut bytes).expect("save PDF");
+        bytes
+    }
+
+    /// **修 #63b(GitHub 关早了):dedup 命中的已存在文档,重新导入必须能补上
+    /// 当年漏掉的页,而不是被短路成永久 `Deduped`。**
+    ///
+    /// 用底层 `Vault` API 直接摆出"首次导入当年漏了第 2 页"这个可观察状态——
+    /// document 已建、`page_count == 2`、`ocr_result` 只有第 1 页——而不经
+    /// `ingest_pdf` 走一遍完整流程:这份 PDF 两页都有真实文本层,`ingest_pdf`
+    /// 今天根本不会漏页,没法用来复现"首次漏页"这个前提(现实中漏页的原因是
+    /// 超出单次 OCR 上限 / 渲染失败 / 模型还没落盘,不是文本层本身有没有——但
+    /// 那些原因都不确定性、依赖具体 OCR 引擎,断言不动;这里只固定"漏页之后
+    /// 的库状态",不纠结漏页的成因)。
+    ///
+    /// 断言的是**真正的缺陷信号**:重新导入同一份文件后,`ocr_result` 里第 2
+    /// 页那一行是不是真的出现了——不是"函数没 panic"这种弱断言。
+    #[test]
+    fn reindex_recovers_missing_pdf_page_on_reimport() {
+        let vdir = tempfile::tempdir().unwrap();
+        let fdir = tempfile::tempdir().unwrap();
+        let v = Vault::open(vdir.path()).unwrap();
+        let name = "2026-02-01_出院小结_两页文本.pdf";
+        let p = fdir.path().join(name);
+        let bytes = build_two_page_pdf_both_pages_have_text();
+        std::fs::write(&p, &bytes).unwrap();
+
+        let imp = v.import(name, "application/pdf", &bytes).unwrap();
+        assert!(!imp.deduped, "首次 import 不应该去重");
+        let doc = v
+            .add_document(NewDocument {
+                source_file_id: imp.source_file.id,
+                doc_type: DocType::DischargeSummary,
+                doc_date: None,
+                doc_date_end: None,
+                title: Some("出院小结".into()),
+                language: None,
+                page_count: 2,
+            })
+            .unwrap();
+        v.add_ocr(NewOcr {
+            document_id: doc.id,
+            page_no: 1,
+            backend: OcrBackendKind::Native,
+            model_version: "text-layer".into(),
+            text: "page one text".into(),
+            confidence: None,
+        })
+        .unwrap();
+        // 摆好前提:此刻确实只有第 1 页有 ocr_result,第 2 页缺。
+        assert_eq!(v.ocr_page_numbers(doc.id).unwrap(), vec![1]);
+
+        // 重新导入**同一份文件**(同字节 ⇒ CAS 命中 dedup)。改动前:
+        // `imp.deduped && vault.has_document(sid)?` 直接短路返回 Deduped,
+        // ocr_result 行数原地不动——这正是本次要修的缺陷,退回该行为应让
+        // 下面的断言变红(见 PR 描述里的 red→green 记录)。
+        let o2 = ingest(&v, &p).unwrap();
+
+        assert_eq!(
+            o2.status,
+            IngestStatus::Reindexed,
+            "文档已存在但仍缺页时,再导一次应报 Reindexed 而不是原地 Deduped"
+        );
+        assert!(
+            o2.pages_without_text.is_empty(),
+            "第 2 页这次应该补上了,got {:?}",
+            o2.pages_without_text
+        );
+        // 核心断言:ocr_result 真的多了一行,不是只测状态字段没 panic。
+        assert_eq!(
+            v.ocr_page_numbers(doc.id).unwrap(),
+            vec![1, 2],
+            "ocr_result 应该多出第 2 页这一行"
+        );
+        let full_text = v.ocr_text(doc.id).unwrap();
+        assert!(
+            full_text.contains("Lab report appended as page two"),
+            "第 2 页的文本应该已经落库:{full_text}"
+        );
+
+        // 事件溯源的硬约束:补页靠的是普通的 `OcrAdded` 事件(见
+        // `reindex_existing_document` 头部注释的推理),不是什么脱离日志的
+        // 旁路写入——`rebuild_from_log` 清空全部派生表、只从 `log/` + `objects/`
+        // 重放,结果必须逐页一致,否则说明补页走了日志之外的路。
+        //
+        // 重放后不假定 `document.id` 数值不变(`document` 表是 `INTEGER PRIMARY
+        // KEY` 无 AUTOINCREMENT,理论上重放顺序一致时会落回同一个 id,但不靠这个
+        // 巧合——按 `source_file_id` 重新查一次,和别处 rebuild 测试的做法一致)。
+        v.rebuild_from_log().unwrap();
+        let doc_after = v
+            .document_by_source_file_id(imp.source_file.id)
+            .unwrap()
+            .expect("重放后 document 必须还在");
+        assert_eq!(
+            v.ocr_page_numbers(doc_after.id).unwrap(),
+            vec![1, 2],
+            "rebuild_from_log 重放后,第 2 页的 ocr_result 必须还在"
+        );
+        assert_eq!(
+            v.ocr_text(doc_after.id).unwrap(),
+            full_text,
+            "rebuild_from_log 重放后文本必须与重放前逐字一致"
+        );
+
+        // 再导一次(此刻已完整):不该再报 Reindexed,也不该重复写 ocr_result。
+        let o3 = ingest(&v, &p).unwrap();
+        assert_eq!(
+            o3.status,
+            IngestStatus::Deduped,
+            "已经补完的文档,再导一次应该原样 Deduped(没有更多可补的页)"
+        );
+        assert_eq!(v.ocr_page_numbers(doc_after.id).unwrap(), vec![1, 2]);
     }
 
     /// **Reproduces the mixed-page-PDF silent-data-loss defect this file's


### PR DESCRIPTION
## 缺陷

`packages/pipeline/src/lib.rs` 里 `imp.deduped && vault.has_document(sid)?` 命中就无条件返回 `Deduped`——一份文档因超出单次 OCR 上限、渲染失败、或本次会话第一份就是 PDF(OCR 模型还没落盘)而漏了某几页文本后,全仓没有任何入口能把这些页补上,用户只能删除整份重新导入。GitHub #63 的 (b) 条描述的正是这个形态,曾被过早关闭((a) 多页 TIFF 报告缺页的问题已修,(b) 这条没有)。

## 选择的方向

选了任务里提出的第二条:dedup 短路那条路放行进 OCR 补齐分支,不重复落库,只补 `ocr_result`。理由:去重的本意是「同一份字节不重复落库」,从不是「同一份文件不许再识别一次」——原始字节已经在 CAS 里(Raw Never Dies),重新识别不需要用户找到原文件、也不需要新的 UI 入口:今天最朴素的"再选一次这份文件导入"(桌面/CLI 已有的动作,mobile 端重选同一份 PDF 一样可达)就会触发补页。

**范围明确限定为 PDF**:多页 TIFF 第 2 页起的缺页恢复需要新的逐帧解码路径(`ocr::decode_image_bounded` 目前只解第一帧),不在本次范围。单页图片 `StoredNoText`(OCR 引擎本身失败,非 TIFF 多帧问题)同样未覆盖——mobile 端图片在到达 Rust 之前已经 OCR 过一次(`ingest_image_with_text`),桌面端 Apple Vision / Windows.Media.Ocr 都不需要下载模型,只有 Linux 的 ppocr-v5 ONNX 存在"模型还没下载"这个失败窗口,且没有一个可注入的引擎缝隙能写出确定性测试——留作已知缺口,如需要请另开工单。

**未新增 UI 按钮**("重新识别这一份"):现有入口已经生效,且要接一个不依赖重选文件的按钮需要新的 FRB 桥接函数 + Flutter UI,超出本次改动预算,直说未做。

## 事件溯源怎么处理

补页走的是普通的 `OcrAdded` 事件,不是新事件类型、不是脱离日志的旁路写入:

1. CAS 去重保证的是「同一份字节不重复落库」——这里不追加 `FileImported`/`DocumentAdded`,没有第二条 source_file、没有第二个 document。
2. 传入的 `missing` 页码由新增的 `Vault::ocr_page_numbers` 现查现算(不是导入当年缓存的旧值),所以每条 append 的 `OcrAdded` 对应的 `(document_id, page_no)` 在库里必然是首次出现,按 `UNIQUE(document_id, page_no)` 正常插入;万一重复触发同一次补页,`materialize::apply_event` 已有的 "Idempotency guard" 会在第二次直接跳过插入和 FTS 索引,不会长出重复行。
3. `rebuild_from_log` 全量重放后与当前库一致——因为"库里现在长什么样"完全由「日志里已经 append 了哪些事件」决定,不由"重放时是否调用过这个函数"决定;一旦事件写进日志,它和任何其它 `OcrAdded` 一样,重放到哪个设备、多少次,都会投影出同一行。测试 `reindex_recovers_missing_pdf_page_on_reimport` 显式验证:补页后调用 `rebuild_from_log()`,`ocr_page_numbers`/`ocr_text` 与重放前逐字一致。

完整推理落在 `reindex_existing_document` 的文档注释里(中文)。

## 改动

- `packages/pipeline/src/lib.rs`:新增 `IngestStatus::Reindexed`;`ingest_with_dicom_parser` 的 dedup 短路改调 `reindex_existing_document`;抽出 `add_ocr_pages`/`missing_pages` 供 `ingest_pdf` 与新逻辑共用(不许两份会走偏的拷贝)。
- `packages/core-model/src/query.rs`:新增 `Vault::ocr_page_numbers`(该文档已落库的页码集合,升序)。
- `apps/cli/src/main.rs`、`apps/desktop/src-tauri/{commands.rs,dto.rs}`、`apps/desktop/src/components/ImportView.tsx`、`apps/mobile_flutter/rust/src/api/{vault.rs,vault_ephemeral.rs}`、`apps/mobile_flutter/lib/screens/import_helpers.dart`:补上新枚举分支的展示态映射(exhaustive match 编译期强制,逐一确认过不会误报"未能处理"/"导入失败")。

## Red → green(实测)

新测试 `reindex_recovers_missing_pdf_page_on_reimport`(`packages/pipeline/src/lib.rs`):先用底层 `Vault` API 摆出"文档已建、`page_count=2`、只有第 1 页有 `ocr_result`"这个可观察状态(不经 `ingest_pdf`,因为测试用的两页都有真文本层的 PDF 今天根本不会漏页,没法复现"首次漏页"这个前提),断言 `ocr_result` 页码集合真的从 `[1]` 变成 `[1,2]`——不是只测状态字段没 panic。

退回修改(把 dedup 短路临时改回无条件返回 `Deduped`)后实测:

```
thread 'tests::reindex_recovers_missing_pdf_page_on_reimport' panicked at
packages/pipeline/src/lib.rs:1102:9:
assertion `left == right` failed: 文档已存在但仍缺页时,再导一次应报 Reindexed 而不是原地 Deduped
  left: Deduped
 right: Reindexed
```

恢复修改后该测试通过;`cargo test -p pipeline` 全绿(13 passed, 1 ignored)。

## 门禁(全部实测通过)

- [x] `cargo test --workspace` —— 全绿
- [x] `cd apps/mobile_flutter/rust && cargo test`(独立 workspace)—— 39 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —— 两个 workspace 均无警告
- [x] `cargo fmt --check` —— 两个 workspace 均无 diff
- [x] `cd apps/mobile_flutter && flutter test` —— 301 passed, exit 0
- [x] `flutter analyze` —— No issues found

不合并,不推 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)