### PR TITLE
fix(ocr): 生产路径改用布局重建 —— 参考区间归属 19% → 79%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4613,6 +4613,7 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-vision",
+ "parser",
  "pdf-extract",
  "pollster",
  "windows 0.62.2",

--- a/examples/demo-dataset/render_scan.py
+++ b/examples/demo-dataset/render_scan.py
@@ -4,13 +4,24 @@ Render plain-text (Chinese) medical report content into a realistic-looking
 "scanned/photographed paper report" image using Pillow.
 
 Usage:
-    python3 render_scan.py <output.png|.jpg> [--handwriting] < content.txt
+    python3 render_scan.py <output.png|.jpg> [--handwriting] [--scale N] < content.txt
 
 The content is read from stdin, one line per row. Long lines are drawn as-is
 (callers are expected to keep them under ~40 CJK chars per line for width).
+
+`--scale N` multiplies the type size and margins by N, so the same text renders
+at the pixel dimensions of a real full-page capture instead of a canvas
+shrink-wrapped around the glyphs. It matters because the OCR engine bands any
+image taller than `TILE_CORE_H` (1100 px, see packages/ocr/src/lib.rs) into
+overlapping horizontal strips and stitches the results back together. At the
+default scale a 17-line report renders about 850 px tall, so it goes through
+`predict` as a single frame and the banding/stitching path is never exercised —
+while a phone photo of the same A4 page is ~3000x4000 px and always is. Any
+evaluation that wants to measure that path has to ask for it explicitly.
 """
 import sys
 import random
+import zlib
 from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageChops
 
 FONT_CANDIDATES = [
@@ -46,23 +57,39 @@ def main():
 
     out_path = sys.argv[1]
     handwriting = "--handwriting" in sys.argv[2:]
+    scale = 1.0
+    if "--scale" in sys.argv[2:]:
+        scale = float(sys.argv[sys.argv.index("--scale") + 1])
 
     text = sys.stdin.read()
     lines = text.split("\n")
     while lines and lines[-1].strip() == "":
         lines.pop()
 
-    random.seed(hash(out_path) & 0xFFFFFFFF)
+    # crc32, not the builtin hash(): CPython salts str hashing per process
+    # (PEP 456), so `hash(out_path)` hands a *different* seed to every
+    # invocation. Rendering the same file twice then produced different grain
+    # and a different rotation angle — fine for generating demo data, fatal for
+    # an A/B evaluation that renders once per run and compares the numbers
+    # across runs. crc32 over the path bytes is stable for a given path forever.
+    random.seed(zlib.crc32(out_path.encode("utf-8")))
 
-    font_size = 24
+    font_size = int(24 * scale)
     font = load_font(font_size)
-    title_font = load_font(font_size + 4)
+    title_font = load_font(font_size + int(4 * scale))
     line_height = int(font_size * 1.75)
-    margin_x, margin_y = 56, 56
+    margin_x = margin_y = int(56 * scale)
 
-    max_chars = max((len(l) for l in lines), default=40)
-    width = max(900, margin_x * 2 + max_chars * (font_size + 4))
-    height = margin_y * 2 + line_height * len(lines) + 30
+    # Measure the widest line with the actual font instead of assuming every
+    # character is full-width. CJK glyphs are, but digits, latin and the spaces
+    # that pad lab tables into columns are not, so `max_chars * font_size`
+    # overshot badly on mixed lines — a 17-line report came out 2066 px wide
+    # with the text ending around 1200, i.e. 40% of the page was empty margin.
+    # A page that wide also skews the aspect ratio away from the portrait paper
+    # the engine actually sees in the field.
+    widest = max((font.getlength(l) for l in lines), default=float(font_size * 40))
+    width = max(900, int(margin_x * 2 + widest))
+    height = margin_y * 2 + line_height * len(lines) + int(30 * scale)
 
     # Slightly off-white paper tone rather than pure white.
     paper = (250, 249, 245)

--- a/packages/ocr/Cargo.toml
+++ b/packages/ocr/Cargo.toml
@@ -26,6 +26,17 @@ lopdf.workspace = true
 pdf-extract.workspace = true
 
 [dev-dependencies]
+# examples/layout_eval.rs 用 parser::extract_labs 把 OCR 文字变成结构化化验行,
+# 再跟真值比对(复用生产已有的、经过语料校验的规则抽取器,而不是给评测另写一套解析)。
+# parser 不依赖 ocr,不会形成 dep 环。
+parser = { path = "../parser" }
+
+[[example]]
+name = "layout_eval"
+# recognize_engine_bare 只在 testing feature 下才存在(见 lib.rs `mod testing`)——
+# 没开这个 feature 时 `cargo build/test/clippy --all-targets`(默认 feature 集)
+# 直接跳过编译这个 example,而不是报「找不到该函数」的编译错误。
+required-features = ["engine", "testing"]
 
 [features]
 # `engine` pulls in `oar-ocr` (PP-OCRv5 via ONNX Runtime / `ort`), which

--- a/packages/ocr/examples/layout_eval.rs
+++ b/packages/ocr/examples/layout_eval.rs
@@ -1,0 +1,510 @@
+// 布局重建评测:量出「手机端 recognize_platform_best 的 engine 兜底分支,从
+// recognize_engine(裸 "\n".join)切到 recognize_engine_layout(按检测框重建表格列)」
+// 对 21 份语料文档分别带来什么变化 —— 不是只报一个汇总数字,每份文档一行。
+//
+// ## 为什么不直接调 recognize_platform_best 来测(甲板陷阱,踩过一次见
+// WORKLIST.md「验证纪律」一节)
+//
+// 在这台 macOS 开发机上,recognize_platform_best 会先走 Apple Vision;
+// Vision 没有逐行检测框,根本用不上 rebuild_layout_text,而且它和手机端真正跑
+// 的 PP-OCRv5 引擎是两个完全不同的识别器,误读模式不可互推。改不改
+// recognize_platform_best 的 engine 兜底分支,在 mac 上调它拿到的都是 Vision
+// 的输出,量不出引擎侧的任何变化。`default-features = false` 也关不掉 Vision——
+// 它是按 target_os 分流,不是按 feature。
+//
+// 所以本评测直接调两个 engine-only 函数本身:
+//   - `ocr::testing::recognize_engine_bare`(= 私有的 recognize_engine,裸拼接,
+//     经由 ocr crate 的 `testing` feature 转发出来,见 lib.rs `mod testing`)
+//   - `ocr::recognize_engine_layout`(同一个引擎,带版面重建)
+// 这就是「手机端 catch-all 分支从 recognize_engine 切到 recognize_engine_layout
+// 会带来什么变化」的直接证据 —— 手机上 recognize_platform_best 的 catch-all 分支
+// 本来就是纯引擎调用(见 packages/ocr/Cargo.toml `engine` feature 注释),跟桌面
+// 走 Vision 是两回事。
+//
+// ## 语料从哪来
+//
+// 真值是 packages/parser/tests/fixtures/corpus/*.txt(21 份,人工书写的干净文本,
+// 表格用空格对齐列)。demo-dataset 里的示例 PDF 大多带真实文本层,走
+// pdf_extract 直接抽取、根本不进 OCR,测不出布局重建的效果,所以不能用;本评测
+// 用 examples/demo-dataset/render_scan.py 把每份 .txt 现渲染成一张不带文本层的
+// 「扫描纸」图片(渲染有确定性:render_scan.py 按输出路径的 hash 做随机数种子,
+// 同一个输出文件名每次渲染出的噪点/倾斜位图完全一致,不会给前后两次评测引入
+// 渲染层面的随机波动),再喂给上面两个函数。
+//
+// ## 指标怎么定义,为什么这么定
+//
+// 21 份文档分两类(判断依据见 `classify` 的注释):
+//
+// 1. **表格类**(6 份文件名含"检验报告"的化验单):跑三条临床指标——
+//    - **化验行召回率**:真值里的化验项目,OCR 产出里有没有识别出对应的行
+//      (按 terminology 词典 key 匹配,不看数值对不对)。
+//    - **值-名配对正确率**:识别出的行,数值是不是配对到了正确的项目(不是
+//      随便一个数字凑巧对,而是真值 key 匹配到的行,其数值和真值一致)。
+//    - **参考区间归属正确率**:参考范围有没有跟着正确的项目走(而不是从相邻
+//      项目串行过来)。
+//
+//    这三条都通过 `parser::extract_labs` 复用——它是生产已经在用、经过真实
+//    语料反复调校的规则抽取器(见 packages/parser/src/labs.rs 模块头),不是
+//    评测另起一套解析逻辑。真值文本本身也过一遍同一个函数得到结构化真值,这样
+//    「真值怎么解析」和「OCR 产出怎么解析」用的是同一套规则,不存在两套口径
+//    互相打架的问题。用户明确要求"不是字符准确率,要反映临床后果"——这三条
+//    都是"某个具体临床数值有没有配对到正确的化验项目"这个问题的不同切面。
+//
+// 2. **非表格类**(其余 15 份,含处方、病历、影像/病理报告,以及血压记录):
+//    跑一条通用的**逐行内容召回率**——真值的每一行(去掉首尾空白后)是否在
+//    OCR 输出里找到一行归一化编辑距离相似度 >= 0.6 的对应行。这条指标不是字符
+//    准确率(不要求整份文档字符对齐),但比"随便有没有这几个字"更能反映内容
+//    保真度。
+//
+//    「血压记录」文件名虽然是表格版式(逐日一行:日期/时间/收缩压舒张压/心率/
+//    血糖),但归入非表格类而不是套用上面三条化验指标——三条化验指标的结构
+//    假设是"一行 = 一个项目名 + 一个数值 + 一个参考范围",而血压记录的行结构
+//    是"一行 = 一个日期 + 好几个并列的生命体征值",没有项目名/参考范围这个
+//    维度(表里也确实没有参考范围列)。`parser::labs` 模块文档明确把"一个
+//    token 里的比值型结果(血压 120/80)"列为 Deliberately NOT handled(`/80`
+//    会被误当单位)。硬套三条化验指标需要现造一套"日期当项目名"的匹配规则,
+//    这正是任务说的"别为了凑指标硬套"——所以血压记录改用通用的逐行召回率,
+//    和其余非表格文档一样对待。
+//
+// ## 怎么跑
+//
+// ```
+// cargo run -p ocr --example layout_eval --features testing --release
+// ```
+// (不加 --release 也能跑,只是每份文档的 OCR 推理会慢不少;21 份 × 2 个引擎
+// 调用,预计几分钟量级,属于正常耗时,不要因为慢就抽样。)
+
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+/// 文档分两类,决定跑哪一套指标——见文件头注释。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DocKind {
+    /// 化验单/检验报告:项目名 + 数值 + 单位 + 参考范围的表格结构。
+    Tabular,
+    /// 其余散文/记录类结构(含血压记录——理由见文件头注释)。
+    Generic,
+}
+
+/// 按文件名判断文档类别。语料文件名形如
+/// `2025-11-05_检验报告_血常规肾功能.txt`,类型字段是下划线分隔的第二段。
+/// 只有"检验报告"这一类具备(项目名, 数值, 单位, 参考范围)的表格结构,见文件
+/// 头注释里对 21 份语料的人工分类依据。
+fn classify(doc_name: &str) -> DocKind {
+    if doc_name.contains("检验报告") {
+        DocKind::Tabular
+    } else {
+        DocKind::Generic
+    }
+}
+
+/// 一份文档在表格类三条指标上的 (命中数, 分母) —— 分母是真值里的化验行数
+/// (或其中带参考范围的行数)。
+#[derive(Debug, Clone, Copy, Default)]
+struct TabularMetrics {
+    row_recall: (usize, usize),
+    pairing_accuracy: (usize, usize),
+    range_attribution: (usize, usize),
+}
+
+/// 一份非表格文档的逐行内容召回率 (命中行数, 真值总行数)。
+#[derive(Debug, Clone, Copy, Default)]
+struct GenericMetrics {
+    line_recall: (usize, usize),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DocMetrics {
+    Tabular(TabularMetrics),
+    Generic(GenericMetrics),
+}
+
+impl DocMetrics {
+    /// 打印成表格一列用的紧凑文本,e.g. `召回 8/8 配对 7/8 区间 8/8`。
+    fn format(&self) -> String {
+        match self {
+            DocMetrics::Tabular(m) => format!(
+                "召回 {}/{}  配对 {}/{}  区间 {}/{}",
+                m.row_recall.0,
+                m.row_recall.1,
+                m.pairing_accuracy.0,
+                m.pairing_accuracy.1,
+                m.range_attribution.0,
+                m.range_attribution.1
+            ),
+            DocMetrics::Generic(m) => {
+                format!("逐行召回 {}/{}", m.line_recall.0, m.line_recall.1)
+            }
+        }
+    }
+}
+
+/// 两个数值(参考区间的一个界)是否视为相等:都缺失算相等,一个有一个没有算
+/// 不等,都有则在容差内算相等。容差 0.01 覆盖真值文本最多两位小数的印刷精度,
+/// 同时严格到不会把"数值读错了但凑巧接近"算对——见文件头注释关于
+/// "不能允许数值随便配"的原则。
+const VALUE_EPS: f64 = 0.01;
+
+fn bound_matches(a: Option<f64>, b: Option<f64>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(x), Some(y)) => (x - y).abs() < VALUE_EPS,
+        _ => false,
+    }
+}
+
+/// 对表格类文档算三条临床指标。`truth`/`extracted` 都是
+/// `parser::extract_labs` 的产出(见文件头注释:真值和 OCR 产出用同一套规则
+/// 抽取器)。匹配键是 terminology 词典解析出的 `analyte_key`,而不是原始文本
+/// (原始名字受 OCR 噪声影响,词典 key 才是"这是同一个化验项目"的可靠判据)。
+///
+/// 一个真值项目在 OCR 产出里可能对应零个、一个或多个同 key 的候选行(同一版面
+/// 缺陷有时会把一行拆成两条候选);只要**存在**一条候选满足条件就算命中——
+/// 这反映的是"一个认真核对报告的人能不能从 OCR 产出里找到正确信息",而不是
+/// "OCR 有没有精确地一行对一行"。
+fn eval_tabular(
+    truth: &[parser::LabObservation],
+    extracted: &[parser::LabObservation],
+) -> TabularMetrics {
+    let mut m = TabularMetrics::default();
+    for t in truth {
+        // 21 份语料里的 6 份检验报告,词典对每个项目缩写/中文名都有覆盖
+        // (creatinine/egfr/urea/uric_acid/glucose/hba1c/cholesterol/ldl/hdl/
+        // triglycerides/wbc/hgb/plt/neut_pct 均在 terminology 必备 key 列表
+        // 里,渲染前跑过 `parser::extract_labs` 直接吃真值文本核实过 42/42
+        // 行全部解析出 analyte_key)。真出现真值行未能解析出 key 的情况,不
+        // 静默跳过——响亮地报出来,不然分母会悄悄缩小,数字看起来比实际更好看。
+        let Some(key) = t.analyte_key.as_deref() else {
+            eprintln!(
+                "  [WARN] 真值行 {:?} 没有解析出 analyte_key,已跳过——三条指标的分母不含它,请检查 terminology 词典覆盖",
+                t.raw_name
+            );
+            continue;
+        };
+        let candidates: Vec<&parser::LabObservation> = extracted
+            .iter()
+            .filter(|e| e.analyte_key.as_deref() == Some(key))
+            .collect();
+
+        m.row_recall.1 += 1;
+        if !candidates.is_empty() {
+            m.row_recall.0 += 1;
+        }
+
+        m.pairing_accuracy.1 += 1;
+        if candidates
+            .iter()
+            .any(|e| (e.value_num - t.value_num).abs() < VALUE_EPS)
+        {
+            m.pairing_accuracy.0 += 1;
+        }
+
+        if t.ref_low.is_some() || t.ref_high.is_some() {
+            m.range_attribution.1 += 1;
+            if candidates.iter().any(|e| {
+                bound_matches(e.ref_low, t.ref_low) && bound_matches(e.ref_high, t.ref_high)
+            }) {
+                m.range_attribution.0 += 1;
+            }
+        }
+    }
+    m
+}
+
+/// 字符级(不是字节级,CJK 一个字一个 cell)Levenshtein 编辑距离。行长度都在
+/// 几十字符量级,O(n*m) 的 DP 足够快,不需要引入额外的字符串相似度依赖。
+fn levenshtein(a: &[char], b: &[char]) -> usize {
+    let (n, m) = (a.len(), b.len());
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut cur = vec![0usize; m + 1];
+    for i in 1..=n {
+        cur[0] = i;
+        for j in 1..=m {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[m]
+}
+
+/// 两行文本的归一化相似度:1 - 编辑距离 / 较长行的字符数。空行视为距离 0
+/// (相似度 1),但调用方已经过滤掉空行,不会走到这个分支。
+fn line_similarity(a: &str, b: &str) -> f64 {
+    let (ca, cb): (Vec<char>, Vec<char>) = (a.chars().collect(), b.chars().collect());
+    let max_len = ca.len().max(cb.len()).max(1);
+    1.0 - (levenshtein(&ca, &cb) as f64 / max_len as f64)
+}
+
+/// 行匹配相似度阈值——见文件头注释:不是要求逐字符对齐,只要求"能认出这是
+/// 同一行内容",容忍空格/标点/个别错字这类 OCR 噪声,但两行内容确实不同时
+/// 应该落在阈值以下。0.6 是凭经验选的:短句(十几字)错 1-2 个字仍然 >= 0.6,
+/// 但整行内容不同(比如串行到相邻行)会明显低于它。
+const LINE_MATCH_THRESHOLD: f64 = 0.6;
+
+fn eval_generic(truth_text: &str, ocr_text: &str) -> GenericMetrics {
+    let truth_lines: Vec<&str> = truth_text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let ocr_lines: Vec<&str> = ocr_text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let mut hit = 0usize;
+    for tl in &truth_lines {
+        let best = ocr_lines
+            .iter()
+            .map(|ol| line_similarity(tl, ol))
+            .fold(0.0_f64, f64::max);
+        if best >= LINE_MATCH_THRESHOLD {
+            hit += 1;
+        }
+    }
+    GenericMetrics {
+        line_recall: (hit, truth_lines.len()),
+    }
+}
+
+fn eval_doc(kind: DocKind, truth_text: &str, ocr_text: &str) -> DocMetrics {
+    match kind {
+        DocKind::Tabular => {
+            let truth_rows = parser::extract_labs(truth_text);
+            let extracted_rows = parser::extract_labs(ocr_text);
+            DocMetrics::Tabular(eval_tabular(&truth_rows, &extracted_rows))
+        }
+        DocKind::Generic => DocMetrics::Generic(eval_generic(truth_text, ocr_text)),
+    }
+}
+
+/// 把一份语料 txt 渲染成一张不带文本层的"扫描纸"图片,调用
+/// `examples/demo-dataset/render_scan.py`(从 stdin 读正文,写 PNG/JPG 到给定
+/// 路径)。渲染按输出路径的字符串 hash 做随机种子(脚本自己的实现),同一个
+/// out_path 每次渲染出的噪点/倾斜完全一致——这保证了"改代码前"和"改代码后"
+/// 两次独立评测跑吃到的是逐比特相同的输入图片,前后数字的差异只可能来自
+/// recognize_engine → recognize_engine_layout 这一步,不会被渲染的随机性污染。
+fn render_scan(script: &Path, text: &str, out: &Path, scale: f64) -> Result<()> {
+    let mut child = Command::new("python3")
+        .arg(script)
+        .arg(out)
+        .arg("--scale")
+        .arg(scale.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("spawn python3 {}", script.display()))?;
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(text.as_bytes())
+        .context("write corpus text to render_scan.py stdin")?;
+    let status = child.wait().context("wait for render_scan.py")?;
+    anyhow::ensure!(
+        status.success(),
+        "render_scan.py exited with {status} for {}",
+        out.display()
+    );
+    Ok(())
+}
+
+/// 渲染倍率,`--scale <N>` 传入,默认 1.0。**这个参数决定评测有没有走到分块路径。**
+///
+/// 引擎对高度 > `TILE_CORE_H`(1100px)的图会切成带 120px 重叠的横条分别 `predict`
+/// 再缝合(见 packages/ocr/src/lib.rs)。倍率 1.0 时,21 份语料渲出来最高 998px ——
+/// **一份都不过门槛**,全部按单帧走,分块与缝合的代码一行都没被执行到。而真机上
+/// 用户拍的是整张 A4,3000×4000px,必然分三块以上。所以「切块导致对齐错」这个
+/// 假设,只有在倍率 3.0(21 份全部分 3 块)下才测得到。
+///
+/// 两档都要跑:倍率 1.0 是「没有分块」的对照组,倍率 3.0 是「有分块」的实验组。
+/// 同一份文档在两档之间的差,才是分块本身的代价;只跑一档区分不出「布局重建的
+/// 收益」和「分块的损失」这两件事。
+const DEFAULT_SCALE: f64 = 1.0;
+
+/// PNG 的宽高就在 IHDR 里,固定偏移 16..24 两个大端 u32。只为在日志里报出
+/// 「这张图被切几块」,不值得为此把 `image` crate 拉进 example 的依赖。
+fn image_dimensions(png: &[u8]) -> Result<(u32, u32)> {
+    anyhow::ensure!(
+        png.len() >= 24 && png.starts_with(&[0x89, b'P', b'N', b'G']),
+        "渲染产物不是 PNG,读不出尺寸"
+    );
+    let rd = |o: usize| u32::from_be_bytes([png[o], png[o + 1], png[o + 2], png[o + 3]]);
+    Ok((rd(16), rd(20)))
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let scale = args
+        .iter()
+        .position(|a| a == "--scale")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.parse::<f64>())
+        .transpose()
+        .context("--scale 的值不是合法浮点数")?
+        .unwrap_or(DEFAULT_SCALE);
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let corpus_dir = manifest_dir.join("../parser/tests/fixtures/corpus");
+    let render_script = manifest_dir.join("../../examples/demo-dataset/render_scan.py");
+    // 渲染产物是构建输出,不入库(仓库 .gitignore 里 /target 已经忽略)。
+    let images_dir = manifest_dir.join("../../target/ocr_layout_eval_images");
+    std::fs::create_dir_all(&images_dir).context("create images_dir")?;
+
+    anyhow::ensure!(
+        corpus_dir.is_dir(),
+        "corpus dir not found: {}",
+        corpus_dir.display()
+    );
+    anyhow::ensure!(
+        render_script.is_file(),
+        "render_scan.py not found: {}",
+        render_script.display()
+    );
+
+    let mut corpus_files: Vec<PathBuf> = std::fs::read_dir(&corpus_dir)
+        .context("read corpus dir")?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|e| e == "txt"))
+        .collect();
+    corpus_files.sort();
+    // 21 份语料全跑,不挑样本——见任务要求,子集会掩盖"哪份文档变差了"这个
+    // 报告最需要的信息。
+    anyhow::ensure!(
+        corpus_files.len() == 21,
+        "expected 21 corpus files, found {} in {} — 语料集是否变了?本评测按 21 份写死校验,发现变化时先确认是否需要跟着改",
+        corpus_files.len(),
+        corpus_dir.display()
+    );
+
+    println!("### 渲染倍率 {scale}x(倍率 1.0 = 单帧不分块;3.0 = 每份切 3 块,走缝合路径)");
+    println!();
+    println!(
+        "| # | 文档 | 类型 | recognize_engine(基线,裸拼接) | recognize_engine_layout(布局重建) |"
+    );
+    println!("|---|---|---|---|---|");
+
+    // 汇总:表格类三条指标各自的命中/分母,非表格类逐行召回的命中/分母 —— 分
+    // 别对基线和布局重建两套统计,PR 描述里的"几份变好/几份不变/几份变差"从
+    // 逐文档结果里数,这里的汇总只是佐证整体方向没有反过来。
+    let mut improved = 0usize;
+    let mut unchanged = 0usize;
+    let mut regressed = 0usize;
+
+    for (idx, path) in corpus_files.iter().enumerate() {
+        let doc_name = path
+            .file_stem()
+            .expect("txt file has a stem")
+            .to_string_lossy()
+            .to_string();
+        let kind = classify(&doc_name);
+        let truth_text = std::fs::read_to_string(path)
+            .with_context(|| format!("read corpus file {}", path.display()))?;
+
+        // 倍率进文件名:两档渲出来的是不同尺寸的图,不能共用一个路径互相覆盖;
+        // 而且 render_scan.py 的随机种子取自输出路径,同名就会拿到同一组噪点——
+        // 两档之间的差就不再只来自尺寸了。
+        let image_path = images_dir.join(format!("{doc_name}@{scale}x.png"));
+        eprintln!("[{}/21] 渲染 {doc_name} (倍率 {scale}) ...", idx + 1);
+        render_scan(&render_script, &truth_text, &image_path, scale)?;
+        let image_bytes = std::fs::read(&image_path)
+            .with_context(|| format!("read rendered image {}", image_path.display()))?;
+        // 如实报出这张图会被切几块——「这一档到底有没有走分块路径」不能靠推断,
+        // 得跟识别结果印在同一份日志里。门槛与 packages/ocr/src/lib.rs 的
+        // TILE_CORE_H 保持一致(那是私有常量,这里按值复刻,只用于报告)。
+        let (img_w, img_h) = image_dimensions(&image_bytes)?;
+        let bands = if img_h <= 1100 {
+            1
+        } else {
+            img_h.div_ceil(1100)
+        };
+        eprintln!("         {img_w}x{img_h}px → {bands} 块");
+
+        eprintln!("[{}/21] OCR(recognize_engine 基线){doc_name} ...", idx + 1);
+        let t0 = Instant::now();
+        let baseline = ocr::testing::recognize_engine_bare(&image_bytes)
+            .with_context(|| format!("recognize_engine_bare failed for {doc_name}"))?;
+        eprintln!(
+            "         {:?}, confidence={:.3}",
+            t0.elapsed(),
+            baseline.confidence
+        );
+
+        eprintln!(
+            "[{}/21] OCR(recognize_engine_layout){doc_name} ...",
+            idx + 1
+        );
+        let t1 = Instant::now();
+        let layout = ocr::recognize_engine_layout(&image_bytes)
+            .with_context(|| format!("recognize_engine_layout failed for {doc_name}"))?;
+        eprintln!(
+            "         {:?}, confidence={:.3}",
+            t1.elapsed(),
+            layout.confidence
+        );
+
+        let before = eval_doc(kind, &truth_text, &baseline.text);
+        let after = eval_doc(kind, &truth_text, &layout.text);
+
+        let direction = match (&before, &after) {
+            (DocMetrics::Tabular(b), DocMetrics::Tabular(a)) => {
+                let score = |m: &TabularMetrics| {
+                    let ratio = |p: (usize, usize)| {
+                        if p.1 == 0 {
+                            1.0
+                        } else {
+                            p.0 as f64 / p.1 as f64
+                        }
+                    };
+                    ratio(m.row_recall) + ratio(m.pairing_accuracy) + ratio(m.range_attribution)
+                };
+                score(a).partial_cmp(&score(b)).expect("no NaN")
+            }
+            (DocMetrics::Generic(b), DocMetrics::Generic(a)) => {
+                let ratio = |p: (usize, usize)| {
+                    if p.1 == 0 {
+                        1.0
+                    } else {
+                        p.0 as f64 / p.1 as f64
+                    }
+                };
+                ratio(a.line_recall)
+                    .partial_cmp(&ratio(b.line_recall))
+                    .expect("no NaN")
+            }
+            _ => unreachable!("kind is the same on both sides"),
+        };
+        match direction {
+            std::cmp::Ordering::Greater => improved += 1,
+            std::cmp::Ordering::Equal => unchanged += 1,
+            std::cmp::Ordering::Less => regressed += 1,
+        }
+
+        let kind_label = match kind {
+            DocKind::Tabular => "表格类",
+            DocKind::Generic => "非表格类",
+        };
+        println!(
+            "| {} | {doc_name} | {kind_label} | {} | {} |",
+            idx + 1,
+            before.format(),
+            after.format()
+        );
+    }
+
+    println!();
+    println!(
+        "汇总:{improved} 份变好,{unchanged} 份不变,{regressed} 份变差(共 21 份。\
+         打分口径:表格类取三条指标比例之和,非表格类取逐行召回率;严格改善/持平/\
+         退步按浮点比较,不设容差缓冲。逐文档表格里的具体分子分母才是判断是否\
+         真的变差的依据,这里只给方向计数。)"
+    );
+
+    Ok(())
+}

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -784,7 +784,14 @@ fn predict_lines(image_bytes: &[u8]) -> Result<Vec<OcrLine>> {
 /// lines' per-line confidences; `0.0` if no lines were recognized). Lazily
 /// builds the OCR pipeline on first call (models auto-download from
 /// ModelScope on first ever run on this machine).
-#[cfg(feature = "engine")]
+///
+/// **已无生产调用者。** 2026-08 起 [`recognize_platform_best`] 的三条引擎分支
+/// 全部改走 [`recognize_engine_layout`](量化依据见那里的表)。这个裸 `"\n".join`
+/// 版本只剩一个用途:给 `examples/layout_eval.rs` 当对照组,量「换过去到底提升
+/// 多少」。所以编译门也跟着收到 `testing`/`test` —— 否则它在正常的
+/// `--features engine` 构建里就是死代码,`cargo build` 会 warn(默认 feature 集
+/// 不含 `engine`,所以 `clippy --all-targets` 照不到这条,别指望它挡)。
+#[cfg(all(feature = "engine", any(test, feature = "testing")))]
 fn recognize_engine(image_bytes: &[u8]) -> Result<OcrOutcome> {
     let mut lines = Vec::new();
     let mut confidences = Vec::new();

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -805,18 +805,51 @@ fn recognize_engine(image_bytes: &[u8]) -> Result<OcrOutcome> {
 
 /// Same recognition as [`recognize_engine`], but the returned text has table
 /// columns reconstructed from each line's detection box instead of being a
-/// flat "\n"-joined dump. **Mobile iOS PP-OCRv5 test path only**
-/// (feat/ios-pp-ocr-test) — every other caller keeps using [`recognize_engine`]
-/// unchanged, so this cannot regress Linux/macOS/Windows output.
+/// flat "\n"-joined dump.
 ///
-/// Mirrors the algorithm the Android path already runs in Dart
-/// (`apps/mobile_flutter/lib/ocr_bridge.dart::_rebuildLayoutText`, added to fix
-/// lab-report tables collapsing into a flat dump when ML Kit splits one visual
-/// row into several `TextLine`s): group detection boxes into visual rows by y,
-/// then within a row map each box's x position to a character column and pad
-/// with spaces. PP-OCRv5's detector already produces one box per text *line*
-/// (not per character or per block), the same granularity ML Kit's
-/// `TextLine.boundingBox` is at, so [`rebuild_layout_text`] ports directly.
+/// **`recognize_platform_best` 的三条引擎分支现在都产出这个函数的结果。**
+///
+/// 改之前,手机端两条采集通路只有一条走这里 —— 说清楚,免得把影响面说大:
+/// - **拍照 / 选图** → Dart `recognizeImageText` → FRB `recognize_image_pp`
+///   (`apps/mobile_flutter/rust/src/api/vault.rs`)→ 本函数。**本来就是对的**,
+///   这次改动不碰它。
+/// - **导入扫描版 PDF** → `pipeline::ingest` → [`recognize_pdf_platform_best`]
+///   → [`recognize_platform_best`] → 曾经是 [`recognize_engine`] 的裸
+///   `"\n".join`。化验单绝大多数是 PDF 进来的,所以表格错位的实际来源是这条。
+///
+/// 桌面 / CLI 同理:Apple Vision 或 Windows.Media.Ocr 跑完没找到文字时的引擎
+/// 兜底,之前也是裸拼接。三处一起换。
+///
+/// 换过来的量化依据(`packages/ocr/examples/layout_eval.rs`,21 份语料渲成扫描页,
+/// 两个引擎吃同一份字节,指标用 `parser::extract_labs` 算,6 份化验单 42 行):
+///
+/// |  | 裸拼接 | 布局重建 |
+/// |---|---|---|
+/// | 化验行召回 · 单帧 | 57.1% | 83.3% |
+/// | 值-名配对 · 单帧 | 54.8% | 81.0% |
+/// | 参考区间归属 · 单帧 | 40.5% | 81.0% |
+/// | 化验行召回 · **分块** | 45.2% | 83.3% |
+/// | 值-名配对 · **分块** | 42.9% | 78.6% |
+/// | 参考区间归属 · **分块** | **19.0%** | **78.6%** |
+///
+/// 「分块」= 图高超过 [`TILE_CORE_H`],走横条切分再缝合的路径(真机拍整页必然
+/// 走到)。裸拼接在分块下参考区间归属从 40.5% 掉到 19.0% —— 缝合把不同横条的行
+/// 按 y 排到一起,而裸拼接只有 y 序、没有 x 信息,同一行的项目名和参考范围因此
+/// 错配到相邻项目上。布局重建保留了检测框的 x 坐标,几乎不受分块影响
+/// (81.0% → 78.6%)。**分块不是元凶,丢弃几何信息才是。**
+///
+/// 非表格类 15 份的逐行召回两者持平(单帧 93.0% vs 92.5%,分块 94.6% vs 94.6%)
+/// —— 散文没有列,重建不改变什么,也没有代价。
+///
+/// 算法本身([`rebuild_layout_text`]):按 y 把检测框归成视觉行,行内按每个框的
+/// x 映射到字符列、用空格补齐。PP-OCRv5 的检测器一个框对应一**行**文本(不是一个
+/// 字、也不是一个段落),正好是这个算法要的粒度。
+///
+/// (这段注释此前写着「移植自安卓 Dart 侧已在跑的 `ocr_bridge.dart::
+/// _rebuildLayoutText`,为修 ML Kit 把一个视觉行拆成多个 `TextLine`」——**已经
+/// 不成立**:安卓早已从 ML Kit 换成和 iOS 同一个 PP-OCRv5(见 `ocr_bridge.dart`
+/// 的 `recognizeImageText`),那个 Dart 函数连同 ML Kit 依赖一起删掉了,现在
+/// grep 不到。留这句话在这里会让人去找一个不存在的参照实现。)
 #[cfg(feature = "engine")]
 pub fn recognize_engine_layout(image_bytes: &[u8]) -> Result<OcrOutcome> {
     let mut confidences = Vec::new();
@@ -1454,7 +1487,7 @@ pub fn recognize_platform_best(image_bytes: &[u8]) -> Result<OcrOutcome> {
     }
     #[cfg(feature = "engine")]
     {
-        recognize_engine(image_bytes)
+        recognize_engine_layout(image_bytes)
     }
     #[cfg(not(feature = "engine"))]
     {
@@ -1478,7 +1511,7 @@ pub fn recognize_platform_best(image_bytes: &[u8]) -> Result<OcrOutcome> {
     }
     #[cfg(feature = "engine")]
     {
-        recognize_engine(image_bytes)
+        recognize_engine_layout(image_bytes)
     }
     #[cfg(not(feature = "engine"))]
     {
@@ -1496,7 +1529,7 @@ pub fn recognize_platform_best(image_bytes: &[u8]) -> Result<OcrOutcome> {
     feature = "engine"
 ))]
 pub fn recognize_platform_best(image_bytes: &[u8]) -> Result<OcrOutcome> {
-    recognize_engine(image_bytes)
+    recognize_engine_layout(image_bytes)
 }
 
 /// No-`engine`, non-native stub: nothing to recognize with. Callers treat OCR
@@ -1939,6 +1972,23 @@ pub mod testing {
     pub fn plain_multipage_tiff(n: usize) -> Vec<u8> {
         let pages: Vec<(u8, bool)> = (0..n).map(|i| ((i as u8) * 40, false)).collect();
         multipage_tiff(&pages)
+    }
+
+    /// 把私有的 [`recognize_engine`](裸拼接、不做版面重建的**旧**引擎产出)转出来,
+    /// 只为 `examples/layout_eval.rs` 能把它当对照组量。
+    ///
+    /// `recognize_engine` 本身继续保持非 `pub`:自 2026-08 起它已不是任何生产
+    /// 路径的产出函数([`recognize_platform_best`] 的三条引擎分支全部改走
+    /// [`recognize_engine_layout`]),留着只作为 `recognize_engine_layout` 的
+    /// 内部实现基座和这个对照组。
+    ///
+    /// 评测为什么必须绕开 [`recognize_platform_best`] 直接调两个引擎函数:在跑
+    /// 评测的 macOS 机器上,那个函数的主识别器是 Apple Vision,和手机端真正跑的
+    /// PP-OCRv5 是两个完全不同的引擎(见它自己的「验证纪律」注释),调它量到的
+    /// 是 Vision 改前 vs Vision 改后 —— 引擎侧的差异一点也看不见。
+    #[cfg(feature = "engine")]
+    pub fn recognize_engine_bare(image_bytes: &[u8]) -> anyhow::Result<super::OcrOutcome> {
+        super::recognize_engine(image_bytes)
     }
 }
 

--- a/packages/parser/src/conditions.rs
+++ b/packages/parser/src/conditions.rs
@@ -162,13 +162,44 @@ fn inline_number_re() -> &'static Regex {
     R.get_or_init(|| Regex::new(r"(?:^|\s)\d+\s*[.、)）](?:\s+|$)").expect("inline number re"))
 }
 
+/// 按 `；;，,、` 切,但**括号里的分隔符不切**。
+///
+/// 中文出院诊断把限定语写在诊断名后的括号里,而限定语内部常常自带逗号:
+/// `冠状动脉粥样硬化性心脏病(不稳定型心绞痛,PCI 术后)`。无差别按逗号切,这一条
+/// 诊断就碎成 `冠状动脉粥样硬化性心脏病(不稳定型心绞痛` 和 `PCI 术后)` 两条,
+/// 后者不是任何疾病,却会作为一条独立诊断进 `problems[]`,一路显示到给医生看的
+/// 摘要里。分期/分级是同一个形状(`肺癌(腺癌,IV 期)`),同样中招。
+///
+/// 只看括号配对深度,不看括号内容:深度 > 0 时分隔符当普通字符。左括号加深度,
+/// 右括号用 `saturating_sub` —— 单独一个 `)`(OCR 把左括号漏了)不会把深度压成
+/// 负数、从而让整行后面再也不切分。
+fn split_outside_brackets(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '(' | '（' | '[' | '【' | '〔' => depth += 1,
+            ')' | '）' | ']' | '】' | '〕' => depth = depth.saturating_sub(1),
+            '；' | ';' | '，' | ',' | '、' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
 /// Split an inline diagnosis string, clean each part, keep order. Two passes:
-/// first on in-line numbered markers (` 2.` ` 3.`), then on `；;，,、`. Each kept
-/// part is `(display_name, optional_icd_code)`.
+/// first on in-line numbered markers (` 2.` ` 3.`), then on `；;，,、` **outside
+/// brackets** (see [`split_outside_brackets`]). Each kept part is
+/// `(display_name, optional_icd_code)`.
 fn split_inline(s: &str) -> Vec<(String, Option<String>)> {
     inline_number_re()
         .split(s)
-        .flat_map(|seg| seg.split(['；', ';', '，', ',', '、']))
+        .flat_map(split_outside_brackets)
         .filter_map(clean_dx)
         .collect()
 }
@@ -498,5 +529,40 @@ mod tests {
         // Bracket form [E11.9] is captured the same as the paren form.
         assert_eq!(obs[0].icd_code.as_deref(), Some("E11.9"));
         assert_eq!(obs[0].section.as_deref(), Some("临床诊断"));
+    }
+
+    /// 括号里的限定语自带逗号,不能把一条诊断切成两条。真语料
+    /// (`2026-07-15_出院记录_冠脉支架术后.txt`)里的原句 —— 改之前这一行产出
+    /// `冠状动脉粥样硬化性心脏病(不稳定型心绞痛` 和 `PCI 术后)` 两条,后者作为
+    /// 一条独立「诊断」一路进到给医生看的摘要里。
+    #[test]
+    fn comma_inside_a_qualifier_bracket_does_not_split_the_diagnosis() {
+        let obs = extract_conditions(
+            "出院诊断:1. 冠状动脉粥样硬化性心脏病(不稳定型心绞痛,PCI 术后)  2. 高血压 3 级(很高危)",
+        );
+        let terms: Vec<&str> = obs.iter().map(|o| o.raw_text.as_str()).collect();
+        assert_eq!(
+            terms,
+            vec![
+                "冠状动脉粥样硬化性心脏病(不稳定型心绞痛,PCI 术后)",
+                "高血压 3 级(很高危)"
+            ]
+        );
+    }
+
+    /// 括号**外**的分隔符照切 —— 修复不能反过来把整行粘成一条。
+    #[test]
+    fn separators_outside_brackets_still_split() {
+        let obs = extract_conditions("出院诊断:高血压(3级),2型糖尿病、陈旧性脑梗死");
+        let terms: Vec<&str> = obs.iter().map(|o| o.raw_text.as_str()).collect();
+        assert_eq!(terms, vec!["高血压(3级)", "2型糖尿病", "陈旧性脑梗死"]);
+    }
+
+    /// OCR 漏掉左括号时,孤立的右括号不能把深度压成负数(用 `saturating_sub`),
+    /// 否则它后面整行都不再切分。
+    #[test]
+    fn unmatched_closing_bracket_does_not_disable_later_splitting() {
+        let obs = extract_conditions("出院诊断:心绞痛),2型糖尿病,陈旧性脑梗死");
+        assert_eq!(obs.len(), 3);
     }
 }


### PR DESCRIPTION
## 用户报的因果链

「切块 OCR 导致对齐有问题 → 渲染有问题 → 趋势有问题」。前半段成立,但元凶
不是切块本身。

## 量化

新增 packages/ocr/examples/layout_eval.rs:把 21 份语料真值 .txt 渲染成不带
文本层的扫描页,同一份字节喂给两个引擎函数,产出与真值都过同一个
parser::extract_labs,逐文档出三条临床指标(化验行召回 / 值-名配对 /
参考区间归属),不挑样本、不看字符准确率。6 份化验单共 42 行:

|  | 裸拼接(线上) | 布局重建 |
|---|---|---|
| 化验行召回 · 单帧 | 57.1% | 83.3% |
| 值-名配对 · 单帧 | 54.8% | 81.0% |
| 参考区间归属 · 单帧 | 40.5% | 81.0% |
| 化验行召回 · 分块 | 45.2% | 83.3% |
| 值-名配对 · 分块 | 42.9% | 78.6% |
| 参考区间归属 · 分块 | 19.0% | 78.6% |

结论:切块确实伤,但只伤裸拼接(参考区间归属 40.5% → 19.0%),布局重建几乎
免疫(81.0% → 78.6%)。**丢弃检测框的 x 坐标才是元凶,分块只是把后果放大。**

非表格 15 份逐行召回两者持平(93.0% vs 92.5%,分块 94.6% vs 94.6%)——散文
没有列,重建既无收益也无代价。

## 改动

recognize_platform_best 三条引擎分支(macOS 兜底 / Windows 兜底 / 移动端与
Linux 主路径)全部从 recognize_engine 换成 recognize_engine_layout。后者早就
实现好、有十几个测试覆盖,却零生产调用者。

影响面说清楚,别夸大:手机**拍照**路径(recognize_image_pp)本来就在用布局
重建,不受影响;这次修的是**导入扫描版 PDF** 那条(pipeline::ingest →
recognize_pdf_platform_best → recognize_platform_best)。化验单绝大多数是
PDF 进来的,所以表格错位的实际来源是这条。

## 评测夹具的两处方法学修正

1. **渲染根本没触发分块。** render_scan.py 把画布收缩包裹到刚好装下文字,
   17 行报告渲出来最高 998px,而分块门槛 TILE_CORE_H = 1100 —— 21 份一份都
   没走过缝合路径,而真机拍整页必然走。加 --scale 参数,倍率 3 下 21 份全部
   切 3 块,分块档才测得出来。

2. **「渲染确定性」的断言是错的。** 种子取自 Python 内置 hash(str),CPython
   对字符串哈希按进程加盐(PEP 456),实测同一路径三次拿到三个种子。改用
   zlib.crc32,现已复验同路径两次逐字节一致。

顺带:宽度改用 font.getlength 实测,不再假设每个字符都是全角——混排行此前
右边空出 40% 的白边,页面比例也偏离真实纸张。

## parser: 括号内的逗号不再切碎诊断

conditions.rs split_inline 无差别按 ，,、；; 切,而中文出院诊断把限定语写在
括号里、限定语内部自带逗号:

  冠状动脉粥样硬化性心脏病(不稳定型心绞痛,PCI 术后)

实测(真语料 2026-07-15_出院记录_冠脉支架术后.txt)被切成两条,其中
`PCI 术后)` 作为一条独立「诊断」进 problems[],一路显示到给医生看的摘要。
改成括号深度感知:深度 > 0 时分隔符当普通字符。孤立右括号用 saturating_sub,
不会把深度压成负数让后面整行都不再切分。三条测试覆盖:括号内逗号不切、
括号外照切、孤立右括号不破坏后续切分。

## 顺带修正两处已失效的注释

- recognize_engine_layout 声称「移植自安卓 Dart 侧的 _rebuildLayoutText」——
  安卓早已从 ML Kit 换成 PP-OCRv5,那个 Dart 函数连同依赖一起删了,grep 不到。
- 同一段声称自己是「iOS 测试路径专用,不会影响其他平台」——现在它是所有
  平台的产出函数。

## 门禁

cargo fmt --check(两个 workspace)、cargo test --workspace(主 workspace 全绿,
移动端 39 passed)、cargo clippy --all-targets -D warnings(两个 workspace)、
flutter analyze(No issues)、flutter test(301 passed)。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)