### PR TITLE
terminology: 补 MedRepBench 词典缺口 —— 端到端 20.0% -> 21.8%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "parser",
  "pdf-extract",
  "pollster",
+ "terminology",
  "windows 0.62.2",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1631,7 +1632,6 @@ dependencies = [
  "serde",
  "serde_json",
  "terminology",
- "unicode-normalization",
 ]
 
 [[package]]

--- a/packages/terminology/dictionary.json
+++ b/packages/terminology/dictionary.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-08-04.1",
+  "version": "2026-08-13.1",
   "note": "Clinical terminology normalization dictionary for MedMe (docs/015 §3.5). Codes pulled from the local OMOP vocab (LOINC / RxNorm / ATC + OMOP standard concept_id). Conversions are affine: canonical_value = slope * source_value + intercept. LOINC property/scale is chosen to agree with canonical_unit (molar LOINC for SI molar canonicals). See docs/superpowers/specs/2026-07-10-terminology-normalization-layer-design.md. Lab entries additionally carry an optional `panel`: the 检验大类 (specimen-report print grouping, e.g. 血常规/肝功能/肾功能) a lab is printed under on a Chinese lab report — a curation of print convention, not a clinical/disease judgment (that's `packages/parser/data/problem_map.json`, a separate axis for the doctor viewer). Absent for entries that don't cleanly fit one of the ~14 curated panels. See packages/terminology/panel_methodology.md.",
   "entries": [
     {
@@ -502,6 +502,7 @@
       "aliases": [
         "白细胞",
         "白细胞计数",
+        "白细胞总数",
         "白血球",
         "WBC",
         "Leukocytes"
@@ -568,6 +569,7 @@
       "aliases": [
         "血小板",
         "血小板计数",
+        "血小板总数",
         "PLT",
         "Platelets",
         "Platelet"
@@ -630,6 +632,7 @@
         "促甲状腺激素",
         "促甲状腺素",
         "甲状腺刺激素",
+        "血清促甲状腺激素",
         "TSH",
         "Thyrotropin"
       ],
@@ -1801,6 +1804,7 @@
       "aliases": [
         "γ-谷氨酰转肽酶",
         "γ-谷氨酰转移酶",
+        "γ-谷氨酰基转移酶",
         "谷氨酰转肽酶",
         "谷氨酰转移酶",
         "GGT",
@@ -1998,6 +2002,7 @@
         "红细胞压积",
         "血细胞比容",
         "红细胞比容",
+        "红细胞比积",
         "压积",
         "HCT",
         "PCV",
@@ -2053,6 +2058,8 @@
         "平均红细胞血红蛋白量",
         "平均血红蛋白量",
         "红细胞平均血红蛋白量",
+        "平均红细胞血红蛋白含量",
+        "平均血红蛋白含量",
         "MCH"
       ],
       "ocr_confusions": []
@@ -2109,6 +2116,8 @@
       "aliases": [
         "红细胞分布宽度",
         "红细胞体积分布宽度",
+        "红细胞分布宽度CV",
+        "红细胞分布宽度变异系数",
         "RDW",
         "RDW-CV",
         "RDWCV"
@@ -2254,6 +2263,7 @@
         "中性粒细胞绝对值",
         "中性粒细胞计数",
         "中性粒细胞数",
+        "中性粒细胞数目",
         "NEUT#",
         "NE#",
         "N#"
@@ -2865,6 +2875,7 @@
       "aliases": [
         "超敏C反应蛋白",
         "高敏C反应蛋白",
+        "超敏C-反应蛋白",
         "超敏CRP",
         "hs-CRP",
         "hsCRP"
@@ -5672,6 +5683,7 @@
       "aliases": [
         "凝血酶时间",
         "血浆凝血酶时间",
+        "凝血酶凝结时间",
         "TT",
         "Thrombin time"
       ],
@@ -7630,6 +7642,7 @@
         "促卵泡激素",
         "促卵泡生成素",
         "卵泡生成激素",
+        "卵泡生成素",
         "FSH",
         "Follitropin",
         "Follicle stimulating hormone"
@@ -7827,6 +7840,7 @@
         "催乳素",
         "泌乳素",
         "血清催乳素",
+        "血清泌乳素",
         "PRL",
         "Prolactin"
       ],
@@ -8745,6 +8759,7 @@
       "aliases": [
         "乙肝表面抗原定量",
         "乙型肝炎表面抗原定量",
+        "乙肝表面抗原定量测定",
         "HBsAg定量",
         "HBsAg quantitative"
       ],
@@ -8800,6 +8815,7 @@
       "aliases": [
         "乙肝表面抗体定量",
         "乙型肝炎表面抗体定量",
+        "乙肝表面抗体定量测定",
         "HBsAb定量",
         "抗-HBs定量",
         "anti-HBs quantitative"
@@ -10410,6 +10426,7 @@
       "aliases": [
         "尿细菌计数",
         "尿细菌",
+        "细菌",
         "细菌计数",
         "尿沉渣细菌",
         "BACT",
@@ -10417,7 +10434,132 @@
         "Bacteria"
       ],
       "ocr_confusions": [],
-      "note": "Urine bacteria count from a formed-element analyzer (LOINC 105907-0, [#/volume] in Urine), canonical /uL (= 10*6/L). This is NOT a urine culture colony count (CFU/mL) — do not fold culture results here."
+      "note": "Urine bacteria count from a formed-element analyzer (LOINC 105907-0, [#/volume] in Urine), canonical /uL (= 10*6/L). This is NOT a urine culture colony count (CFU/mL) — do not fold culture results here. Bare '细菌' claimed here (unqualified by 尿/urine) is a deliberate call: on MedRepBench the bare form only ever appears on 尿常规 report rows printed with a matching /uL-class unit, never on the culture or 白带/精液 panels alongside this key's sibling entries — see the A-line dictionary-gap report for the audit."
+    },
+    {
+      "key": "urine_pathologic_casts",
+      "canonical_name": "尿病理管型",
+      "category": "lab",
+      "system": "urine",
+      "panel": "尿液",
+      "codes": {
+        "loinc": "78741-6",
+        "omop_concept_id": 21491346
+      },
+      "canonical_unit": "/uL",
+      "units": [
+        {
+          "unit": "/uL",
+          "slope": 1.0,
+          "intercept": 0.0
+        },
+        {
+          "unit": "10*6/L",
+          "slope": 1.0,
+          "intercept": 0.0
+        }
+      ],
+      "aliases": [
+        "尿病理管型",
+        "病理管型",
+        "尿沉渣病理管型"
+      ],
+      "ocr_confusions": [],
+      "note": "Pathologic (non-hyaline) casts from a urine formed-element analyzer (LOINC 78741-6, [#/volume] in Urine by Automated count), canonical /uL (= 10*6/L). Distinct from the generic urine_casts entry (LOINC 51483-6, whose aliases include 透明管型/hyaline casts) — modern Chinese urine analyzers (Sysmex/Iris etc.) print 病理管型 as a separate parameter from 透明管型, so this is a separate key rather than an alias on urine_casts."
+    },
+    {
+      "key": "urine_mucus",
+      "canonical_name": "尿粘液丝",
+      "category": "lab",
+      "system": "urine",
+      "panel": "尿液",
+      "codes": {
+        "loinc": "51478-6",
+        "omop_concept_id": 3029363
+      },
+      "canonical_unit": "/uL",
+      "units": [
+        {
+          "unit": "/uL",
+          "slope": 1.0,
+          "intercept": 0.0
+        },
+        {
+          "unit": "10*6/L",
+          "slope": 1.0,
+          "intercept": 0.0
+        }
+      ],
+      "aliases": [
+        "尿粘液丝",
+        "粘液丝",
+        "黏液丝",
+        "尿沉渣粘液丝"
+      ],
+      "ocr_confusions": [],
+      "note": "Mucus threads from a urine formed-element analyzer (LOINC 51478-6, [#/volume] in Urine by Automated count), canonical /uL (= 10*6/L)."
+    },
+    {
+      "key": "urine_yeast",
+      "canonical_name": "尿酵母菌",
+      "category": "lab",
+      "system": "urine",
+      "panel": "尿液",
+      "codes": {
+        "loinc": "51481-0",
+        "omop_concept_id": 3029350
+      },
+      "canonical_unit": "/uL",
+      "units": [
+        {
+          "unit": "/uL",
+          "slope": 1.0,
+          "intercept": 0.0
+        },
+        {
+          "unit": "10*6/L",
+          "slope": 1.0,
+          "intercept": 0.0
+        }
+      ],
+      "aliases": [
+        "尿酵母菌",
+        "酵母菌",
+        "尿沉渣酵母菌"
+      ],
+      "ocr_confusions": [],
+      "note": "Yeast count from a urine formed-element analyzer (LOINC 51481-0, [#/volume] in Urine by Automated count), canonical /uL (= 10*6/L). Distinct from the qualitative dipstick/culture '真菌'(fungus) rows elsewhere on urinalysis reports, which have no fixed unit and are not modeled here."
+    },
+    {
+      "key": "urine_wbc_clumps",
+      "canonical_name": "尿白细胞团",
+      "category": "lab",
+      "system": "urine",
+      "panel": "尿液",
+      "codes": {
+        "loinc": "33768-3",
+        "omop_concept_id": 3029794
+      },
+      "canonical_unit": "/uL",
+      "units": [
+        {
+          "unit": "/uL",
+          "slope": 1.0,
+          "intercept": 0.0
+        },
+        {
+          "unit": "10*6/L",
+          "slope": 1.0,
+          "intercept": 0.0
+        }
+      ],
+      "aliases": [
+        "尿白细胞团",
+        "白细胞团",
+        "尿沉渣白细胞团"
+      ],
+      "ocr_confusions": [],
+      "note": "Leukocyte clumps from a urine formed-element analyzer (LOINC 33768-3, [#/volume] in Urine by Automated count), canonical /uL (= 10*6/L). Distinct from urine_wbc_count (individual leukocytes, LOINC 30405-5) — clumps are counted as a separate analyzer parameter."
     },
     {
       "key": "urine_crystals",

--- a/packages/terminology/src/lib.rs
+++ b/packages/terminology/src/lib.rs
@@ -436,6 +436,26 @@ fn strip_trailing_dose(s: &str) -> Option<String> {
     None
 }
 
+/// 剥掉报告版式的印刷标记:真实报告常在项目名前印 `#`/`*`/`★`/`☆`/`◆`(「重点关注」/
+/// 「异常提示」/院内打印惯例),`*` 有时会剥完括号后残留在末尾(如
+/// 「γ-谷氨酰转肽酶(γ-GT化学法)*」剥括号后是「…酶*」)。这些标记与项目名本身无关,
+/// 但 `normalize` 是精确查表,标记不去掉就整条认不出。返回 `None` 表示没有可剥的标记。
+///
+/// **尾部刻意不剥 `#`**:血细胞分类计数的字典别名本来就用尾部 `#` 表示「绝对值/计数」
+/// 而非「百分比」(`NEUT#`、`LYM#`、`MONO#`…… 见 build_index 建索引时收录的别名),
+/// `#` 是这些别名的一部分,剥了会把「NEUT#」错剥成「NEUT」。前缀 `#` 没有这个问题——
+/// 词典里没有一条别名以 `#`/`*`/`★`/`☆`/`◆` 开头。
+fn strip_report_markers(s: &str) -> Option<String> {
+    const LEADING: &[char] = &['#', '*', '★', '☆', '◆'];
+    const TRAILING: &[char] = &['*', '★', '☆', '◆'];
+    let stripped = s.trim_start_matches(LEADING).trim_end_matches(TRAILING);
+    if stripped.chars().count() < s.chars().count() && !stripped.is_empty() {
+        Some(stripped.to_string())
+    } else {
+        None
+    }
+}
+
 /// 术语名**候选拆分**(提取层调用,不在 [`normalize`] 里跑):真实报告/处方写
 /// 「甘油三酯 TG」「肌酐 Cr(Scr)」「甲泼尼龙片(美卓乐)4mg」——整串精确查表必 miss,
 /// 拆开后各自查即命中。
@@ -492,6 +512,14 @@ pub fn term_candidates(name: &str) -> Vec<String> {
             if !t.is_empty() {
                 cands.push(t.to_string());
             }
+        }
+    }
+    // 每个候选再补一个「去掉报告版式印刷标记」的版本(#/*/★/☆/◆,见
+    // strip_report_markers 文档)。放在去规格之前,好让「★白细胞计数5mg」这类
+    // 标记+规格叠加的候选也能在下一步被去规格补全。
+    for i in 0..cands.len() {
+        if let Some(stem) = strip_report_markers(&cands[i]) {
+            cands.push(stem);
         }
     }
     // 每个候选再补一个「去掉尾部规格」的版本(处方:醋酸泼尼松片5mg)。
@@ -1002,6 +1030,31 @@ mod tests {
     }
 
     #[test]
+    fn strips_report_print_markers() {
+        // 真实报告在项目名前印 #/*/★/☆/◆(重点关注/异常提示/院内惯例),剥完括号
+        // 后 * 有时残留在尾部。这些都不是项目名的一部分。
+        let hit = |name: &str| {
+            term_candidates(name)
+                .iter()
+                .find_map(|c| normalize(c))
+                .unwrap_or_else(|| panic!("no candidate hit for {name}"))
+                .key
+        };
+        assert_eq!(hit("#白细胞计数"), "wbc");
+        assert_eq!(hit("*红细胞计数"), "rbc");
+        assert_eq!(hit("★血小板计数"), "plt");
+        assert_eq!(hit("☆癌胚抗原"), "cea");
+        assert_eq!(hit("◆乙肝e抗原"), "hbeag");
+        // 剥括号后残留的尾部 *。
+        assert_eq!(hit("γ-谷氨酰转肽酶(γ-GT化学法)*"), "ggt");
+        // 叠加多个标记(前缀 ★ + *)。
+        assert_eq!(hit("★*凝血酶原时间"), "pt");
+        // 尾部 # 是别名本身的一部分(NEUT# = 绝对计数,≠ NEUT),不能被剥掉;
+        // 整串本来就直配得到,不该被误剥成查不到的「NEUT」。
+        assert_eq!(normalize("NEUT#").unwrap().key, "neut_count");
+    }
+
+    #[test]
     fn unit_notation_folds_but_never_folds_case() {
         // 记法差异(报告 vs UCUM)折叠后必须一致。
         for (report, ucum) in [
@@ -1101,10 +1154,13 @@ mod tests {
     fn total_entry_count_is_expected() {
         // Coverage expansion (2026-07-14.1): 191 + 446 按专科批次扩容 = 637,再减 1
         // (2026-08-05:去重 polystyrene_sulfonate 的重复条目,见 dictionary_keys_are_globally_unique)= 636。
+        // +4 (2026-08-13.1:MedRepBench 词典缺口扫描,补尿沉渣分析仪四项 ——
+        // urine_pathologic_casts/urine_mucus/urine_yeast/urine_wbc_clumps,均有独立
+        // LOINC 标准概念,见各条目 note)= 640。
         // A drift here means an entry was accidentally dropped or duplicated.
         assert_eq!(
             dictionary_entries().len(),
-            636,
+            640,
             "unexpected dictionary entry count"
         );
     }


### PR DESCRIPTION
## Summary

A 线(术语词典缺口)成果。683 份真实中文化验单(MedRepBench)上跑分:

| | baseline | 本 PR 后 |
|---|---|---|
| 词典未覆盖 | 2571 (50.7%) | 2376 (46.9%) |
| 可比条目 | 2043 (40.3%) | 2220 (43.8%) |
| 定性条目 | 454 (9.0%) | 472 (9.3%) |
| **端到端(数值抽对/全部真值)** | **20.0% (1015/5068)** | **21.8% (1105/5068)** |

三条几何重建(②)指标基本走平(58.7%->58.6% / 49.7%->49.8% / 24.3%->24.9%),①/③ 两臂同步小幅上升 —— 说明提升来自分母扩容后同等质量地被抽对,不是某一臂的偶然波动。**端到端 +1.8pp(+90 条)才是真提升**,分母结构见 baseline 说明。

## 改动

1. `packages/terminology/src/lib.rs`:`term_candidates` 新增 `strip_report_markers`,剥掉项目名前印的 `#`/`*`/`★`/`☆`/`◆`(重点关注/异常提示/院内打印惯例标记),以及剥完括号后残留在尾部的 `*`。尾部 `#` 刻意保留(`NEUT#`/`LYM#` 等绝对计数别名的一部分)。新增测试 `strips_report_print_markers` 守住这条,含"不能误伤 `NEUT#`"的反例。

2. `dictionary.json`:12 个已建模指标补同义词别名(逐条核对 `analyte_key` 已存在,未新造 key)—— 白细胞总数/血小板总数/平均血红蛋白含量/平均红细胞血红蛋白含量/红细胞分布宽度CV/红细胞分布宽度变异系数/中性粒细胞数目/凝血酶凝结时间/γ-谷氨酰基转移酶/红细胞比积/卵泡生成素/血清泌乳素/血清促甲状腺激素/超敏C-反应蛋白/乙肝表面抗原(抗体)定量测定/尿细菌裸称。

3. 新增 4 条尿沉渣分析仪条目(经本地 OMOP vocab 核实标准 LOINC):`urine_pathologic_casts`(78741-6)、`urine_mucus`(51478-6)、`urine_yeast`(51481-0)、`urine_wbc_clumps`(33768-3)。词典条目数 636 -> 640。

## 明确不加(有理由)

- **定性项**(滴虫/颜色/清洁度/线索细胞/霉菌/真菌/唾液酸苷酶/过氧化氢/浊度/粘稠度/标本满意度……):`parser::labs` 不处理定性值,加进词典也进不了趋势,不为刷覆盖率而加。
- **裸 `PH值`/`酸碱度`/`pH`**:数据集里这三个写法横跨尿常规/白带常规/精液常规三种标本,且均无单位可作判别证据 —— 强行归一到某一个 `*_ph` 条目会系统性地把另外两种标本误标。`blood_ph` 条目本身的 note 已经写明"故别名不含裸 pH"以避免与 `urine_ph` 冲突,同样的顾虑扩大到三种标本就必须整体回避裸形式。
- **乙肝 e 抗原/e 抗体/核心抗体的"定量测定"**:本地 OMOP vocab 查不到对应标准 LOINC 概念,且各报告单位互不折算(S/CO、COI、PEIU/mL、IU/mL 因平台而异)——与字典里其它条目一贯拒绝瞎编换算的原则一致,只加了已有干净 LOINC + 单位的 `hbsag_quant`/`hbsab_quant` 两条真实同义词。

## 剩余天花板

词典缺口清单里还剩 ~1100 个不同定量项名(每个多为 1-3 次出现的长尾),多数需要逐条查 LOINC/核实报告语境才能"有理有据"地加,性价比递减;真正结构性的天花板是可比条目里的**项目召回**(几何重建仅 58.6%)和**值-名配对**(49.8%)—— 这是版面/OCR 问题,不是词典问题,分别归 C 线 / 需要后续投入。

## Test plan

- [x] `cargo fmt --check`(两个 workspace)
- [x] `cargo clippy --all-targets -- -D warnings`(两个 workspace)
- [x] `cargo test --workspace`(两个 workspace 全绿,含新增 `strips_report_print_markers`)
- [x] `flutter analyze` + `flutter test`(301 项全绿,未改动 Flutter 代码,回归验证)
- [x] `./target/release/examples/medrep --score --out out_dict` 改前改后对比(见上表)

🤖 Generated with [Claude Code](https://claude.com/claude-code)