### PR TITLE
移动端 PDF 导入加逐页进度出口(Rust → StreamSink → Dart)

### DIFF
--- a/apps/mobile_flutter/lib/import_flow.dart
+++ b/apps/mobile_flutter/lib/import_flow.dart
@@ -685,7 +685,36 @@ Future<ImportRunResult> _runImport(
       } else {
         stage = 'save';
         final bytes = await File(item.path).readAsBytes();
-        outcome = await ingestBytes(filename: item.name, data: bytes);
+        // 扫描版 PDF 的耗时几乎全砸在这一步:测试 PDF 的扫描页几乎全是
+        // JPEG(DCTDecode)编码——手机拍照/App 导出扫描件最常见的编码——而
+        // `packages/ocr` 自己就能 OCR 这种页(见 `pipeline::ingest_pdf`)。下面
+        // `backfillPagesWithoutText` 那条按页回填的进度只在 Rust 没能处理时才
+        // 触发,这种最常见的情况下它一次都不会跑——原来这一步全程零反馈(真机上
+        // 是几十秒量级)。`ingestBytesWithProgress` 换掉 `ingestBytes`,复用与
+        // 下面 `backfillPagesWithoutText` 的 `onPage` 回调完全同一套文案。
+        //
+        // **不会抛出 Rust 侧的 `Err`**(与 `loadDemoData` 同一个坑,见
+        // `PdfImportProgressDto` 顶部文档):FRB 带 `StreamSink` 参数的函数,
+        // Dart 侧没有任何代码 `await` 函数自身的返回值。成败走流最后一条消息的
+        // `outcome`/`error`,这里判它、失败原样 `throw`,与旧版 `ingestBytes`
+        // 失败时抛异常的外部行为对齐,下面的 `catch` 不用跟着改。
+        ImportOutcomeDto? pdfOutcome;
+        await for (final p in ingestBytesWithProgress(
+          filename: item.name,
+          data: bytes,
+        )) {
+          if (p.error != null) throw p.error!;
+          if (p.outcome != null) {
+            pdfOutcome = p.outcome;
+            break;
+          }
+          progress.value = items.length > 1
+              ? '正在导入 ${i + 1}/${items.length} · 识别第 ${p.page}/${p.total} 页…'
+              : '正在识别第 ${p.page}/${p.total} 页…';
+        }
+        outcome =
+            pdfOutcome ??
+            (throw '导入未返回结果(ingest_bytes_with_progress 流意外结束)');
       }
 
       // 按页补 OCR:哪些页缺文本层由 `outcome.pagesWithoutText` 点名。逻辑本身

--- a/apps/mobile_flutter/lib/src/rust/api/dto.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/dto.dart
@@ -9,7 +9,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'dto.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `from_encounter`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
 
 /// 认领结果:医生代拍的包被还原进本机保险箱之后,各类记录各有几份。
 ///
@@ -462,6 +462,61 @@ class PatientProfileDto {
           birthDate == other.birthDate &&
           age == other.age &&
           recordCount == other.recordCount;
+}
+
+/// `api::vault::ingest_bytes_with_progress` 经 `StreamSink` 逐页推给 Dart 的
+/// 扫描版 PDF OCR 进度,配合 `import_flow.dart` 画「正在识别第 N/M 页」。
+///
+/// **为什么这条路会被卡住几十秒零反馈**:测试 PDF 的扫描页几乎全是 JPEG
+/// (DCTDecode)编码——手机拍照 / App 导出扫描件最常见的编码——而
+/// `packages/ocr` 的 `recognize_pdf_mixed` 自己就能 OCR 这种页
+/// (`extract_dct_images`)。于是耗时全砸在 `ingest_bytes` 这一次 Rust 调用
+/// 里,`import_flow.dart` 里那条按页回填的进度(`onPage` 回调,只在 Rust
+/// 没能处理时才触发)一次都没机会跑——真机上一份 25 页的扫描件是几十秒量级,
+/// 屏幕上却什么进度都没有。这个 DTO 就是给这几十秒补一个进度出口。
+///
+/// **`outcome`/`error` 而不是让函数自身返回值——同 [DemoLoadProgressDto]
+/// 顶部那段坑**:带 `StreamSink` 参数的 FRB 函数,Dart 侧签名整个折成
+/// `Stream<T>`,没有任何代码 `await` 函数自身的 `Result`。旧版 `ingest_bytes`
+/// 靠返回值报成败——如果 `ingest_bytes_with_progress` 也这样处理,恒返回
+/// `Ok(())` 却不把结果塞进流,就是把「导入失败」原样静默成功,和这张工单要
+/// 修的缺陷是同一个坑换个地方复发。所以每次调用的终态都在流的**最后一条**
+/// 消息里,`outcome`(成功)与 `error`(失败)二者恰好其一非 `None`;中间的
+/// 进度消息两者都是 `None`。
+class PdfImportProgressDto {
+  /// 已识别完的页码(1-based)。终态消息(`outcome`/`error` 非 `None`)固定
+  /// 为 0——彼时页进度已经没有意义。
+  final int page;
+
+  /// 这份 PDF 的真实总页数。终态消息固定为 0。
+  final int total;
+
+  /// 导入成功的终态结果;仅在流的最后一条消息里非 `None`,与 `error` 互斥。
+  final ImportOutcomeDto? outcome;
+
+  /// 导入失败的原因;仅在流的最后一条消息里非 `None`,与 `outcome` 互斥。
+  final String? error;
+
+  const PdfImportProgressDto({
+    required this.page,
+    required this.total,
+    this.outcome,
+    this.error,
+  });
+
+  @override
+  int get hashCode =>
+      page.hashCode ^ total.hashCode ^ outcome.hashCode ^ error.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PdfImportProgressDto &&
+          runtimeType == other.runtimeType &&
+          page == other.page &&
+          total == other.total &&
+          outcome == other.outcome &&
+          error == other.error;
 }
 
 /// 一条化验序列:最近值 + 趋势 + 最近几个点(≤4,时间升序)。没有任何带日期的点

--- a/apps/mobile_flutter/lib/src/rust/api/vault.dart
+++ b/apps/mobile_flutter/lib/src/rust/api/vault.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'dto.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_self_measurement_to`, `collect_demo_files`, `detected_name_for`, `doc_summary`, `fmt_value`, `format_plausibility_violation`, `home_monitoring_demo_entries`, `ingest_one`, `machine_device_id`, `open_resilient_with_fallback`, `parse_measured_at`, `resolve_vault_paths`, `self_measured_label`, `self_measured_title`, `vault_cell`, `with_state_mut`, `with_state`
+// These functions are ignored because they are not marked as `pub`: `add_self_measurement_to`, `collect_demo_files`, `detected_name_for`, `doc_summary`, `final_progress_dto`, `fmt_value`, `format_plausibility_violation`, `home_monitoring_demo_entries`, `ingest_bytes_core`, `ingest_one_with_progress`, `ingest_one`, `machine_device_id`, `map_ingest_result`, `open_resilient_with_fallback`, `parse_measured_at`, `prepare_ingest_tmp_file`, `resolve_vault_paths`, `self_measured_label`, `self_measured_title`, `vault_cell`, `with_state_mut`, `with_state`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultState`
 
 /// 打开(或新建)保险箱。iCloud 容器路径由 **Dart 侧经 MethodChannel 解析后传入**
@@ -81,13 +81,38 @@ Future<ImportOutcomeDto> ingestFile({required String path}) =>
     RustLib.instance.api.crateApiVaultIngestFile(path: path);
 
 /// 采集(字节直传):Flutter 侧从相机/相册/文件选择器拿到的字节 + 原始文件名。
-/// 落到沙盒 data 目录下的一次性临时文件(保留扩展名——`pipeline::mime_for` 靠
-/// 扩展名判 MIME/PDF/DICOM)→ 跑 ingest → 重建分组 → 删临时文件。镜像 Tauri 版
-/// `ingest_bytes`,只是临时文件目录用 `data_dir`(FRB 没有 `app_cache_dir()`)。
+/// 落到沙盒 data 目录下的一次性临时文件 → 跑 ingest → 重建分组 → 删临时文件。
+/// 镜像 Tauri 版 `ingest_bytes`,只是临时文件目录用 `data_dir`(FRB 没有
+/// `app_cache_dir()`)。
+///
+/// 扫描版 PDF 想要「正在识别第 N/M 页」的逐页进度请用
+/// [`ingest_bytes_with_progress`]——这个函数保持原样(没有进度出口、靠返回值
+/// 报成败),是为了不影响它现有的一大票调用方:`vault_projections.rs` 里几十处
+/// 直接调 `ingest_bytes(...)` 并**依赖返回值**的测试。改这个函数的签名会波及
+/// 全部这些调用方;新加一个函数、旧的原样保留,代价最小(决策见 PR 描述)。
 Future<ImportOutcomeDto> ingestBytes({
   required String filename,
   required List<int> data,
 }) => RustLib.instance.api.crateApiVaultIngestBytes(
+  filename: filename,
+  data: data,
+);
+
+/// 同 [`ingest_bytes`],但多接一个 `progress`:扫描版 PDF 逐页 OCR
+/// (`pipeline::ingest_pdf` → `ocr::recognize_pdf_mixed`)时逐页推一条
+/// [PdfImportProgressDto],配合 `import_flow.dart` 画「正在识别第 N/M 页」。
+/// 与 [`load_demo_data`] 同一手法。
+///
+/// **恒返回 `Ok(())`,成败都走 `progress`——同 [`load_demo_data`] 那个坑**
+/// (见 [DemoLoadProgressDto] 顶部文档):带 `StreamSink` 参数的 FRB 函数,
+/// Dart 侧没有任何代码 `await` 这个函数自身的返回值,真返回 `Err` 会在这里
+/// 悄悄丢失。旧版 `ingest_bytes` 靠返回值报成败,这里换成
+/// [`final_progress_dto`] 编码进流的最后一条消息——绝不能让一次真实失败被
+/// 悄悄变成「流正常结束但没有终态消息」这种 Dart 侧永远等不到结果的状态。
+Stream<PdfImportProgressDto> ingestBytesWithProgress({
+  required String filename,
+  required List<int> data,
+}) => RustLib.instance.api.crateApiVaultIngestBytesWithProgress(
   filename: filename,
   data: data,
 );

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.dart
@@ -69,7 +69,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 564326456;
+  int get rustContentHash => 553873576;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -195,6 +195,11 @@ abstract class RustLibApi extends BaseApi {
   Future<IcloudStatusDto> crateApiVaultIcloudStatus();
 
   Future<ImportOutcomeDto> crateApiVaultIngestBytes({
+    required String filename,
+    required List<int> data,
+  });
+
+  Stream<PdfImportProgressDto> crateApiVaultIngestBytesWithProgress({
     required String filename,
     required List<int> data,
   });
@@ -1267,6 +1272,49 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Stream<PdfImportProgressDto> crateApiVaultIngestBytesWithProgress({
+    required String filename,
+    required List<int> data,
+  }) {
+    final progress = RustStreamSink<PdfImportProgressDto>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_String(filename, serializer);
+            sse_encode_list_prim_u_8_loose(data, serializer);
+            sse_encode_StreamSink_pdf_import_progress_dto_Sse(
+              progress,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 32,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: sse_decode_AnyhowException,
+          ),
+          constMeta: kCrateApiVaultIngestBytesWithProgressConstMeta,
+          argValues: [filename, data, progress],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return progress.stream;
+  }
+
+  TaskConstMeta get kCrateApiVaultIngestBytesWithProgressConstMeta =>
+      const TaskConstMeta(
+        debugName: "ingest_bytes_with_progress",
+        argNames: ["filename", "data", "progress"],
+      );
+
+  @override
   Future<ImportOutcomeDto> crateApiVaultIngestFile({required String path}) {
     return handler.executeNormal(
       NormalTask(
@@ -1276,7 +1324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1312,7 +1360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1342,7 +1390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1369,7 +1417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1402,7 +1450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 36,
+              funcId: 37,
               port: port_,
             );
           },
@@ -1438,7 +1486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1467,7 +1515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1501,7 +1549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1534,7 +1582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1566,7 +1614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1596,7 +1644,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1626,7 +1674,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1654,7 +1702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1681,7 +1729,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1711,7 +1759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1744,7 +1792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -1774,7 +1822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1801,7 +1849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1828,7 +1876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -1855,7 +1903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -1882,6 +1930,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RustStreamSink<DemoLoadProgressDto>
   dco_decode_StreamSink_demo_load_progress_dto_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  RustStreamSink<PdfImportProgressDto>
+  dco_decode_StreamSink_pdf_import_progress_dto_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -1969,6 +2024,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_i_64(raw);
+  }
+
+  @protected
+  ImportOutcomeDto dco_decode_box_autoadd_import_outcome_dto(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_import_outcome_dto(raw);
   }
 
   @protected
@@ -2345,6 +2406,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImportOutcomeDto? dco_decode_opt_box_autoadd_import_outcome_dto(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_import_outcome_dto(raw);
+  }
+
+  @protected
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2356,6 +2423,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       birthDate: dco_decode_opt_String(arr[2]),
       age: dco_decode_opt_String(arr[3]),
       recordCount: dco_decode_i_64(arr[4]),
+    );
+  }
+
+  @protected
+  PdfImportProgressDto dco_decode_pdf_import_progress_dto(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return PdfImportProgressDto(
+      page: dco_decode_i_32(arr[0]),
+      total: dco_decode_i_32(arr[1]),
+      outcome: dco_decode_opt_box_autoadd_import_outcome_dto(arr[2]),
+      error: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -2654,6 +2735,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RustStreamSink<PdfImportProgressDto>
+  sse_decode_StreamSink_pdf_import_progress_dto_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
@@ -2742,6 +2832,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_i_64(deserializer));
+  }
+
+  @protected
+  ImportOutcomeDto sse_decode_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_import_outcome_dto(deserializer));
   }
 
   @protected
@@ -3299,6 +3397,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImportOutcomeDto? sse_decode_opt_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_import_outcome_dto(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   PatientProfileDto sse_decode_patient_profile_dto(
     SseDeserializer deserializer,
   ) {
@@ -3314,6 +3425,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       birthDate: var_birthDate,
       age: var_age,
       recordCount: var_recordCount,
+    );
+  }
+
+  @protected
+  PdfImportProgressDto sse_decode_pdf_import_progress_dto(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_page = sse_decode_i_32(deserializer);
+    var var_total = sse_decode_i_32(deserializer);
+    var var_outcome = sse_decode_opt_box_autoadd_import_outcome_dto(
+      deserializer,
+    );
+    var var_error = sse_decode_opt_String(deserializer);
+    return PdfImportProgressDto(
+      page: var_page,
+      total: var_total,
+      outcome: var_outcome,
+      error: var_error,
     );
   }
 
@@ -3652,6 +3782,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_StreamSink_pdf_import_progress_dto_Sse(
+    RustStreamSink<PdfImportProgressDto> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_pdf_import_progress_dto,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
@@ -3737,6 +3884,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_64(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_import_outcome_dto(self, serializer);
   }
 
   @protected
@@ -4218,6 +4374,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_import_outcome_dto(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_patient_profile_dto(
     PatientProfileDto self,
     SseSerializer serializer,
@@ -4228,6 +4397,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.birthDate, serializer);
     sse_encode_opt_String(self.age, serializer);
     sse_encode_i_64(self.recordCount, serializer);
+  }
+
+  @protected
+  void sse_encode_pdf_import_progress_dto(
+    PdfImportProgressDto self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.page, serializer);
+    sse_encode_i_32(self.total, serializer);
+    sse_encode_opt_box_autoadd_import_outcome_dto(self.outcome, serializer);
+    sse_encode_opt_String(self.error, serializer);
   }
 
   @protected

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.io.dart
@@ -29,6 +29,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_demo_load_progress_dto_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<PdfImportProgressDto>
+  dco_decode_StreamSink_pdf_import_progress_dto_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -60,6 +64,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
+  ImportOutcomeDto dco_decode_box_autoadd_import_outcome_dto(dynamic raw);
 
   @protected
   ChronicConditionDto dco_decode_chronic_condition_dto(dynamic raw);
@@ -193,7 +200,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
 
   @protected
+  ImportOutcomeDto? dco_decode_opt_box_autoadd_import_outcome_dto(dynamic raw);
+
+  @protected
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
+
+  @protected
+  PdfImportProgressDto dco_decode_pdf_import_progress_dto(dynamic raw);
 
   @protected
   ProxyLabDto dco_decode_proxy_lab_dto(dynamic raw);
@@ -266,6 +279,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<PdfImportProgressDto>
+  sse_decode_StreamSink_pdf_import_progress_dto_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -301,6 +320,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
+  ImportOutcomeDto sse_decode_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChronicConditionDto sse_decode_chronic_condition_dto(
@@ -470,7 +494,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
+  ImportOutcomeDto? sse_decode_opt_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PatientProfileDto sse_decode_patient_profile_dto(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PdfImportProgressDto sse_decode_pdf_import_progress_dto(
     SseDeserializer deserializer,
   );
 
@@ -556,6 +590,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_pdf_import_progress_dto_Sse(
+    RustStreamSink<PdfImportProgressDto> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -600,6 +640,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_i_64(
     PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto self,
     SseSerializer serializer,
   );
 
@@ -829,8 +875,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_patient_profile_dto(
     PatientProfileDto self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_pdf_import_progress_dto(
+    PdfImportProgressDto self,
     SseSerializer serializer,
   );
 

--- a/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
+++ b/apps/mobile_flutter/lib/src/rust/frb_generated.web.dart
@@ -31,6 +31,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_demo_load_progress_dto_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<PdfImportProgressDto>
+  dco_decode_StreamSink_pdf_import_progress_dto_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -62,6 +66,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
+  ImportOutcomeDto dco_decode_box_autoadd_import_outcome_dto(dynamic raw);
 
   @protected
   ChronicConditionDto dco_decode_chronic_condition_dto(dynamic raw);
@@ -195,7 +202,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
 
   @protected
+  ImportOutcomeDto? dco_decode_opt_box_autoadd_import_outcome_dto(dynamic raw);
+
+  @protected
   PatientProfileDto dco_decode_patient_profile_dto(dynamic raw);
+
+  @protected
+  PdfImportProgressDto dco_decode_pdf_import_progress_dto(dynamic raw);
 
   @protected
   ProxyLabDto dco_decode_proxy_lab_dto(dynamic raw);
@@ -268,6 +281,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<PdfImportProgressDto>
+  sse_decode_StreamSink_pdf_import_progress_dto_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -303,6 +322,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
+  ImportOutcomeDto sse_decode_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ChronicConditionDto sse_decode_chronic_condition_dto(
@@ -472,7 +496,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
+  ImportOutcomeDto? sse_decode_opt_box_autoadd_import_outcome_dto(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PatientProfileDto sse_decode_patient_profile_dto(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PdfImportProgressDto sse_decode_pdf_import_progress_dto(
     SseDeserializer deserializer,
   );
 
@@ -558,6 +592,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_pdf_import_progress_dto_Sse(
+    RustStreamSink<PdfImportProgressDto> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -602,6 +642,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_i_64(
     PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto self,
     SseSerializer serializer,
   );
 
@@ -831,8 +877,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_import_outcome_dto(
+    ImportOutcomeDto? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_patient_profile_dto(
     PatientProfileDto self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_pdf_import_progress_dto(
+    PdfImportProgressDto self,
     SseSerializer serializer,
   );
 

--- a/apps/mobile_flutter/rust/Cargo.lock
+++ b/apps/mobile_flutter/rust/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "flutter_rust_bridge",
  "include_dir",
  "log",
+ "lopdf 0.44.0",
  "medme-share",
  "ocr",
  "parser",

--- a/apps/mobile_flutter/rust/Cargo.toml
+++ b/apps/mobile_flutter/rust/Cargo.toml
@@ -72,6 +72,11 @@ log = "0.4"
 [dev-dependencies]
 # `api::vault_ephemeral` 的单测用临时目录(会话根/沙盒 `cache_dir`)。
 tempfile = "3"
+# 只为手搭一份真实的多页文本 PDF,验证 `ingest_bytes_core` 逐页进度回调确实
+# 被调到(`packages/ocr`/`packages/pipeline` 的同类测试已经在依赖它,版本与根
+# workspace `Cargo.toml` 的 `lopdf = "0.44"` 保持一致——本 crate 是独立
+# workspace,没有 `.workspace = true` 可用)。仅测试 profile 链接,不影响出货体积。
+lopdf = "0.44"
 
 [lints.rust]
 # `pp_ocr` 由 build.rs 按目标平台产出(见那里的说明);声明出来,免得

--- a/apps/mobile_flutter/rust/src/api/dto.rs
+++ b/apps/mobile_flutter/rust/src/api/dto.rs
@@ -38,6 +38,38 @@ pub struct DemoLoadProgressDto {
     pub error: Option<String>,
 }
 
+/// `api::vault::ingest_bytes_with_progress` 经 `StreamSink` 逐页推给 Dart 的
+/// 扫描版 PDF OCR 进度,配合 `import_flow.dart` 画「正在识别第 N/M 页」。
+///
+/// **为什么这条路会被卡住几十秒零反馈**:测试 PDF 的扫描页几乎全是 JPEG
+/// (DCTDecode)编码——手机拍照 / App 导出扫描件最常见的编码——而
+/// `packages/ocr` 的 `recognize_pdf_mixed` 自己就能 OCR 这种页
+/// (`extract_dct_images`)。于是耗时全砸在 `ingest_bytes` 这一次 Rust 调用
+/// 里,`import_flow.dart` 里那条按页回填的进度(`onPage` 回调,只在 Rust
+/// 没能处理时才触发)一次都没机会跑——真机上一份 25 页的扫描件是几十秒量级,
+/// 屏幕上却什么进度都没有。这个 DTO 就是给这几十秒补一个进度出口。
+///
+/// **`outcome`/`error` 而不是让函数自身返回值——同 [DemoLoadProgressDto]
+/// 顶部那段坑**:带 `StreamSink` 参数的 FRB 函数,Dart 侧签名整个折成
+/// `Stream<T>`,没有任何代码 `await` 函数自身的 `Result`。旧版 `ingest_bytes`
+/// 靠返回值报成败——如果 `ingest_bytes_with_progress` 也这样处理,恒返回
+/// `Ok(())` 却不把结果塞进流,就是把「导入失败」原样静默成功,和这张工单要
+/// 修的缺陷是同一个坑换个地方复发。所以每次调用的终态都在流的**最后一条**
+/// 消息里,`outcome`(成功)与 `error`(失败)二者恰好其一非 `None`;中间的
+/// 进度消息两者都是 `None`。
+#[derive(Debug, Clone)]
+pub struct PdfImportProgressDto {
+    /// 已识别完的页码(1-based)。终态消息(`outcome`/`error` 非 `None`)固定
+    /// 为 0——彼时页进度已经没有意义。
+    pub page: i32,
+    /// 这份 PDF 的真实总页数。终态消息固定为 0。
+    pub total: i32,
+    /// 导入成功的终态结果;仅在流的最后一条消息里非 `None`,与 `error` 互斥。
+    pub outcome: Option<ImportOutcomeDto>,
+    /// 导入失败的原因;仅在流的最后一条消息里非 `None`,与 `outcome` 互斥。
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct DocumentSummaryDto {
     pub id: i64,

--- a/apps/mobile_flutter/rust/src/api/vault.rs
+++ b/apps/mobile_flutter/rust/src/api/vault.rs
@@ -369,24 +369,18 @@ fn detected_name_for(v: &Vault, doc_id: i64) -> Option<String> {
         .and_then(|t| parser::extract_demographics(&t).name)
 }
 
-/// 跑一次 `pipeline::ingest` 并映射成 `ImportOutcomeDto`。抽取失败(扫描图等)
-/// 不致命——原文件已进 CAS,返回 status="failed" 让前端提示「未能识别」而非报错
-/// 崩溃。与 Tauri 版 `ingest_one` 同构。
+/// 把一次 `pipeline::ingest`(或它的变体)的结果映射成 `ImportOutcomeDto`。
+/// 抽取失败(扫描图等)不致命——原文件已进 CAS,返回 status="failed" 让前端
+/// 提示「未能识别」而非报错崩溃。与 Tauri 版 `ingest_one` 同构。
 ///
-/// 图片**不走这里**:Flutter 端先用 PP-OCRv5(`ocr_bridge.dart` →
-/// `recognize_image_pp`,iOS/安卓同引擎同模型)识别好文本,再走
-/// `ingest_image_with_text`。这里只处理 PDF/TXT/DICOM 等有文本层/结构化元数据的
-/// 文件类型。(旧注释写「安卓走 google_mlkit_text_recognition」,那条依赖早已
-/// 删除,别再据此推断。)
-fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
-    // Panic firewall:parser/dicom 栈里的 panic 不能一路 unwind 穿过持锁的 Vault、
-    // 污染共享 Mutex(与 Tauri 版 `ingest_one` 同一理由)。
-    let dispatched = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        pipeline::ingest(v, path)
-    })) {
-        Ok(r) => r,
-        Err(_) => Err(anyhow::anyhow!("导入时发生内部错误(已隔离),该文件已跳过")),
-    };
+/// [`ingest_one`]/[`ingest_one_with_progress`] 共用这段映射逻辑——两者只在
+/// 「调 `pipeline::ingest` 还是 `pipeline::ingest_with_progress`」上分岔,映射
+/// 逻辑必须只长一份,不然两条路迟早走偏。
+fn map_ingest_result(
+    v: &Vault,
+    path: &Path,
+    dispatched: anyhow::Result<pipeline::IngestOutcome>,
+) -> ImportOutcomeDto {
     match dispatched {
         Ok(o) => {
             let status = match o.status {
@@ -435,6 +429,44 @@ fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
     }
 }
 
+/// 跑一次 `pipeline::ingest` 并映射成 `ImportOutcomeDto`。
+///
+/// 图片**不走这里**:Flutter 端先用 PP-OCRv5(`ocr_bridge.dart` →
+/// `recognize_image_pp`,iOS/安卓同引擎同模型)识别好文本,再走
+/// `ingest_image_with_text`。这里只处理 PDF/TXT/DICOM 等有文本层/结构化元数据的
+/// 文件类型。(旧注释写「安卓走 google_mlkit_text_recognition」,那条依赖早已
+/// 删除,别再据此推断。)
+fn ingest_one(v: &Vault, path: &Path) -> ImportOutcomeDto {
+    // Panic firewall:parser/dicom 栈里的 panic 不能一路 unwind 穿过持锁的 Vault、
+    // 污染共享 Mutex(与 Tauri 版 `ingest_one` 同一理由)。
+    let dispatched = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pipeline::ingest(v, path)
+    })) {
+        Ok(r) => r,
+        Err(_) => Err(anyhow::anyhow!("导入时发生内部错误(已隔离),该文件已跳过")),
+    };
+    map_ingest_result(v, path, dispatched)
+}
+
+/// 同 [`ingest_one`],但透传逐页 OCR 进度回调——[`ingest_bytes_with_progress`]
+/// 用。拆成单独函数而不是给 `ingest_one` 加参数,理由与 `ingest_bytes`/
+/// `ingest_bytes_with_progress` 分离同一条:`ingest_file`/`load_demo_data` 等
+/// 一堆调用方不需要进度,不该被迫改调用点或签名。
+fn ingest_one_with_progress(
+    v: &Vault,
+    path: &Path,
+    on_page: Option<pipeline::PdfPageProgress<'_>>,
+) -> ImportOutcomeDto {
+    // Panic firewall:同 `ingest_one`。
+    let dispatched = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pipeline::ingest_with_progress(v, path, on_page)
+    })) {
+        Ok(r) => r,
+        Err(_) => Err(anyhow::anyhow!("导入时发生内部错误(已隔离),该文件已跳过")),
+    };
+    map_ingest_result(v, path, dispatched)
+}
+
 /// 采集:对一个真实文件路径(如系统文件选择器返回的路径)跑 ingest,然后重建
 /// 就诊分组。PDF/TXT/DICOM 走 `pipeline::ingest`。
 pub fn ingest_file(path: String) -> anyhow::Result<ImportOutcomeDto> {
@@ -447,11 +479,15 @@ pub fn ingest_file(path: String) -> anyhow::Result<ImportOutcomeDto> {
     })
 }
 
-/// 采集(字节直传):Flutter 侧从相机/相册/文件选择器拿到的字节 + 原始文件名。
-/// 落到沙盒 data 目录下的一次性临时文件(保留扩展名——`pipeline::mime_for` 靠
-/// 扩展名判 MIME/PDF/DICOM)→ 跑 ingest → 重建分组 → 删临时文件。镜像 Tauri 版
-/// `ingest_bytes`,只是临时文件目录用 `data_dir`(FRB 没有 `app_cache_dir()`)。
-pub fn ingest_bytes(filename: String, data: Vec<u8>) -> anyhow::Result<ImportOutcomeDto> {
+/// [`ingest_bytes`]/[`ingest_bytes_with_progress`] 共用的准备阶段:校验体积、
+/// 清洗文件名、落一次性临时文件(保留扩展名——`pipeline::mime_for` 靠扩展名判
+/// MIME/PDF/DICOM)。两者只在「用哪条 ingest 入口跑」上分岔,准备逻辑不许长成
+/// 两份会走偏的拷贝。调用方用完 `tmp_dir` 负责删。
+fn prepare_ingest_tmp_file(
+    state: &VaultState,
+    filename: &str,
+    data: &[u8],
+) -> anyhow::Result<(PathBuf, PathBuf)> {
     if data.is_empty() {
         anyhow::bail!("空文件,未采集到任何数据");
     }
@@ -462,7 +498,7 @@ pub fn ingest_bytes(filename: String, data: Vec<u8>) -> anyhow::Result<ImportOut
             pipeline::MAX_INGEST_BYTES
         );
     }
-    let base = Path::new(&filename)
+    let base = Path::new(filename)
         .file_name()
         .and_then(|n| n.to_str())
         .filter(|n| !n.is_empty())
@@ -472,21 +508,104 @@ pub fn ingest_bytes(filename: String, data: Vec<u8>) -> anyhow::Result<ImportOut
     } else {
         format!("{base}.jpg")
     };
+    let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S%f");
+    let tmp_dir = state.data_dir.join("medme-ingest").join(stamp.to_string());
+    std::fs::create_dir_all(&tmp_dir)?;
+    let tmp_path = tmp_dir.join(&safe_name);
+    std::fs::write(&tmp_path, data)?;
+    Ok((tmp_dir, tmp_path))
+}
 
-    with_state(|state| {
-        let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S%f");
-        let tmp_dir = state.data_dir.join("medme-ingest").join(stamp.to_string());
-        std::fs::create_dir_all(&tmp_dir)?;
-        let tmp_path = tmp_dir.join(&safe_name);
-        std::fs::write(&tmp_path, &data)?;
+/// [`ingest_bytes`]/[`ingest_bytes_with_progress`] 共用的核心逻辑:准备临时
+/// 文件 → 跑 ingest(可选逐页进度回调)→ 重建就诊分组 → 删临时文件。
+///
+/// 特意只吃一个普通闭包 `on_page: Option<pipeline::PdfPageProgress<'_>>`,
+/// 不直接吃 `StreamSink`——这样才能在**不构造真实 `StreamSink`** 的前提下
+/// 单元测试(`StreamSink` 需要真实 Dart 消息端口才能造出来,单测环境下造不出,
+/// 同 [DemoLoadProgressDto] 顶部注释)。`ingest_bytes_with_progress` 只负责把
+/// 一个「写 `StreamSink`」的闭包包成这个类型,自身不含任何除此之外的逻辑。
+fn ingest_bytes_core(
+    state: &VaultState,
+    filename: &str,
+    data: &[u8],
+    on_page: Option<pipeline::PdfPageProgress<'_>>,
+) -> anyhow::Result<ImportOutcomeDto> {
+    let (tmp_dir, tmp_path) = prepare_ingest_tmp_file(state, filename, data)?;
+    let v = &state.vault;
+    let outcome = ingest_one_with_progress(v, &tmp_path, on_page);
+    v.rebuild_encounters()
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let _ = std::fs::remove_dir_all(&tmp_dir); // 尽力清理,失败无妨
+    Ok(outcome)
+}
 
-        let v = &state.vault;
-        let outcome = ingest_one(v, &tmp_path);
-        v.rebuild_encounters()
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        let _ = std::fs::remove_dir_all(&tmp_dir); // 尽力清理,失败无妨
-        Ok(outcome)
-    })
+/// 采集(字节直传):Flutter 侧从相机/相册/文件选择器拿到的字节 + 原始文件名。
+/// 落到沙盒 data 目录下的一次性临时文件 → 跑 ingest → 重建分组 → 删临时文件。
+/// 镜像 Tauri 版 `ingest_bytes`,只是临时文件目录用 `data_dir`(FRB 没有
+/// `app_cache_dir()`)。
+///
+/// 扫描版 PDF 想要「正在识别第 N/M 页」的逐页进度请用
+/// [`ingest_bytes_with_progress`]——这个函数保持原样(没有进度出口、靠返回值
+/// 报成败),是为了不影响它现有的一大票调用方:`vault_projections.rs` 里几十处
+/// 直接调 `ingest_bytes(...)` 并**依赖返回值**的测试。改这个函数的签名会波及
+/// 全部这些调用方;新加一个函数、旧的原样保留,代价最小(决策见 PR 描述)。
+pub fn ingest_bytes(filename: String, data: Vec<u8>) -> anyhow::Result<ImportOutcomeDto> {
+    with_state(|state| ingest_bytes_core(state, &filename, &data, None))
+}
+
+/// 把 [`ingest_bytes_core`] 的最终 `Result` 编码成 [PdfImportProgressDto] 的
+/// 终态消息(`outcome`/`error` 二者恰好其一非 `None`)。
+///
+/// 抽成纯函数,单独就是为了能在**不构造真实 `StreamSink`** 的前提下,对
+/// 「成功和失败各自映射成什么」直接下断言——尤其是「失败必须映射成 `error`
+/// 非 `None`,不能悄悄变成一个 `outcome`/`error` 都是 `None` 的消息(那等于
+/// 静默丢失)」,这正是 [PdfImportProgressDto] 顶部文档里提到的最大风险点。
+fn final_progress_dto(result: anyhow::Result<ImportOutcomeDto>) -> PdfImportProgressDto {
+    match result {
+        Ok(outcome) => PdfImportProgressDto {
+            page: 0,
+            total: 0,
+            outcome: Some(outcome),
+            error: None,
+        },
+        Err(e) => PdfImportProgressDto {
+            page: 0,
+            total: 0,
+            outcome: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+/// 同 [`ingest_bytes`],但多接一个 `progress`:扫描版 PDF 逐页 OCR
+/// (`pipeline::ingest_pdf` → `ocr::recognize_pdf_mixed`)时逐页推一条
+/// [PdfImportProgressDto],配合 `import_flow.dart` 画「正在识别第 N/M 页」。
+/// 与 [`load_demo_data`] 同一手法。
+///
+/// **恒返回 `Ok(())`,成败都走 `progress`——同 [`load_demo_data`] 那个坑**
+/// (见 [DemoLoadProgressDto] 顶部文档):带 `StreamSink` 参数的 FRB 函数,
+/// Dart 侧没有任何代码 `await` 这个函数自身的返回值,真返回 `Err` 会在这里
+/// 悄悄丢失。旧版 `ingest_bytes` 靠返回值报成败,这里换成
+/// [`final_progress_dto`] 编码进流的最后一条消息——绝不能让一次真实失败被
+/// 悄悄变成「流正常结束但没有终态消息」这种 Dart 侧永远等不到结果的状态。
+pub fn ingest_bytes_with_progress(
+    filename: String,
+    data: Vec<u8>,
+    progress: StreamSink<PdfImportProgressDto>,
+) -> anyhow::Result<()> {
+    let cb = |page: i32, total: i32| {
+        // 忽略发送失败:监听端已断开不该打断导入本身(与 `load_demo_data`
+        // 同一理由,单向 UI 反馈,不是导入流程的一部分)。
+        let _ = progress.add(PdfImportProgressDto {
+            page,
+            total,
+            outcome: None,
+            error: None,
+        });
+    };
+    let result = with_state(|state| ingest_bytes_core(state, &filename, &data, Some(&cb)));
+    let _ = progress.add(final_progress_dto(result));
+    Ok(())
 }
 
 /// 扫描版 PDF 的逐页 OCR 回填。`ingest_bytes`/`ingest_pdf`(Rust pipeline)对
@@ -1842,5 +1961,177 @@ mod measured_at_timezone_tests {
             "2026-05-01",
             "应按传入偏移下的字面日期落库,不因转 UTC 跨到下一天",
         );
+    }
+}
+
+#[cfg(test)]
+mod ingest_bytes_progress_tests {
+    use super::*;
+
+    /// 造一份两页、每页都有真实文本层的最小 PDF——不需要 OCR 引擎就能走完
+    /// `pipeline::ingest_pdf` 的逐页分支,与 `packages/pipeline`/`packages/ocr`
+    /// 里同类测试手搭 PDF 的做法一致(见那两处 `build_two_page_pdf_*`/
+    /// `recognize_pdf_mixed_reads_real_two_page_pdf_in_order`)。
+    fn build_two_page_text_pdf() -> Vec<u8> {
+        use lopdf::content::{Content, Operation};
+        use lopdf::{dictionary, Document as LoDocument, Object, Stream};
+
+        let mut doc = LoDocument::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+        });
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! { "F1" => font_id },
+        });
+        let page_of = |doc: &mut LoDocument, text: &str, parent, resources| {
+            let content = Content {
+                operations: vec![
+                    Operation::new("BT", vec![]),
+                    Operation::new("Tf", vec!["F1".into(), 12.into()]),
+                    Operation::new("Td", vec![20.into(), 700.into()]),
+                    Operation::new("Tj", vec![Object::string_literal(text)]),
+                    Operation::new("ET", vec![]),
+                ],
+            };
+            let content_id = doc.add_object(Stream::new(
+                dictionary! {},
+                content.encode().expect("encode content stream"),
+            ));
+            doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => parent,
+                "Contents" => content_id,
+                "Resources" => resources,
+            })
+        };
+        let page1_id = page_of(
+            &mut doc,
+            "Page one clinical text content",
+            pages_id,
+            resources_id,
+        );
+        let page2_id = page_of(
+            &mut doc,
+            "Page two clinical text content",
+            pages_id,
+            resources_id,
+        );
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![page1_id.into(), page2_id.into()],
+                "Count" => 2,
+                "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        let mut bytes = Vec::new();
+        doc.save_to(&mut bytes).expect("save PDF");
+        bytes
+    }
+
+    /// 单测专用:开一个临时保险箱,组一份 `VaultState`——不经全局 `VAULT`
+    /// 静态/`open_vault`(那条路要真实沙盒目录、且是进程级单例,并发测试会
+    /// 互相打架),与 `home_monitoring_demo_data_tests` 里的做法同一手法。
+    /// 返回值把 `tempfile::TempDir` 一并交出去,调用方必须持有到断言结束
+    /// (`TempDir` drop 时删目录,提前丢弃会让 `data_dir`/`docs_dir` 失效)。
+    fn test_vault_state() -> (VaultState, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().join("docs");
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&docs_dir).unwrap();
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let truth_root = docs_dir.join("vault");
+        let db_path = truth_root.join("medme.db");
+        let vault = Vault::open_split_resilient(&truth_root, &db_path, "test-device").unwrap();
+        (
+            VaultState {
+                vault,
+                truth_root,
+                db_path,
+                device_id: "test-device".to_string(),
+                docs_dir,
+                data_dir,
+            },
+            tmp,
+        )
+    }
+
+    /// 本工单要修的核心行为:`ingest_bytes_core` 必须让 `on_page` 逐页触发,
+    /// 次数等于页数、顺序一致——这就是移动端导入对话框能画出「正在识别第
+    /// N/M 页」而不是原地不动几十秒转圈的直接依据。
+    #[test]
+    fn ingest_bytes_core_reports_progress_once_per_page() {
+        let (state, _tmp) = test_vault_state();
+        let bytes = build_two_page_text_pdf();
+        let seen: std::cell::RefCell<Vec<(i32, i32)>> = std::cell::RefCell::new(Vec::new());
+        let cb = |page: i32, total: i32| seen.borrow_mut().push((page, total));
+
+        let outcome =
+            ingest_bytes_core(&state, "两页文本.pdf", &bytes, Some(&cb)).expect("ingest 应成功");
+        assert_eq!(outcome.status, "new");
+        assert_eq!(
+            seen.into_inner(),
+            vec![(1, 2), (2, 2)],
+            "必须逐页各报一次,顺序一致,total 是真实页数"
+        );
+    }
+
+    /// 回归:重构成 `prepare_ingest_tmp_file`/`ingest_bytes_core` 之后,旧版
+    /// `ingest_bytes` 的「空文件拒绝」校验不能丢——空字节走的是这条共用路径,
+    /// 两个入口(`ingest_bytes`/`ingest_bytes_with_progress`)都靠它挡住。
+    #[test]
+    fn ingest_bytes_core_rejects_empty_data() {
+        let (state, _tmp) = test_vault_state();
+        let err = ingest_bytes_core(&state, "空文件.pdf", &[], None)
+            .expect_err("空数据应该报错,不能悄悄成功");
+        assert!(
+            err.to_string().contains("空文件"),
+            "错误信息应指明原因:{err}"
+        );
+    }
+
+    /// **本工单最大的风险点自证**:`ingest_bytes_with_progress` 不能像
+    /// [DemoLoadProgressDto] 顶部文档警告的那样,把一次真实失败悄悄变成
+    /// Dart 侧永远等不到的「流正常结束但没有终态消息」。`final_progress_dto`
+    /// 就是这个映射的全部逻辑,拆成纯函数使其可以在不构造真实 `StreamSink`
+    /// 的前提下(单测环境下造不出来)直接断言:给定一个真实的 `Err`,
+    /// 映射结果必须把它原样带在 `error` 里,`outcome` 必须是 `None`——
+    /// 不允许两者都是 `None`(那就是把失败悄悄吞成了不确定态)。
+    #[test]
+    fn final_progress_dto_carries_the_error_through_not_swallowed() {
+        let dto = final_progress_dto(Err(anyhow::anyhow!("空文件,未采集到任何数据")));
+        assert!(dto.outcome.is_none(), "失败时 outcome 必须是 None");
+        assert_eq!(
+            dto.error.as_deref(),
+            Some("空文件,未采集到任何数据"),
+            "失败原因必须原样带出,不能丢失"
+        );
+    }
+
+    /// 对照组:成功时同一个函数必须把 `outcome` 带出、`error` 留空——与上面
+    /// 失败那条一起,钉住 `outcome`/`error` 互斥这条契约的两端。
+    #[test]
+    fn final_progress_dto_carries_the_outcome_on_success() {
+        let outcome = ImportOutcomeDto {
+            name: "test.pdf".to_string(),
+            source_file_id: 1,
+            status: "new".to_string(),
+            doc_type: None,
+            document_id: Some(1),
+            detected_name: None,
+            pages_without_text: Vec::new(),
+        };
+        let dto = final_progress_dto(Ok(outcome));
+        assert!(dto.error.is_none(), "成功时 error 必须是 None");
+        assert_eq!(dto.outcome.map(|o| o.status), Some("new".to_string()));
     }
 }

--- a/apps/mobile_flutter/rust/src/frb_generated.rs
+++ b/apps/mobile_flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 564326456;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 553873576;
 
 // Section: executor
 
@@ -1176,6 +1176,50 @@ fn wire__crate__api__vault__ingest_bytes_impl(
         },
     )
 }
+fn wire__crate__api__vault__ingest_bytes_with_progress_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ingest_bytes_with_progress",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_filename = <String>::sse_decode(&mut deserializer);
+            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_progress = <StreamSink<
+                crate::api::dto::PdfImportProgressDto,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::vault::ingest_bytes_with_progress(
+                            api_filename,
+                            api_data,
+                            api_progress,
+                        )?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__vault__ingest_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1916,6 +1960,19 @@ impl SseDecode
     }
 }
 
+impl SseDecode
+    for StreamSink<
+        crate::api::dto::PdfImportProgressDto,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
 impl SseDecode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2535,6 +2592,19 @@ impl SseDecode for Option<i64> {
     }
 }
 
+impl SseDecode for Option<crate::api::dto::ImportOutcomeDto> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::dto::ImportOutcomeDto>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for crate::api::dto::PatientProfileDto {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2549,6 +2619,22 @@ impl SseDecode for crate::api::dto::PatientProfileDto {
             birth_date: var_birthDate,
             age: var_age,
             record_count: var_recordCount,
+        };
+    }
+}
+
+impl SseDecode for crate::api::dto::PdfImportProgressDto {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_page = <i32>::sse_decode(deserializer);
+        let mut var_total = <i32>::sse_decode(deserializer);
+        let mut var_outcome = <Option<crate::api::dto::ImportOutcomeDto>>::sse_decode(deserializer);
+        let mut var_error = <Option<String>>::sse_decode(deserializer);
+        return crate::api::dto::PdfImportProgressDto {
+            page: var_page,
+            total: var_total,
+            outcome: var_outcome,
+            error: var_error,
         };
     }
 }
@@ -3003,44 +3089,50 @@ fn pde_ffi_dispatcher_primary_impl(
         29 => wire__crate__api__vault__get_document_impl(port, ptr, rust_vec_len, data_len),
         30 => wire__crate__api__vault__icloud_status_impl(port, ptr, rust_vec_len, data_len),
         31 => wire__crate__api__vault__ingest_bytes_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
-        33 => {
+        32 => wire__crate__api__vault__ingest_bytes_with_progress_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        33 => wire__crate__api__vault__ingest_file_impl(port, ptr, rust_vec_len, data_len),
+        34 => {
             wire__crate__api__vault__ingest_image_with_text_impl(port, ptr, rust_vec_len, data_len)
         }
-        34 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__vault__proxy_claim_blob_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__vault__proxy_summary_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__vault__qr_share_blob_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__vault__recognize_image_pp_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
-        46 => {
+        35 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__vault__load_archive_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__vault__load_demo_data_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__vault__open_vault_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__vault__patient_profile_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__vault__proxy_claim_blob_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__vault__proxy_summary_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__vault__qr_share_blob_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__vault__read_source_bytes_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__vault__recognize_image_pp_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__vault__render_dicom_png_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__vault__reset_vault_impl(port, ptr, rust_vec_len, data_len),
+        47 => {
             wire__crate__api__vault__self_measurement_values_impl(port, ptr, rust_vec_len, data_len)
         }
-        47 => {
+        48 => {
             wire__crate__api__vault__source_file_object_path_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__api__vault_projections__view_emergency_card_impl(
+        49 => wire__crate__api__vault_projections__view_emergency_card_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => wire__crate__api__vault_projections__view_trend_panel_catalog_impl(
+        50 => wire__crate__api__vault_projections__view_trend_panel_catalog_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => {
+        51 => {
             wire__crate__api__vault_projections__view_trends_impl(port, ptr, rust_vec_len, data_len)
         }
-        51 => wire__crate__api__vault_projections__view_visit_summary_impl(
+        52 => wire__crate__api__vault_projections__view_visit_summary_impl(
             port,
             ptr,
             rust_vec_len,
@@ -3437,6 +3529,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::dto::PatientProfileDto>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::dto::PdfImportProgressDto {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.page.into_into_dart().into_dart(),
+            self.total.into_into_dart().into_dart(),
+            self.outcome.into_into_dart().into_dart(),
+            self.error.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::dto::PdfImportProgressDto
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::dto::PdfImportProgressDto>
+    for crate::api::dto::PdfImportProgressDto
+{
+    fn into_into_dart(self) -> crate::api::dto::PdfImportProgressDto {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::dto::ProxyLabDto {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3825,6 +3940,18 @@ impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
 impl SseEncode
     for StreamSink<
         crate::api::dto::DemoLoadProgressDto,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
+    for StreamSink<
+        crate::api::dto::PdfImportProgressDto,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -4291,6 +4418,16 @@ impl SseEncode for Option<i64> {
     }
 }
 
+impl SseEncode for Option<crate::api::dto::ImportOutcomeDto> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::dto::ImportOutcomeDto>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for crate::api::dto::PatientProfileDto {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4299,6 +4436,16 @@ impl SseEncode for crate::api::dto::PatientProfileDto {
         <Option<String>>::sse_encode(self.birth_date, serializer);
         <Option<String>>::sse_encode(self.age, serializer);
         <i64>::sse_encode(self.record_count, serializer);
+    }
+}
+
+impl SseEncode for crate::api::dto::PdfImportProgressDto {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.page, serializer);
+        <i32>::sse_encode(self.total, serializer);
+        <Option<crate::api::dto::ImportOutcomeDto>>::sse_encode(self.outcome, serializer);
+        <Option<String>>::sse_encode(self.error, serializer);
     }
 }
 

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -1738,6 +1738,26 @@ impl MixedPdfOutcome {
     }
 }
 
+/// Per-page progress callback for [`recognize_pdf_mixed_with_progress`]:
+/// called once per page, immediately after that page's text-layer/OCR
+/// decision is made, in page order (`page_no` 1..=`total`, `total` is the
+/// PDF's real page count -- same value [`MixedPdfOutcome::page_count`] would
+/// return). Fires for *every* page, not just OCR'd ones -- a text-layer page
+/// resolves near-instantly, so including it just makes the progress signal
+/// denser, never wrong.
+///
+/// Why this exists: mobile's `ingest_bytes` hits exactly one of two progress
+/// paths for a scanned PDF. If the page images aren't `DCTDecode`-encoded
+/// JPEGs, `recognize_pdf_mixed` can't OCR them at all (see
+/// [`extract_dct_images`]'s doc comment) and mobile's Dart-side fallback
+/// (`import_flow.dart` rendering pages itself) does the OCR and reports
+/// per-page progress there. But real-world scans from a phone camera or a
+/// hospital portal export are overwhelmingly JPEG -- that's the *other* path,
+/// where this function does succeed and all the OCR time lands inside this
+/// one Rust call, with nothing upstream able to report progress unless this
+/// callback exists.
+pub type PdfPageProgress<'a> = &'a dyn Fn(i32, i32);
+
 /// Resolve one page that has no usable text layer: OCR its embedded
 /// DCTDecode image(s) if the per-document OCR budget allows, otherwise
 /// report [`PdfPageText::Unrecognized`] rather than silently skip it.
@@ -1803,28 +1823,40 @@ fn build_mixed_pages<F>(
     page_texts: Vec<String>,
     mut page_images: Vec<Vec<Vec<u8>>>,
     mut recognize_one: F,
+    on_page: Option<PdfPageProgress<'_>>,
 ) -> Vec<PdfPage>
 where
     F: FnMut(&[u8]) -> Result<OcrOutcome>,
 {
     let mut ocr_budget = MAX_OCR_PAGE_IMAGES;
+    let total = page_texts.len() as i32;
     page_texts
         .into_iter()
         .enumerate()
         .map(|(idx, text)| {
             let page_no = idx as i32 + 1;
-            if text.trim().chars().count() >= MIN_TEXT_LAYER_LEN {
-                return PdfPage {
+            let page = if text.trim().chars().count() >= MIN_TEXT_LAYER_LEN {
+                PdfPage {
                     page_no,
                     result: PdfPageText::TextLayer(text),
-                };
+                }
+            } else {
+                let images = page_images
+                    .get_mut(idx)
+                    .map(std::mem::take)
+                    .unwrap_or_default();
+                let result = resolve_page_via_ocr(images, &mut ocr_budget, &mut recognize_one);
+                PdfPage { page_no, result }
+            };
+            // Report *after* this page is resolved (not before) -- `page_no`
+            // then means "this many pages are now done", matching the
+            // `loaded`/`total` convention `DemoLoadProgressDto` already uses
+            // elsewhere in this codebase, rather than inventing a second
+            // "about to start" convention here.
+            if let Some(cb) = on_page {
+                cb(page_no, total);
             }
-            let images = page_images
-                .get_mut(idx)
-                .map(std::mem::take)
-                .unwrap_or_default();
-            let result = resolve_page_via_ocr(images, &mut ocr_budget, &mut recognize_one);
-            PdfPage { page_no, result }
+            page
         })
         .collect()
 }
@@ -1841,6 +1873,20 @@ where
 /// [`MixedPdfOutcome::unrecognized_pages`] for what it MUST tell the caller
 /// was not captured -- never silently drop that list.
 pub fn recognize_pdf_mixed(pdf_bytes: &[u8]) -> Result<MixedPdfOutcome> {
+    recognize_pdf_mixed_with_progress(pdf_bytes, None)
+}
+
+/// Same as [`recognize_pdf_mixed`], but reports per-page progress through
+/// `on_page` (see [`PdfPageProgress`]) as each page is resolved. Split out
+/// as its own function -- rather than making [`recognize_pdf_mixed`] take
+/// `Option<PdfPageProgress<'_>>` directly -- purely so the many existing
+/// callers that don't need progress (desktop, CLI, `reindex_existing_document`)
+/// keep an unchanged call site; `recognize_pdf_mixed` is now a one-line
+/// wrapper that passes `None`.
+pub fn recognize_pdf_mixed_with_progress(
+    pdf_bytes: &[u8],
+    on_page: Option<PdfPageProgress<'_>>,
+) -> Result<MixedPdfOutcome> {
     let doc = Document::load_mem(pdf_bytes).context("recognize_pdf_mixed: parse PDF")?;
     let page_ids: Vec<lopdf::ObjectId> = doc.get_pages().into_values().collect();
     let mut page_texts = pdf_extract::extract_text_from_mem_by_pages(pdf_bytes)
@@ -1856,7 +1902,7 @@ pub fn recognize_pdf_mixed(pdf_bytes: &[u8]) -> Result<MixedPdfOutcome> {
         .iter()
         .map(|&page_id| extract_dct_images(&doc, page_id))
         .collect();
-    let pages = build_mixed_pages(page_texts, page_images, recognize_platform_best);
+    let pages = build_mixed_pages(page_texts, page_images, recognize_platform_best, on_page);
     Ok(MixedPdfOutcome { pages })
 }
 
@@ -2563,14 +2609,19 @@ mod tests {
             vec![vec![0xFFu8]], // page 2: one (fake) DCTDecode image
         ];
         let mut calls = 0usize;
-        let pages = build_mixed_pages(page_texts, page_images, |_bytes| {
-            calls += 1;
-            Ok(OcrOutcome {
-                text: "化验结果:肌酐 120".to_string(),
-                confidence: 0.9,
-                backend: OcrBackend::Onnx,
-            })
-        });
+        let pages = build_mixed_pages(
+            page_texts,
+            page_images,
+            |_bytes| {
+                calls += 1;
+                Ok(OcrOutcome {
+                    text: "化验结果:肌酐 120".to_string(),
+                    confidence: 0.9,
+                    backend: OcrBackend::Onnx,
+                })
+            },
+            None,
+        );
         assert_eq!(calls, 1, "only the image-only page should trigger OCR");
         assert_eq!(pages.len(), 2);
         assert!(matches!(pages[0].result, PdfPageText::TextLayer(_)));
@@ -2607,9 +2658,12 @@ mod tests {
             String::new(),
         ];
         let page_images = vec![vec![], vec![]]; // neither page has an image
-        let pages = build_mixed_pages(page_texts, page_images, |_bytes| {
-            panic!("recognize_one should never be called: page 2 has no image")
-        });
+        let pages = build_mixed_pages(
+            page_texts,
+            page_images,
+            |_bytes| panic!("recognize_one should never be called: page 2 has no image"),
+            None,
+        );
         assert_eq!(pages.len(), 2);
         assert_eq!(pages[1].result, PdfPageText::Unrecognized);
 
@@ -2633,14 +2687,19 @@ mod tests {
         let page_texts = vec![String::new(); total];
         let page_images = vec![vec![vec![0u8]]; total];
         let mut calls = 0usize;
-        let pages = build_mixed_pages(page_texts, page_images, |_bytes| {
-            calls += 1;
-            Ok(OcrOutcome {
-                text: "text".to_string(),
-                confidence: 1.0,
-                backend: OcrBackend::Onnx,
-            })
-        });
+        let pages = build_mixed_pages(
+            page_texts,
+            page_images,
+            |_bytes| {
+                calls += 1;
+                Ok(OcrOutcome {
+                    text: "text".to_string(),
+                    confidence: 1.0,
+                    backend: OcrBackend::Onnx,
+                })
+            },
+            None,
+        );
         assert_eq!(
             calls, MAX_OCR_PAGE_IMAGES,
             "OCR must run on at most the cap-many pages"
@@ -2650,6 +2709,45 @@ mod tests {
             outcome.unrecognized_pages().len(),
             extra,
             "pages past the cap must be reported, not silently dropped"
+        );
+    }
+
+    /// `on_page` must fire exactly once per page, in order, `(1, total)` ..
+    /// `(total, total)` -- this is the signal mobile's import dialog paints
+    /// "正在识别第 N/M 页" from (see `PdfPageProgress`'s doc comment for why
+    /// this callback exists at all). Mixes a text-layer page and an OCR'd
+    /// page so the callback is proven to fire on both paths, not just one.
+    #[test]
+    fn build_mixed_pages_reports_progress_once_per_page_in_order() {
+        let page_texts = vec![
+            "够长的第一页文本内容超过阈值二十个字符没问题".to_string(),
+            String::new(), // scanned page: needs OCR
+            String::new(), // scanned page, no image: stays Unrecognized
+        ];
+        let page_images = vec![vec![], vec![vec![0xFFu8]], vec![]];
+        // `on_page`'s type is `&dyn Fn`, not `FnMut` -- it may be called from
+        // inside a `.map()` closure that itself needs to be `Copy`-able (see
+        // `build_mixed_pages`'s doc comment). `RefCell` gets interior
+        // mutability without weakening that bound just for this test.
+        let seen: std::cell::RefCell<Vec<(i32, i32)>> = std::cell::RefCell::new(Vec::new());
+        let cb = |page_no: i32, total: i32| seen.borrow_mut().push((page_no, total));
+        let pages = build_mixed_pages(
+            page_texts,
+            page_images,
+            |_bytes| {
+                Ok(OcrOutcome {
+                    text: "化验结果".to_string(),
+                    confidence: 0.9,
+                    backend: OcrBackend::Onnx,
+                })
+            },
+            Some(&cb),
+        );
+        assert_eq!(pages.len(), 3);
+        assert_eq!(
+            seen.into_inner(),
+            vec![(1, 3), (2, 3), (3, 3)],
+            "must report once per page, in order, with the true page count as total"
         );
     }
 

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -10,6 +10,11 @@ use std::path::Path;
 /// 知道原件有几页才能不撒谎。语义见 `ocr::image_page_count`。
 pub use ocr::image_page_count;
 
+/// 扫描 PDF 逐页 OCR 进度回调的类型——转出给移动端 crate 用,理由与
+/// [`image_page_count`] 一样:移动端不该被迫直接依赖 `ocr`(它按 target 门控,
+/// 桌面/CLI 构建也不需要这个类型)。语义见 `ocr::PdfPageProgress`。
+pub use ocr::PdfPageProgress;
+
 /// 单个文件导入体积上限(字节)。超过即拒绝,**在把整份文件读进内存之前**就返回
 /// 错误 —— 否则一份几个 GB 的文件/畸形附件会在任何解析器跑起来之前就把进程 OOM。
 /// 200MB 足以覆盖高分辨率照片、扫描 PDF 与常见单张 DICOM;超大 DICOM 序列本就按
@@ -361,7 +366,7 @@ pub type DicomMetaParser<'a> = &'a dyn Fn(&[u8]) -> anyhow::Result<dicom::DicomM
 /// 导入一个文件(进程内解析 DICOM 元数据)。桌面端请用
 /// [`ingest_with_dicom_parser`] 注入隔离解析器。
 pub fn ingest(vault: &Vault, path: &Path) -> anyhow::Result<IngestOutcome> {
-    ingest_with_dicom_parser(vault, path, &dicom::parse_meta)
+    ingest_inner(vault, path, &dicom::parse_meta, None)
 }
 
 /// 同 [`ingest`],但由调用方提供 DICOM 元数据解析器(见 [`DicomMetaParser`])。
@@ -369,6 +374,39 @@ pub fn ingest_with_dicom_parser(
     vault: &Vault,
     path: &Path,
     parse_dicom_meta: DicomMetaParser<'_>,
+) -> anyhow::Result<IngestOutcome> {
+    ingest_inner(vault, path, parse_dicom_meta, None)
+}
+
+/// 同 [`ingest`],但多接受一个可选的逐页 OCR 进度回调(见
+/// [`PdfPageProgress`])——目前只有扫描版 PDF 分支([`ingest_pdf`])会调用它;
+/// 其余分支(纯文本、单页图片、DICOM)本身就是"一下子完成",没有中间态可报,
+/// 回调不会被调用。移动端 `ingest_bytes_with_progress` 用这个函数换取
+/// 「正在识别第 N/M 页」的进度信号(见那边的文档注释——`StreamSink` 参数导致
+/// 函数自身返回值到不了 Dart,进度和终态都得走另一条路)。
+///
+/// 不像 [`ingest_with_dicom_parser`] 那样接受自定义 DICOM 解析器:移动端是
+/// 这个函数目前唯一的调用方,它的文件选择器不接受 `.dcm`(见
+/// [`DicomMetaParser`] 文档),用进程内解析足够。桌面端如果将来也要进度,
+/// 再加一个 `ingest_with_dicom_parser_and_progress`——不在本次改动范围内,
+/// 现在加了也没有调用方,不必先造好。
+pub fn ingest_with_progress(
+    vault: &Vault,
+    path: &Path,
+    on_page: Option<PdfPageProgress<'_>>,
+) -> anyhow::Result<IngestOutcome> {
+    ingest_inner(vault, path, &dicom::parse_meta, on_page)
+}
+
+/// [`ingest`]/[`ingest_with_dicom_parser`]/[`ingest_with_progress`] 共用的实现。
+/// 拆出来是为了让"要不要报进度"只在这一处分岔——桌面/CLI 经前两个入口调用,
+/// `on_page` 恒为 `None`,签名和行为不变;移动端经 [`ingest_with_progress`]
+/// 调用才会真的传一个回调。
+fn ingest_inner(
+    vault: &Vault,
+    path: &Path,
+    parse_dicom_meta: DicomMetaParser<'_>,
+    on_page: Option<PdfPageProgress<'_>>,
 ) -> anyhow::Result<IngestOutcome> {
     // 体积闸门:先看元数据里的文件大小,超上限就拒绝 —— 绝不 slurp 一份不可信的
     // 超大文件进内存(那会在解析前就 OOM)。用 metadata().len() 而非读入后再判。
@@ -388,6 +426,10 @@ pub fn ingest_with_dicom_parser(
     let sid = imp.source_file.id;
 
     if imp.deduped && vault.has_document(sid)? {
+        // 补页走的是这次重新导入拿到的原始字节,不是首次导入当年那份——同一份
+        // 文件已经在手上,复用即可。这条路不接进度:`reindex_existing_document`
+        // 补的是首次导入时漏掉的少数页,不是本次改动要解决的"首次导入几十秒
+        // 零反馈"场景,不在范围内(见 PR 描述)。
         return reindex_existing_document(vault, sid, &name, is_pdf(path), &bytes);
     }
 
@@ -400,7 +442,7 @@ pub fn ingest_with_dicom_parser(
     // PDF 走独立分支(逐页判定文本层,而非整份拼接后的长度——见 `ingest_pdf`
     // 文档注释里的"混合页 PDF 静默丢数据"缺陷)。
     if is_pdf(path) {
-        return ingest_pdf(vault, sid, &name, &bytes, imp.deduped);
+        return ingest_pdf(vault, sid, &name, &bytes, imp.deduped, on_page);
     }
 
     match parser::extract(path) {
@@ -513,14 +555,20 @@ fn ingest_image(
 /// `IngestOutcome::pages_without_text`——调用方(尤其移动端 UI)必须显式告知
 /// 用户"这些页未能识别",不能让人以为整份都读了。桌面/CLI 目前还没有对应的
 /// UI 横幅(不在本次改动范围),至少落一条 `eprintln!` 留痕。
+///
+/// `on_page` 只在经 [`ingest_with_progress`] 调用时非 `None`(移动端);桌面/CLI
+/// 经 [`ingest`]/[`ingest_with_dicom_parser`] 调用时恒为 `None`,原样透传给
+/// `ocr::recognize_pdf_mixed_with_progress`,`None` 时它退化成
+/// `recognize_pdf_mixed`——不多花一次调用、也不改变行为。
 fn ingest_pdf(
     vault: &Vault,
     sid: i64,
     name: &str,
     bytes: &[u8],
     deduped: bool,
+    on_page: Option<PdfPageProgress<'_>>,
 ) -> anyhow::Result<IngestOutcome> {
-    let mixed = match ocr::recognize_pdf_mixed(bytes) {
+    let mixed = match ocr::recognize_pdf_mixed_with_progress(bytes, on_page) {
         Ok(m) => m,
         // 连 lopdf 都解析不了(畸形/损坏 PDF):和旧版行为一致——不致命,退回
         // 「已存但无文本」而不是让整次 ingest 报错(原文件已进 CAS,时间线仍
@@ -1194,6 +1242,35 @@ trailer\n<< /Root 1 0 R /Size 4 >>\n%%EOF\n";
         assert!(
             text.contains("Discharge summary"),
             "page 1 text missing: {text}"
+        );
+    }
+
+    /// This is the fix the ticket is about: importing a multi-page scanned
+    /// PDF used to be a black box on mobile -- a spinner with zero feedback
+    /// until the whole file finished (real-world timing: 25 pages ~10s on a
+    /// fast native Mac build, several times that on an actual phone). `ingest`
+    /// (the plain entry point CLI/desktop use) must keep reporting nothing,
+    /// while [`ingest_with_progress`] must report once per page, in order,
+    /// with the true page count -- this is what lets mobile's import dialog
+    /// paint "正在识别第 N/M 页" instead of a dead spinner.
+    #[test]
+    fn ingest_with_progress_reports_once_per_page_in_order() {
+        let vdir = tempfile::tempdir().unwrap();
+        let fdir = tempfile::tempdir().unwrap();
+        let v = Vault::open(vdir.path()).unwrap();
+        let p = fdir
+            .path()
+            .join("2026-02-01_出院小结_两页文本_进度测试.pdf");
+        std::fs::write(&p, build_two_page_pdf_both_pages_have_text()).unwrap();
+
+        let seen: std::cell::RefCell<Vec<(i32, i32)>> = std::cell::RefCell::new(Vec::new());
+        let cb = |page_no: i32, total: i32| seen.borrow_mut().push((page_no, total));
+        let o = ingest_with_progress(&v, &p, Some(&cb)).unwrap();
+        assert_eq!(o.status, IngestStatus::New);
+        assert_eq!(
+            seen.into_inner(),
+            vec![(1, 2), (2, 2)],
+            "must report once per page, in order, with the true page count as total"
         );
     }
 


### PR DESCRIPTION
## 问题

导入一份多页扫描 PDF 时,界面全程只显示「正在导入 1/1」——那个 1/1 数的是**文件数**。

`feat/reindex-button` 刚做完的那版把 Dart 侧回填改成了逐页报「正在识别第 N/M 页」,但那条路只在 Rust 没能处理时才走。实测发现:测试 PDF 的图是 **JPEG(DCTDecode)编码**,而 `packages/ocr` 对这种能自己 OCR(`recognize_pdf_mixed` → `extract_dct_images`),所以时间**全花在 Rust 侧**,Dart 回填一次都没跑——新加的进度文案根本没机会显示。JPEG 是手机拍照/App 导出扫描件最常见的编码,这是最常见的那条路。

性能实测(本机原生 arm64 release):1 页 1.85s / 3 页 1.46s / 25 页 10.4s。真机比这台 Mac 慢几倍,一份 25 页扫描件在真机上是几十秒量级——那几十秒里屏幕上什么进度都没有。

## 实现:进度从 Rust 一路穿到 Dart

### 三个关键决策

**1. 进度穿透层数(`recognize_pdf_mixed` → `pipeline::ingest` → 移动端)**

`packages/ocr` 新增 `PdfPageProgress<'a> = &'a dyn Fn(i32, i32)` 类型 + `recognize_pdf_mixed_with_progress(bytes, on_page: Option<PdfPageProgress>)`;`build_mixed_pages` 逐页(含文本层页,近乎即时,进度更密不算错)调用一次 `on_page(page_no, total)`。`recognize_pdf_mixed` 退化成 `on_page: None` 的薄封装,签名不变。

`packages/pipeline` 新增 `ingest_with_progress(vault, path, on_page)`(默认 DICOM 解析器 + 可选进度),与既有的 `ingest`/`ingest_with_dicom_parser` 共享一个私有 `ingest_inner`——**两个既有入口的签名和行为逐字节不变**,`ingest_pdf` 只是多一个透传参数。选 `Option<&dyn Fn>` 而不是给 `ingest`/`ingest_with_dicom_parser` 直接加参数,是因为那两个函数有一堆调用方(CLI、桌面、`reindex_existing_document`、demo 数据）不需要进度,不该被迫改调用点。

**2. 不改 `ingest_bytes` 签名,新增 `ingest_bytes_with_progress`**

`vault_projections.rs` 里几十处测试直接调 `ingest_bytes(...)` 并依赖其**返回值**——加 `StreamSink` 参数会让 FRB 把签名整个折成 `Stream<T>`,波及全部这些调用方。新增一个函数、旧的原样保留,代价最小。两者共享私有 `ingest_bytes_core`(准备临时文件 → 跑 ingest → 重建分组 → 清理)。

**3. StreamSink 错误处理(本工单最大的风险点)**

`load_demo_data`/`DemoLoadProgressDto` 顶部文档记着一个真实踩过的坑:带 `StreamSink` 参数的 FRB 函数,Dart 侧没有任何代码 `await` 函数自身的返回值——真返回 `Err` 会悄悄丢失。仿照同一手法:新增 `PdfImportProgressDto { page, total, outcome: Option<ImportOutcomeDto>, error: Option<String> }`,`outcome`/`error` 二者恰好其一非 `None` 地编码进流的**最后一条**消息。

为了能在**不构造真实 `StreamSink`**(单测环境下造不出来,需要真实 Dart 消息端口)的前提下验证这条编码逻辑没有把失败悄悄吞掉,把 `Result → 终态 DTO` 的映射抽成纯函数 `final_progress_dto`,直接对它下断言(见下面的测试)。

### Dart 侧接入

`import_flow.dart` 的 `_runImport` 非图片分支从 `ingestBytes` 换成 `ingestBytesWithProgress`,复用已有 `onPage` 回调那套「正在识别第 N/M 页」文案(没有再造一套)。流里的 `error` 原样 `throw`,与旧版 `ingestBytes` 失败时抛异常的外部行为对齐,下游 `catch` 逻辑不用改。

FRB 绑定用 `flutter_rust_bridge_codegen generate` 重新生成(`frb_generated.rs`/`.dart` 系列文件)。

## 测试:红 → 绿

用 `git stash` 验证:stash 后 grep 新符号(`PdfPageProgress`/`ingest_with_progress`/`ingest_bytes_with_progress`/`PdfImportProgressDto`)全部为空,新测试全部被 cargo 过滤成 0 个匹配(能力不存在);`git stash pop` 恢复后全部通过。

```
=== ocr crate ===
test tests::build_mixed_pages_reports_progress_once_per_page_in_order ... ok

=== pipeline crate（真实两页 PDF）===
test tests::ingest_with_progress_reports_once_per_page_in_order ... ok

=== mobile crate ===
test api::vault::ingest_bytes_progress_tests::final_progress_dto_carries_the_error_through_not_swallowed ... ok
test api::vault::ingest_bytes_progress_tests::final_progress_dto_carries_the_outcome_on_success ... ok
test api::vault::ingest_bytes_progress_tests::ingest_bytes_core_rejects_empty_data ... ok
test api::vault::ingest_bytes_progress_tests::ingest_bytes_core_reports_progress_once_per_page ... ok
```

`ingest_bytes_core_reports_progress_once_per_page` 断言次数 == 页数、顺序一致；`final_progress_dto_carries_the_error_through_not_swallowed` 断言给定真实 `Err` 时,终态 DTO 的 `error` 必须原样带出、`outcome` 必须是 `None`——不允许两者都是 `None`(那就是把失败悄悄吞成了不确定态)。

## 门禁全绿

- `cargo test --workspace`(main workspace):全绿
- `cd apps/mobile_flutter/rust && cargo test`(独立 workspace):43 passed
- `cargo clippy --workspace --all-targets -- -D warnings`:两个 workspace 均无警告
- `cargo fmt --check`:两个 workspace 均无差异
- `cd apps/mobile_flutter && flutter test`:307 passed
- `flutter analyze`:No issues found

## CLI/桌面不受影响

`apps/cli`、`apps/desktop/src-tauri` 调用的 `pipeline::ingest`/`ingest_with_dicom_parser` 签名和行为逐字节不变(新增的是 `ingest_inner`/`ingest_with_progress`,两个既有入口只是委托过去,`on_page` 恒 `None`)。两处均已 `cargo build` 验证通过。

## 范围外 / 已知缺口

- `reindex_existing_document`(详情页「重新识别」按钮那条路,`feat/reindex-button` 刚加的)仍调用不带进度的 `recognize_pdf_mixed`——它补的是首次导入漏掉的少数页,不是本工单要解决的「首次导入几十秒零反馈」场景,判断不值得为它扩大改动范围,已在 `pipeline` 源码注释里写明理由。
- `screens/doctor/proxy_intake_flow.dart`(医生代拍流程)仍调用旧版 `vault.ingestBytes`,未同步接入进度——同样的黑箱问题理论上也存在,但任务范围明确聚焦 `import_flow.dart`,未做改动,如实报告。

不合并,仅供审阅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>