### PR TITLE
fix(ocr): 倾斜归行改修图像级去斜——683 份真实数据验证，第三轮翻案

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "parser",
  "pdf-extract",
  "pollster",
+ "terminology",
  "windows 0.62.2",
 ]
 

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -670,10 +670,6 @@ const ORIENT_TALL_RATIO: f32 = 1.3;
 /// sideways (rotated 90°/270°) and try to upright it.
 #[cfg(feature = "engine")]
 const ORIENT_TALL_THRESHOLD: f32 = 0.5;
-/// Minimum in-plane skew (degrees) worth a deskew + re-OCR pass. Below this the
-/// tilt doesn't meaningfully hurt row grouping and isn't worth the resample.
-#[cfg(feature = "engine")]
-const ORIENT_MIN_DESKEW_DEG: f32 = 1.0;
 
 /// Fraction of non-empty lines whose detection box is taller than wide (by
 /// [`ORIENT_TALL_RATIO`]). Near 0 for an upright document (text lines are wide and
@@ -708,6 +704,51 @@ fn mean_line_confidence(lines: &[OcrLine]) -> f32 {
         .filter_map(|l| l.confidence)
         .collect();
     mean_confidence(&confs)
+}
+
+/// How tilted `lines`' own detected-box geometry is, in the same terms
+/// [`rebuild_layout_text`] judges it by: `tilt_drift` is directly comparable
+/// to `LAYOUT_ROW_Y_TOLERANCE_RATIO * median_height`, the bar
+/// `trust_cell_content` uses there. `correction_deg` is the angle
+/// [`deskew`] would need to level it — see
+/// `ocr_box_tilt_correction_deg_cancels_a_real_image_rotation` for why this sign
+/// is right, verified against the actual [`rotate_about_center`] this module
+/// wraps, not just derived on paper.
+///
+/// `None` when there are too few non-empty lines to fit a slope from (same
+/// floor [`find_dual_column_band`] requires for any pattern to be trusted)
+/// or the content span is degenerate.
+#[cfg(feature = "engine")]
+fn measure_ocr_box_tilt(lines: &[OcrLine]) -> Option<(f32, f32, f32)> {
+    let owned: Vec<LayoutLine> = lines
+        .iter()
+        .filter(|l| !l.text.trim().is_empty())
+        .map(|l| LayoutLine {
+            text: String::new(), // geometry only -- content plays no part in the fit
+            left: l.left,
+            top: l.top,
+            right: l.right,
+            height: l.bottom - l.top,
+        })
+        .collect();
+    if owned.len() < DUAL_COLUMN_MIN_SUPPORT_ROWS {
+        return None;
+    }
+    let refs: Vec<&LayoutLine> = owned.iter().collect();
+    let content_left = refs.iter().map(|l| l.left).fold(f32::INFINITY, f32::min);
+    let content_right = refs
+        .iter()
+        .map(|l| l.right)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let content_span = content_right - content_left;
+    let median_height = median_line_height(&refs);
+    if content_span <= 0.0 || median_height <= 0.0 {
+        return None;
+    }
+    let slope = estimate_tilt(&refs, median_height);
+    let tilt_drift = slope.abs() * content_span;
+    let correction_deg = (-slope).atan().to_degrees();
+    Some((tilt_drift, median_height, correction_deg))
 }
 
 /// Decode + preprocess, then recognize with automatic **page-orientation
@@ -754,23 +795,42 @@ fn predict_lines(image_bytes: &[u8]) -> Result<Vec<OcrLine>> {
     }
 
     // 2) Deskew (in-plane tilt). A tilted photo leaves text rows slanted even once
-    //    upright; the detector then merges/mis-groups cells (the "mashed, hard to
-    //    read" layout). If the chosen upright image has a meaningful in-plane skew,
-    //    rotate it flat (reusing the projection-profile [`estimate_skew_deg`] +
-    //    [`deskew`] already used in [`preprocess`]) and re-OCR so rows come back
-    //    horizontal. `preprocess` already deskewed upright inputs, so this only fires
-    //    for pages that were *rotated first* (their skew survives the rotation).
-    //    **Failure-safe**: accept the deskewed result only if it kept ~all its lines
-    //    and didn't make the page look more sideways — otherwise keep the pre-deskew
-    //    result. A bad warp is worse than none.
-    let gray = best_img.to_luma8();
-    if let Some(angle) = estimate_skew_deg(&gray) {
-        if angle.is_finite() && angle.abs() >= ORIENT_MIN_DESKEW_DEG {
-            let deskewed = DynamicImage::ImageLuma8(deskew(&gray, angle));
+    //    upright; row-grouping then either merges cells from neighbouring records
+    //    into one visual row, or — once the tilt is large enough to trip
+    //    `rebuild_layout_text`'s own `trust_cell_content` guard — degrades to
+    //    dropping values rather than risk pairing them wrong. Either way the fix
+    //    belongs here, before that guard ever has to fire: measure the tilt in the
+    //    OCR engine's own detected boxes ([`measure_ocr_box_tilt`]) and, if
+    //    row-grouping would no longer trust this page's geometry, rotate the image
+    //    by the fitted correction and re-OCR so rows come back level.
+    //
+    //    This deliberately does **not** reuse the pixel-intensity projection
+    //    profile ([`estimate_skew_deg`], still used by [`preprocess`] for the
+    //    same purpose) for this decision. On real photographed lab-report tables
+    //    that estimator is unreliable — measured on 40 real MedRepBench photos
+    //    (`improve/skew`'s evidence), it returned exactly 0.0° (claiming a level
+    //    page) on documents whose detected boxes show tilt drift over 200px, and
+    //    on others it saturated at its ±10° search ceiling — a sign it never
+    //    converged, not that the true skew is 10° — sometimes on *both* the
+    //    initial estimate and the re-estimate after applying its own correction.
+    //    It gets dragged off by content that isn't a text baseline (table grid
+    //    lines, stamps, fold creases), which real lab photos are full of.
+    //    [`estimate_tilt`] instead fits the OCR engine's own detected text-line
+    //    boxes, which by construction only exist where the engine already found
+    //    text — immune to the non-text content that misleads the pixel profile.
+    //
+    //    **Failure-safe**: accept the deskewed result only if it kept ~all its
+    //    lines *and* measurably reduced the tilt — otherwise keep the pre-deskew
+    //    result. A bad correction (or one that just trades one tilt for another)
+    //    is worse than none.
+    if let Some((drift, median_height, correction_deg)) = measure_ocr_box_tilt(&best_lines) {
+        if drift > LAYOUT_ROW_Y_TOLERANCE_RATIO * median_height {
+            let gray = best_img.to_luma8();
+            let deskewed = DynamicImage::ImageLuma8(deskew(&gray, correction_deg));
             if let Ok(dl) = predict_lines_core(&deskewed) {
                 let kept_lines = dl.len() * 10 >= best_lines.len() * 8;
-                let not_worse = tall_fraction(&dl) <= tall_fraction(&best_lines) + 0.05;
-                if kept_lines && not_worse {
+                let improved = measure_ocr_box_tilt(&dl).is_none_or(|(d, _, _)| d < drift);
+                if kept_lines && improved {
                     return Ok(dl);
                 }
             }
@@ -2542,6 +2602,112 @@ mod tests {
         assert!(
             residual.abs() <= 1.5,
             "expected small residual skew after deskew, got {residual} (estimated correction was {estimated})"
+        );
+    }
+
+    /// Validates the sign convention `measure_ocr_box_tilt` relies on
+    /// (`correction_deg = (-slope).atan().to_degrees()`) against the actual
+    /// [`rotate_about_center`] this module's [`deskew`] wraps -- not just the
+    /// derivation from its "rotates clockwise" doc comment. Marks four points
+    /// on one horizontal "text line", physically rotates the image by a known
+    /// angle, relocates the marks and fits their slope (the same quantity
+    /// [`estimate_tilt`] fits from real OCR box tops), and checks two things:
+    /// (a) that fitted slope matches `tan(applied angle)` -- confirming
+    /// `estimate_tilt`'s "top = intercept + slope*x" model actually describes
+    /// what a real clockwise image rotation produces, not just the synthetic
+    /// coordinates `estimate_tilt_recovers_known_page_rotation` constructs by
+    /// hand -- and (b) that rotating a second time by the derived
+    /// `correction_deg` brings the marks back level. Getting this sign wrong
+    /// would make `predict_lines`' step-2 redeskew double the tilt instead of
+    /// cancelling it, silently, on every real photo it fires on.
+    #[test]
+    fn ocr_box_tilt_correction_deg_cancels_a_real_image_rotation() {
+        let (w, h) = (400u32, 400u32);
+        let mut img = GrayImage::from_pixel(w, h, Luma([255]));
+        let xs = [80.0f32, 160.0, 240.0, 320.0];
+        let y0 = 200i64;
+        // 5x5 filled squares, not single pixels -- Nearest-neighbour resampling
+        // under a small rotation can step over (never land exactly on) a
+        // 1px mark, losing it entirely; a few-pixel square always has some
+        // pixel survive the resample.
+        for &x in &xs {
+            for dx in -2i64..=2 {
+                for dy in -2i64..=2 {
+                    img.put_pixel((x as i64 + dx) as u32, (y0 + dy) as u32, Luma([0]));
+                }
+            }
+        }
+
+        // Centroid (mean y of dark pixels in the column) of the mark nearest
+        // `x`, robust to the square's exact footprint after resampling.
+        let locate = |im: &GrayImage, x: u32| -> Option<f32> {
+            let lo = x.saturating_sub(3);
+            let hi = (x + 3).min(im.width() - 1);
+            let mut sum = 0f64;
+            let mut n = 0u32;
+            for xx in lo..=hi {
+                for y in 0..im.height() {
+                    if im.get_pixel(xx, y).0[0] < 128 {
+                        sum += y as f64;
+                        n += 1;
+                    }
+                }
+            }
+            (n > 0).then(|| (sum / n as f64) as f32)
+        };
+        // Least-squares dy/dx over the relocated marks -- exactly what
+        // `estimate_tilt` fits from OCR box tops, just computed directly here
+        // so this test doesn't depend on the detection-box grouping machinery.
+        let fit_slope = |pts: &[(f32, f32)]| -> f32 {
+            let mean_x = pts.iter().map(|p| p.0).sum::<f32>() / pts.len() as f32;
+            let mean_y = pts.iter().map(|p| p.1).sum::<f32>() / pts.len() as f32;
+            let num: f32 = pts.iter().map(|&(x, y)| (x - mean_x) * (y - mean_y)).sum();
+            let den: f32 = pts.iter().map(|&(x, _)| (x - mean_x).powi(2)).sum();
+            num / den
+        };
+
+        let theta_deg = 6.0f32;
+        let rotated = rotate_about_center(
+            &img,
+            theta_deg.to_radians(),
+            Interpolation::Nearest,
+            Border::Constant(Luma([255])),
+        );
+        let pts: Vec<(f32, f32)> = xs
+            .iter()
+            .filter_map(|&x| locate(&rotated, x as u32).map(|y| (x, y)))
+            .collect();
+        assert!(
+            pts.len() >= 3,
+            "expected to relocate the rotated marks, got {pts:?}"
+        );
+        let slope = fit_slope(&pts);
+        assert!(
+            (slope - theta_deg.to_radians().tan()).abs() < 0.03,
+            "expected slope ~= tan({theta_deg}deg) = {}, got {slope}",
+            theta_deg.to_radians().tan()
+        );
+
+        let correction_deg = (-slope).atan().to_degrees();
+        let releveled = rotate_about_center(
+            &rotated,
+            correction_deg.to_radians(),
+            Interpolation::Nearest,
+            Border::Constant(Luma([255])),
+        );
+        let pts2: Vec<(f32, f32)> = xs
+            .iter()
+            .filter_map(|&x| locate(&releveled, x as u32).map(|y| (x, y)))
+            .collect();
+        assert!(
+            pts2.len() >= 3,
+            "expected to relocate the releveled marks, got {pts2:?}"
+        );
+        let residual_slope = fit_slope(&pts2);
+        assert!(
+            residual_slope.abs() < 0.03,
+            "expected releveled marks near-flat, got slope {residual_slope} \
+             (correction_deg={correction_deg})"
         );
     }
 


### PR DESCRIPTION
## 结论

**值得做，推翻前两轮「不做」的结论**——但不是在前两轮已经证伪的技术路线上硬来。

前两轮（`fix/tilt-aware-rows` 741d165、`fix/banded-tilt-rows` a7ad523）各自验证过：
1. 在行分组阶段用坐标数学（`top - s*x`）修正倾斜——不安全，在最难的真实照片上产生了比不修正更差的错配。
2. 复用 `estimate_skew_deg`（像素强度投影方差）做图像级去斜——不管用，估计器在这张照片上打到 ±10° 搜索区间上限（未收敛信号），去斜后残留倾斜量级基本不变。
3. 分带（局部斜率）估计——不改变结果，局部斜率≈全局斜率。

**本轮走第三条路，两轮都没试过**：不复用像素强度投影，改用 OCR 引擎自己识别出的检测框几何（`estimate_tilt`，本来就用在 `rebuild_layout_text` 里判断 `trust_cell_content`）驱动图像级的真实旋转 + 重新识别，而不是行分组阶段的坐标事后修正。

## 683 份 MedRepBench 真实化验单全量结果

对照基准（B 线修过 gt.tsv 双短横区间解析 bug 后的口径）：

| 指标 | 改前 | 改后 | Δ |
|---|---|---|---|
| 项目召回 | 58.7% (1199/2043) | 59.9% (1223/2043) | +24 条 |
| 值-名配对 | 49.7% (1015/2043) | 52.1% (1065/2043) | +50 条 |
| 参考区间归属 | 24.5% (423/1729) | 28.4% (491/1729) | +68 条 |
| 端到端 | 20.0% (1015/5068) | 21.0% (1065/5068) | +50 条 |

三条指标 + 端到端全部同向改善。③ PP-StructureV3（独立流水线，不经过本次改动的任何代码）三条指标与产出为空份数分毫不差，交叉验证改动范围正确。

## 变差的部分（如实报告）

① 裸拼接（`recognize_engine_bare`，**无生产调用者**，只在 eval 里当对照组）项目召回 5.7%→5.0%、值-名配对 5.4%→4.7%。推测（未单独隔离验证）：更多文档触发了图像旋转+重新识别，双线性重采样轻微模糊小字；② 有版面几何冗余能从修正中获益抵消这点代价，① 没有几何可用，只承担重采样代价。不影响生产路径（`recognize_platform_best` 走②不走①）。

## 根因诊断（40 份真实照片）

`estimate_skew_deg` 在真实化验单照片上系统性失灵：对一部分文档返回 `0.0°`（宣称水平）而实际检测框倾斜漂移超过 200px；对另一部分打到 ±10° 搜索上限且去斜后仍不收敛。会被表格线/印章/折痕带偏。改用检测框几何后：平均倾斜漂移从 157.8px 降到 58.6px，`trust_cell_content=false` 的文档占比从 56%(22/39) 降到 33%(13/39)。

## 安全性

- 符号约定不是推导出来就信——新增 `ocr_box_tilt_correction_deg_cancels_a_real_image_rotation`，端到端过真实的 `rotate_about_center`（不是手写矩阵）验证符号。
- 失败安全：只有重新识别后行数没掉太多、且倾斜确实变小了才采纳。
- 第二轮的回归哨兵 `rebuild_layout_text_report1_tilt_does_not_misattribute_reference_ranges` 原样通过，未改断言——本次改动只碰 OCR 引擎运行前的图像级步骤，不碰行分组本身，两者正交。

## 门禁

根 workspace 与 `apps/mobile_flutter/rust` 的 `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace --release` 全绿；`apps/mobile_flutter` 的 `flutter analyze`（No issues found）、`flutter test`（301 passed）全绿。

## 测试计划

- [x] `cargo test -p ocr --features engine,testing --release`：45 passed，0 failed
- [x] 根 workspace + mobile_flutter/rust 两个 workspace 门禁全绿
- [x] flutter analyze + flutter test 全绿
- [x] 683 份 MedRepBench 全量（非抽样）跑通 `--produce` + `--score`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>