### PR TITLE
fix(parser): stop reporting a wrapped range's own low bound as a value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "parser",
  "pdf-extract",
  "pollster",
+ "terminology",
  "windows 0.62.2",
 ]
 

--- a/packages/ocr/examples/medrep.rs
+++ b/packages/ocr/examples/medrep.rs
@@ -106,6 +106,16 @@ struct Tally {
     /// A/B 两类被排除的条目数(只统计,不计分)
     no_dict: usize,
     qualitative: usize,
+    /// **错配**:抽出的某行认定了某个 analyte_key,该文档真值里也有这个指标,
+    /// 但数值对不上 —— 也就是「我们说这是白细胞 = 11.8,真值说白细胞是 6.2」。
+    /// 这是最危险的一类:用户看到的是一个**看着合理但错误的临床值**,比漏掉糟得多。
+    /// 召回类指标全都看不见它,所以必须单列。分母是所有抽出且能对上真值指标的行。
+    mis_value: usize,
+    mis_denom: usize,
+    /// 抽出的 analyte_key 在该文档真值里**根本没有**。可能是我们无中生有,也可能是
+    /// 真值标注不全(MedRepBench 只标了它认为是化验项的行)。**不能直接当错误**,
+    /// 只作为「模糊匹配开得太松」的预警信号看趋势。
+    unknown_key: usize,
     /// 产出为空(该臂在这份图上整个失败)
     empty_docs: usize,
     docs: usize,
@@ -337,6 +347,43 @@ fn score(out: &str) -> Result<()> {
             if !non_empty {
                 t.empty_docs += 1;
             }
+            // 反向:看我们抽出来的每一行,是不是把值安到了错的指标上。
+            {
+                use std::collections::HashMap as Map;
+                let mut by_key: Map<&str, Vec<f64>> = Map::new();
+                for gi in items {
+                    if let (Some(m), Some(v)) = (
+                        terminology::resolve(
+                            &gi.name,
+                            if gi.unit.is_empty() {
+                                None
+                            } else {
+                                Some(gi.unit.as_str())
+                            },
+                        ),
+                        gi.value,
+                    ) {
+                        by_key
+                            .entry(Box::leak(m.key.clone().into_boxed_str()))
+                            .or_default()
+                            .push(v);
+                    }
+                }
+                for r in &rows {
+                    let Some(k) = r.analyte_key.as_deref() else {
+                        continue;
+                    };
+                    match by_key.get(k) {
+                        Some(vals) => {
+                            t.mis_denom += 1;
+                            if !vals.iter().any(|v| (v - r.value_num).abs() < VALUE_EPS) {
+                                t.mis_value += 1;
+                            }
+                        }
+                        None => t.unknown_key += 1,
+                    }
+                }
+            }
             for gi in items {
                 // A 类:词典不认识这个名字 —— 与识别质量无关的上游天花板。
                 let Some(m) = terminology::resolve(
@@ -440,6 +487,21 @@ fn score(out: &str) -> Result<()> {
         }
         println!();
     }
+    print!("| **错配率**(值安错指标) |");
+    for t in &tally {
+        print!(
+            " {:.1}% ({}/{}) |",
+            pct(t.mis_value, t.mis_denom),
+            t.mis_value,
+            t.mis_denom
+        );
+    }
+    println!();
+    print!("| 真值里没有的指标(预警) |");
+    for t in &tally {
+        print!(" {} |", t.unknown_key);
+    }
+    println!();
     print!("| 产出为空的份数 |");
     for t in &tally {
         print!(" {}/{} |", t.empty_docs, t.docs);

--- a/packages/ocr/examples/medrep_recall_diag.rs
+++ b/packages/ocr/examples/medrep_recall_diag.rs
@@ -1,0 +1,272 @@
+// 诊断专用,不是评测夹具:把「项目召回」的失配案例按根因分桶计数,给改进线定位
+// 该先啃哪一块。不影响 medrep.rs / medrep_attrib.rs 的任何评分逻辑,只读它们已经
+// 产出的 arm2_geo 文本 + gt.tsv 真值,自己再跑一遍 parser::extract_labs 做归类。
+//
+// 跑法:
+// cargo run --release -p ocr --example medrep_recall_diag -- --out out_recall [--samples 5]
+
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const ROOT: &str = "/private/tmp/claude-501/-Volumes-extraSupply-Projects-openmed/3c224b0f-768e-498c-b5ef-328c3ba3b549/scratchpad/datasets/medrepbench";
+
+/// 与 medrep_attrib.rs 的 norm() 逐字相同 —— 判据必须一致,不能各诊断各的。
+fn norm(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_whitespace() && !matches!(c, '#' | '*' | '※' | '·' | '．' | '・'))
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+struct Item {
+    name: String,
+    value: f64,
+    unit: String,
+}
+
+#[derive(Default)]
+struct Bucket {
+    count: usize,
+    samples: Vec<(String, String)>, // (doc, context)
+}
+
+impl Bucket {
+    fn hit(&mut self, doc: &str, ctx: String, keep: usize) {
+        self.count += 1;
+        if self.samples.len() < keep {
+            self.samples.push((doc.to_string(), ctx));
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let out = args
+        .iter()
+        .position(|a| a == "--out")
+        .and_then(|i| args.get(i + 1).cloned())
+        .unwrap_or_else(|| "out_recall".to_string());
+    let samples: usize = args
+        .iter()
+        .position(|a| a == "--samples")
+        .and_then(|i| args.get(i + 1).cloned())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6);
+
+    let text = std::fs::read_to_string(format!("{ROOT}/gt.tsv")).context("读 gt.tsv")?;
+    let mut gt: BTreeMap<String, Vec<Item>> = BTreeMap::new();
+    for line in text.lines() {
+        let c: Vec<&str> = line.split('\t').collect();
+        if c.len() < 7 || c[6] != "num" {
+            continue;
+        }
+        let Ok(v) = c[2].parse::<f64>() else { continue };
+        gt.entry(c[0].to_string()).or_default().push(Item {
+            name: c[1].to_string(),
+            value: v,
+            unit: c[3].to_string(),
+        });
+    }
+
+    let dir = PathBuf::from(ROOT).join(&out).join("arm2_geo");
+    anyhow::ensure!(dir.is_dir(), "{} 不存在,先跑 --produce", dir.display());
+
+    let mut b_name_missing = Bucket::default(); // OCR 没读到名字(不管数值)
+    let mut b_value_missing = Bucket::default(); // 名字读到了,数值没读到
+    let mut b_same_line_serial = Bucket::default(); // 同行,行首粘着序号且行内还有别的列(bare-pair 限制卡住)
+    let mut b_same_line_multi = Bucket::default(); // 同行,这一行已经被解析成另一条目(双栏/多项目挤一行)
+    let mut b_same_line_other = Bucket::default(); // 同行,原因待查
+    let mut b_wrap_adjacent = Bucket::default(); // 名在一行、数在紧邻的下一行/上一行
+    let mut b_wrap_far = Bucket::default(); // 名与数都读到了,但隔了 2+ 行
+    let mut b_dict_key_mismatch = Bucket::default(); // 名和数同行且被抽出,但 analyte_key 对不上真值(词典歧义)
+
+    let mut n_total = 0usize;
+    let mut n_miss = 0usize;
+
+    for (doc, items) in &gt {
+        let Ok(body) = std::fs::read_to_string(dir.join(format!("{doc}.txt"))) else {
+            continue;
+        };
+        let lines: Vec<&str> = body.lines().collect();
+        let rows = parser::extract_labs(&body);
+
+        for it in items {
+            let Some(m) = terminology::resolve(
+                &it.name,
+                if it.unit.is_empty() {
+                    None
+                } else {
+                    Some(it.unit.as_str())
+                },
+            ) else {
+                continue; // 词典未覆盖,不属于本诊断范围
+            };
+            n_total += 1;
+
+            let recalled = rows
+                .iter()
+                .any(|r| r.analyte_key.as_deref() == Some(m.key.as_str()));
+            if recalled {
+                continue;
+            }
+            n_miss += 1;
+
+            let name_norm = norm(&it.name);
+            let value_raw = norm(&format!("{}", it.value));
+            let name_ok = name_norm.chars().count() >= 2;
+
+            let name_lines: Vec<usize> = if name_ok {
+                lines
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, l)| norm(l).contains(&name_norm))
+                    .map(|(i, _)| i)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let value_lines: Vec<usize> = lines
+                .iter()
+                .enumerate()
+                .filter(|(_, l)| norm(l).contains(&value_raw))
+                .map(|(i, _)| i)
+                .collect();
+
+            if name_lines.is_empty() {
+                b_name_missing.hit(
+                    doc,
+                    format!("真值名={} 数值={}", it.name, it.value),
+                    samples,
+                );
+                continue;
+            }
+            if value_lines.is_empty() {
+                b_value_missing.hit(
+                    doc,
+                    format!(
+                        "真值名={} 数值={} | 名字所在行: {:?}",
+                        it.name,
+                        it.value,
+                        name_lines.iter().map(|&i| lines[i]).collect::<Vec<_>>()
+                    ),
+                    samples,
+                );
+                continue;
+            }
+
+            // 名字和数值都读到了 —— 找同一行的交集
+            let same_line: Vec<usize> = name_lines
+                .iter()
+                .copied()
+                .filter(|i| value_lines.contains(i))
+                .collect();
+
+            if let Some(&li) = same_line.first() {
+                let line = lines[li];
+                let trimmed = line.trim_start();
+                let starts_with_serial = trimmed.chars().next().is_some_and(|c| c.is_ascii_digit());
+                // 这一行是否已经被 parser 解析成了别的行(说明它被消费给了别的项目,
+                // 常见于双栏/一行挤两项目 —— parser 一行只产一条)
+                let line_already_used = rows.iter().any(|r| {
+                    line.contains(&r.raw_name) && {
+                        let vs = format!("{}", r.value_num);
+                        line.contains(&vs)
+                    }
+                });
+                if line_already_used {
+                    b_same_line_multi.hit(
+                        doc,
+                        format!("真值名={} 数值={} | 行: {:?}", it.name, it.value, line),
+                        samples,
+                    );
+                } else if starts_with_serial {
+                    b_same_line_serial.hit(
+                        doc,
+                        format!("真值名={} 数值={} | 行: {:?}", it.name, it.value, line),
+                        samples,
+                    );
+                } else {
+                    // 检查该行是否真被 parser 抽出过(任何 analyte),但 key 对不上
+                    // 真值(词典歧义/别名冲突)。
+                    let parsed_here = rows.iter().find(|r| line.contains(&r.raw_name));
+                    if let Some(r) = parsed_here {
+                        b_dict_key_mismatch.hit(
+                            doc,
+                            format!(
+                                "真值名={}(key={}) 数值={} | 抽成 raw_name={} key={:?} 行: {:?}",
+                                it.name, m.key, it.value, r.raw_name, r.analyte_key, line
+                            ),
+                            samples,
+                        );
+                    } else {
+                        b_same_line_other.hit(
+                            doc,
+                            format!("真值名={} 数值={} | 行: {:?}", it.name, it.value, line),
+                            samples,
+                        );
+                    }
+                }
+                continue;
+            }
+
+            // 不同行:找最近距离
+            let min_dist = name_lines
+                .iter()
+                .flat_map(|&ni| value_lines.iter().map(move |&vi| ni.abs_diff(vi)))
+                .min()
+                .unwrap_or(usize::MAX);
+            if min_dist == 1 {
+                // 定位具体是哪一对相邻行,取第一对
+                let pair = name_lines
+                    .iter()
+                    .flat_map(|&ni| value_lines.iter().map(move |&vi| (ni, vi)))
+                    .find(|(ni, vi)| ni.abs_diff(*vi) == 1)
+                    .unwrap();
+                b_wrap_adjacent.hit(
+                    doc,
+                    format!(
+                        "真值名={} 数值={} | 名行[{}]: {:?} 数行[{}]: {:?}",
+                        it.name, it.value, pair.0, lines[pair.0], pair.1, lines[pair.1]
+                    ),
+                    samples,
+                );
+            } else {
+                b_wrap_far.hit(
+                    doc,
+                    format!(
+                        "真值名={} 数值={} 相距{}行 | 名行示例: {:?}",
+                        it.name, it.value, min_dist, lines[name_lines[0]]
+                    ),
+                    samples,
+                );
+            }
+        }
+    }
+
+    println!("# 项目召回失配分类({n_miss}/{n_total} 条未召回,arm2_geo,--out {out})\n");
+    let report = |label: &str, b: &Bucket| {
+        println!(
+            "## {label}: {} 条 ({:.1}%)",
+            b.count,
+            b.count as f64 / n_miss.max(1) as f64 * 100.0
+        );
+        for (doc, ctx) in &b.samples {
+            println!("- [{doc}] {ctx}");
+        }
+        println!();
+    };
+    report("OCR 没读到名字(上游天花板)", &b_name_missing);
+    report("OCR 没读到数值(名字读到了)", &b_value_missing);
+    report("同行:被序号前缀卡住(非 bare-pair)", &b_same_line_serial);
+    report(
+        "同行:这一行已被解析成另一项目(疑似双栏/多项目挤一行)",
+        &b_same_line_multi,
+    );
+    report("同行:词典 key 对不上真值(别名/歧义)", &b_dict_key_mismatch);
+    report("同行:原因待查", &b_same_line_other);
+    report("折行:名与数相邻(距离=1行)", &b_wrap_adjacent);
+    report("名与数都读到但相距 2+ 行", &b_wrap_far);
+
+    Ok(())
+}

--- a/packages/ocr/src/lib.rs
+++ b/packages/ocr/src/lib.rs
@@ -670,10 +670,6 @@ const ORIENT_TALL_RATIO: f32 = 1.3;
 /// sideways (rotated 90°/270°) and try to upright it.
 #[cfg(feature = "engine")]
 const ORIENT_TALL_THRESHOLD: f32 = 0.5;
-/// Minimum in-plane skew (degrees) worth a deskew + re-OCR pass. Below this the
-/// tilt doesn't meaningfully hurt row grouping and isn't worth the resample.
-#[cfg(feature = "engine")]
-const ORIENT_MIN_DESKEW_DEG: f32 = 1.0;
 
 /// Fraction of non-empty lines whose detection box is taller than wide (by
 /// [`ORIENT_TALL_RATIO`]). Near 0 for an upright document (text lines are wide and
@@ -708,6 +704,51 @@ fn mean_line_confidence(lines: &[OcrLine]) -> f32 {
         .filter_map(|l| l.confidence)
         .collect();
     mean_confidence(&confs)
+}
+
+/// How tilted `lines`' own detected-box geometry is, in the same terms
+/// [`rebuild_layout_text`] judges it by: `tilt_drift` is directly comparable
+/// to `LAYOUT_ROW_Y_TOLERANCE_RATIO * median_height`, the bar
+/// `trust_cell_content` uses there. `correction_deg` is the angle
+/// [`deskew`] would need to level it — see
+/// `ocr_box_tilt_correction_deg_cancels_a_real_image_rotation` for why this sign
+/// is right, verified against the actual [`rotate_about_center`] this module
+/// wraps, not just derived on paper.
+///
+/// `None` when there are too few non-empty lines to fit a slope from (same
+/// floor [`find_dual_column_band`] requires for any pattern to be trusted)
+/// or the content span is degenerate.
+#[cfg(feature = "engine")]
+fn measure_ocr_box_tilt(lines: &[OcrLine]) -> Option<(f32, f32, f32)> {
+    let owned: Vec<LayoutLine> = lines
+        .iter()
+        .filter(|l| !l.text.trim().is_empty())
+        .map(|l| LayoutLine {
+            text: String::new(), // geometry only -- content plays no part in the fit
+            left: l.left,
+            top: l.top,
+            right: l.right,
+            height: l.bottom - l.top,
+        })
+        .collect();
+    if owned.len() < DUAL_COLUMN_MIN_SUPPORT_ROWS {
+        return None;
+    }
+    let refs: Vec<&LayoutLine> = owned.iter().collect();
+    let content_left = refs.iter().map(|l| l.left).fold(f32::INFINITY, f32::min);
+    let content_right = refs
+        .iter()
+        .map(|l| l.right)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let content_span = content_right - content_left;
+    let median_height = median_line_height(&refs);
+    if content_span <= 0.0 || median_height <= 0.0 {
+        return None;
+    }
+    let slope = estimate_tilt(&refs, median_height);
+    let tilt_drift = slope.abs() * content_span;
+    let correction_deg = (-slope).atan().to_degrees();
+    Some((tilt_drift, median_height, correction_deg))
 }
 
 /// Decode + preprocess, then recognize with automatic **page-orientation
@@ -754,23 +795,42 @@ fn predict_lines(image_bytes: &[u8]) -> Result<Vec<OcrLine>> {
     }
 
     // 2) Deskew (in-plane tilt). A tilted photo leaves text rows slanted even once
-    //    upright; the detector then merges/mis-groups cells (the "mashed, hard to
-    //    read" layout). If the chosen upright image has a meaningful in-plane skew,
-    //    rotate it flat (reusing the projection-profile [`estimate_skew_deg`] +
-    //    [`deskew`] already used in [`preprocess`]) and re-OCR so rows come back
-    //    horizontal. `preprocess` already deskewed upright inputs, so this only fires
-    //    for pages that were *rotated first* (their skew survives the rotation).
-    //    **Failure-safe**: accept the deskewed result only if it kept ~all its lines
-    //    and didn't make the page look more sideways — otherwise keep the pre-deskew
-    //    result. A bad warp is worse than none.
-    let gray = best_img.to_luma8();
-    if let Some(angle) = estimate_skew_deg(&gray) {
-        if angle.is_finite() && angle.abs() >= ORIENT_MIN_DESKEW_DEG {
-            let deskewed = DynamicImage::ImageLuma8(deskew(&gray, angle));
+    //    upright; row-grouping then either merges cells from neighbouring records
+    //    into one visual row, or — once the tilt is large enough to trip
+    //    `rebuild_layout_text`'s own `trust_cell_content` guard — degrades to
+    //    dropping values rather than risk pairing them wrong. Either way the fix
+    //    belongs here, before that guard ever has to fire: measure the tilt in the
+    //    OCR engine's own detected boxes ([`measure_ocr_box_tilt`]) and, if
+    //    row-grouping would no longer trust this page's geometry, rotate the image
+    //    by the fitted correction and re-OCR so rows come back level.
+    //
+    //    This deliberately does **not** reuse the pixel-intensity projection
+    //    profile ([`estimate_skew_deg`], still used by [`preprocess`] for the
+    //    same purpose) for this decision. On real photographed lab-report tables
+    //    that estimator is unreliable — measured on 40 real MedRepBench photos
+    //    (`improve/skew`'s evidence), it returned exactly 0.0° (claiming a level
+    //    page) on documents whose detected boxes show tilt drift over 200px, and
+    //    on others it saturated at its ±10° search ceiling — a sign it never
+    //    converged, not that the true skew is 10° — sometimes on *both* the
+    //    initial estimate and the re-estimate after applying its own correction.
+    //    It gets dragged off by content that isn't a text baseline (table grid
+    //    lines, stamps, fold creases), which real lab photos are full of.
+    //    [`estimate_tilt`] instead fits the OCR engine's own detected text-line
+    //    boxes, which by construction only exist where the engine already found
+    //    text — immune to the non-text content that misleads the pixel profile.
+    //
+    //    **Failure-safe**: accept the deskewed result only if it kept ~all its
+    //    lines *and* measurably reduced the tilt — otherwise keep the pre-deskew
+    //    result. A bad correction (or one that just trades one tilt for another)
+    //    is worse than none.
+    if let Some((drift, median_height, correction_deg)) = measure_ocr_box_tilt(&best_lines) {
+        if drift > LAYOUT_ROW_Y_TOLERANCE_RATIO * median_height {
+            let gray = best_img.to_luma8();
+            let deskewed = DynamicImage::ImageLuma8(deskew(&gray, correction_deg));
             if let Ok(dl) = predict_lines_core(&deskewed) {
                 let kept_lines = dl.len() * 10 >= best_lines.len() * 8;
-                let not_worse = tall_fraction(&dl) <= tall_fraction(&best_lines) + 0.05;
-                if kept_lines && not_worse {
+                let improved = measure_ocr_box_tilt(&dl).is_none_or(|(d, _, _)| d < drift);
+                if kept_lines && improved {
                     return Ok(dl);
                 }
             }
@@ -2542,6 +2602,112 @@ mod tests {
         assert!(
             residual.abs() <= 1.5,
             "expected small residual skew after deskew, got {residual} (estimated correction was {estimated})"
+        );
+    }
+
+    /// Validates the sign convention `measure_ocr_box_tilt` relies on
+    /// (`correction_deg = (-slope).atan().to_degrees()`) against the actual
+    /// [`rotate_about_center`] this module's [`deskew`] wraps -- not just the
+    /// derivation from its "rotates clockwise" doc comment. Marks four points
+    /// on one horizontal "text line", physically rotates the image by a known
+    /// angle, relocates the marks and fits their slope (the same quantity
+    /// [`estimate_tilt`] fits from real OCR box tops), and checks two things:
+    /// (a) that fitted slope matches `tan(applied angle)` -- confirming
+    /// `estimate_tilt`'s "top = intercept + slope*x" model actually describes
+    /// what a real clockwise image rotation produces, not just the synthetic
+    /// coordinates `estimate_tilt_recovers_known_page_rotation` constructs by
+    /// hand -- and (b) that rotating a second time by the derived
+    /// `correction_deg` brings the marks back level. Getting this sign wrong
+    /// would make `predict_lines`' step-2 redeskew double the tilt instead of
+    /// cancelling it, silently, on every real photo it fires on.
+    #[test]
+    fn ocr_box_tilt_correction_deg_cancels_a_real_image_rotation() {
+        let (w, h) = (400u32, 400u32);
+        let mut img = GrayImage::from_pixel(w, h, Luma([255]));
+        let xs = [80.0f32, 160.0, 240.0, 320.0];
+        let y0 = 200i64;
+        // 5x5 filled squares, not single pixels -- Nearest-neighbour resampling
+        // under a small rotation can step over (never land exactly on) a
+        // 1px mark, losing it entirely; a few-pixel square always has some
+        // pixel survive the resample.
+        for &x in &xs {
+            for dx in -2i64..=2 {
+                for dy in -2i64..=2 {
+                    img.put_pixel((x as i64 + dx) as u32, (y0 + dy) as u32, Luma([0]));
+                }
+            }
+        }
+
+        // Centroid (mean y of dark pixels in the column) of the mark nearest
+        // `x`, robust to the square's exact footprint after resampling.
+        let locate = |im: &GrayImage, x: u32| -> Option<f32> {
+            let lo = x.saturating_sub(3);
+            let hi = (x + 3).min(im.width() - 1);
+            let mut sum = 0f64;
+            let mut n = 0u32;
+            for xx in lo..=hi {
+                for y in 0..im.height() {
+                    if im.get_pixel(xx, y).0[0] < 128 {
+                        sum += y as f64;
+                        n += 1;
+                    }
+                }
+            }
+            (n > 0).then(|| (sum / n as f64) as f32)
+        };
+        // Least-squares dy/dx over the relocated marks -- exactly what
+        // `estimate_tilt` fits from OCR box tops, just computed directly here
+        // so this test doesn't depend on the detection-box grouping machinery.
+        let fit_slope = |pts: &[(f32, f32)]| -> f32 {
+            let mean_x = pts.iter().map(|p| p.0).sum::<f32>() / pts.len() as f32;
+            let mean_y = pts.iter().map(|p| p.1).sum::<f32>() / pts.len() as f32;
+            let num: f32 = pts.iter().map(|&(x, y)| (x - mean_x) * (y - mean_y)).sum();
+            let den: f32 = pts.iter().map(|&(x, _)| (x - mean_x).powi(2)).sum();
+            num / den
+        };
+
+        let theta_deg = 6.0f32;
+        let rotated = rotate_about_center(
+            &img,
+            theta_deg.to_radians(),
+            Interpolation::Nearest,
+            Border::Constant(Luma([255])),
+        );
+        let pts: Vec<(f32, f32)> = xs
+            .iter()
+            .filter_map(|&x| locate(&rotated, x as u32).map(|y| (x, y)))
+            .collect();
+        assert!(
+            pts.len() >= 3,
+            "expected to relocate the rotated marks, got {pts:?}"
+        );
+        let slope = fit_slope(&pts);
+        assert!(
+            (slope - theta_deg.to_radians().tan()).abs() < 0.03,
+            "expected slope ~= tan({theta_deg}deg) = {}, got {slope}",
+            theta_deg.to_radians().tan()
+        );
+
+        let correction_deg = (-slope).atan().to_degrees();
+        let releveled = rotate_about_center(
+            &rotated,
+            correction_deg.to_radians(),
+            Interpolation::Nearest,
+            Border::Constant(Luma([255])),
+        );
+        let pts2: Vec<(f32, f32)> = xs
+            .iter()
+            .filter_map(|&x| locate(&releveled, x as u32).map(|y| (x, y)))
+            .collect();
+        assert!(
+            pts2.len() >= 3,
+            "expected to relocate the releveled marks, got {pts2:?}"
+        );
+        let residual_slope = fit_slope(&pts2);
+        assert!(
+            residual_slope.abs() < 0.03,
+            "expected releveled marks near-flat, got slope {residual_slope} \
+             (correction_deg={correction_deg})"
         );
     }
 

--- a/packages/parser/src/labs.rs
+++ b/packages/parser/src/labs.rs
@@ -250,6 +250,22 @@ fn range_two_re() -> &'static Regex {
         Regex::new(r"(\d+(?:[.,]\d+)?)\s*[-~]+\s*(\d+(?:[.,]\d+)?)").expect("range re")
     })
 }
+/// A whitespace-delimited token that is NOTHING BUT a bounded range (an
+/// optional trailing `%`, nothing else) — anchored start-to-end, unlike
+/// `range_two_re` which matches anywhere. Used to keep `parse_rest_with_residual`'s
+/// unit search from mistaking a SECOND lab entry's own reference range
+/// (`11.00-45.00%`, printed as one token with no internal space) for THIS
+/// entry's unit. Deliberately anchored to the WHOLE token: the CBC
+/// `×10⁹/L`/`×10¹²/L` unit shape (`10~9/L`, `10^12/L`) also starts with a
+/// digit-dash-digit run but is never followed by nothing else — it always has
+/// a trailing `/<letter>` — so it fails this anchored match and stays a valid
+/// unit candidate. See `parse_rest_with_residual`'s unit-token loop.
+fn bare_range_token_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"^\d+(?:[.,]\d+)?[-~]+\d+(?:[.,]\d+)?%?$").expect("bare range token re")
+    })
+}
 fn range_high_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
     R.get_or_init(|| Regex::new(r"[<≤]=?\s*(\d+(?:[.,]\d+)?)").expect("high re"))
@@ -699,11 +715,57 @@ fn find_range(folded: &str) -> Option<RangeMatch> {
     None
 }
 
-/// Parse the trailing `单位 参考范围 [↑/↓]` columns. The reference range is matched
-/// on the whole (punctuation-folded) string first — so a spaced `< 5.20` or
-/// `3.9 - 6.1` parses as one range — then blanked out; unit and flag are read from
-/// what remains, order-independently.
-fn parse_rest(rest: &str) -> (Option<String>, Option<f64>, Option<f64>, Option<String>) {
+/// A whitespace-delimited token together with its byte span in the source
+/// string it was cut from. `str::split_whitespace` alone doesn't expose
+/// positions; `parse_rest_with_residual` needs them to blank out exactly the
+/// tokens it consumed while leaving everything else — including a second
+/// analyte's own name/value, when the line packs two lab entries side by side
+/// (see that function's doc) — untouched.
+fn whitespace_tokens_with_spans(s: &str) -> Vec<(&str, usize, usize)> {
+    let mut out = Vec::new();
+    let mut start: Option<usize> = None;
+    for (i, c) in s.char_indices() {
+        if c.is_whitespace() {
+            if let Some(st) = start.take() {
+                out.push((&s[st..i], st, i));
+            }
+        } else if start.is_none() {
+            start = Some(i);
+        }
+    }
+    if let Some(st) = start {
+        out.push((&s[st..], st, s.len()));
+    }
+    out
+}
+
+/// Parse the trailing `单位 参考范围 [↑/↓]` columns — same job as before this
+/// module could recover a second entry: the reference range is matched on the
+/// whole (punctuation-folded) string first — so a spaced `< 5.20` or
+/// `3.9 - 6.1` parses as one range — then blanked out; unit and flag are read
+/// from what remains, order-independently. PLUS the RESIDUAL text left over
+/// after the range/unit/flag/label-noise tokens actually consumed here are
+/// blanked to spaces (byte-for-byte, so every OTHER token's position is
+/// undisturbed).
+///
+/// The residual exists for exactly one purpose — recovering a SECOND lab entry
+/// packed onto the same physical line as the one just parsed; see
+/// `recover_second_entry`'s doc for the two-column layout that produces this
+/// shape. Blanking only what was ACTUALLY consumed — not every token — is what
+/// keeps that safe: entry 1's own reference range/unit/flag can never be
+/// mistaken for entry 2's name or value (they're gone from the residual), while
+/// a genuine second entry's name/value/unit/range, never touched by entry 1's
+/// parse, comes through completely intact for `parse_line` to read fresh,
+/// gated by exactly the same rules as any other line.
+fn parse_rest_with_residual(
+    rest: &str,
+) -> (
+    Option<String>,
+    Option<f64>,
+    Option<f64>,
+    Option<String>,
+    String,
+) {
     let folded = fold_range_punct(rest);
     // Split a CBC ×10⁹/L or ×10¹²/L unit that OCR glued onto the number before it
     // (see glued_cbc_unit_re doc) before any numeric parsing, so the range regex
@@ -721,9 +783,11 @@ fn parse_rest(rest: &str) -> (Option<String>, Option<f64>, Option<f64>, Option<S
         // Blank the range so its digits can't be re-read as a unit token.
         scan.replace_range(s..e, " ");
     }
+    let mut residual = scan.clone();
 
     let (mut unit, mut flag) = (None, None);
-    for raw in scan.split_whitespace() {
+    let tokens = whitespace_tokens_with_spans(&scan);
+    for (idx, &(raw, start, end)) in tokens.iter().enumerate() {
         let tok =
             raw.trim_matches(|c| matches!(c, '(' | ')' | '（' | '）' | '[' | ']' | '【' | '】'));
         if tok.is_empty() {
@@ -751,26 +815,59 @@ fn parse_rest(rest: &str) -> (Option<String>, Option<f64>, Option<f64>, Option<S
         // their printed range, whenever OCR put spaces around the slash.
         if raw.contains('↑') || matches!(tok, "H" | "Ｈ" | "高" | "偏高") {
             flag = Some("H".to_string());
+            residual.replace_range(start..end, &" ".repeat(end - start));
             continue;
         }
         if raw.contains('↓') || matches!(tok, "L" | "Ｌ" | "低" | "偏低") {
             flag = Some("L".to_string());
+            residual.replace_range(start..end, &" ".repeat(end - start));
             continue;
         }
         // Label noise inside inline `(参考 …)` / `正常范围` etc.
         if tok.contains("参考") || tok.contains("范围") || tok.contains("正常") {
+            residual.replace_range(start..end, &" ".repeat(end - start));
             continue;
         }
-        // First unit-looking token wins (has a letter, %, / or degree sign).
+        // First unit-looking token wins (has a letter, %, / or degree sign) —
+        // UNLESS it's a bare run of 2+ uppercase ASCII letters with a CJK-led
+        // token somewhere after it. That specific shape (`MPV` ahead of
+        // `血小板体积分布宽度`) is a SECOND lab entry's own English abbreviation
+        // column, not this entry's unit — real corpus, two-column report
+        // flattened onto one line (see `recover_second_entry`'s doc). No unit
+        // in `dictionary_entries()` is a bare run of uppercase letters — every
+        // one carries a `/`, `%`, `°`, `μ`/`u`, or a digit (`g/L`, `x10^9/L`,
+        // `mmol/L`, `IU/mL`, `fL`, `pg`, `s`) — so this can only ever withhold
+        // a token that was never going to be a valid unit match anyway; the
+        // CJK-lookahead guard further restricts it to fire only when there's
+        // a plausible second entry to protect, so a genuinely bare uppercase
+        // token at the tail of an ordinary line (nothing after it) is
+        // completely unaffected.
         if unit.is_none()
             && tok
                 .chars()
                 .any(|c| c.is_ascii_alphabetic() || c == '%' || c == '/' || c == '°')
         {
-            unit = Some(tok.to_string());
+            let looks_like_next_entrys_abbreviation = tok.chars().count() >= 2
+                && tok.chars().all(|c| c.is_ascii_uppercase())
+                && tokens[idx + 1..].iter().any(|&(t, _, _)| {
+                    t.chars()
+                        .next()
+                        .is_some_and(|c| ('\u{4e00}'..='\u{9fa5}').contains(&c))
+                });
+            // Same shape of mistake, different token: a SECOND entry's own
+            // reference range printed as one glued token (`11.00-45.00%`,
+            // no internal space) satisfies "has a letter/%/…" just as well as
+            // a real unit does. `bare_range_token_re` tells the two apart —
+            // see that regex's doc for why the CBC `10~9/L` unit shape
+            // survives this check unharmed.
+            let looks_like_a_bare_range = bare_range_token_re().is_match(tok);
+            if !looks_like_next_entrys_abbreviation && !looks_like_a_bare_range {
+                unit = Some(tok.to_string());
+                residual.replace_range(start..end, &" ".repeat(end - start));
+            }
         }
     }
-    (unit, low, high, flag)
+    (unit, low, high, flag, residual)
 }
 
 /// Extract normalized lab observations from a report's text. Unknown analytes
@@ -795,7 +892,7 @@ pub fn extract_labs_with_unreadable(text: &str) -> (Vec<LabObservation>, Vec<Unr
     let lines: Vec<&str> = text.lines().collect();
     let mut i = 0;
     while i < lines.len() {
-        let outcome = parse_line(lines[i]);
+        let (outcome, extra) = parse_line(lines[i]);
         // A line that yielded nothing may be the NAME half of a row whose
         // result columns wrapped onto the next line. Only ever attempted here,
         // i.e. after the line has failed on its own, so joining can never take
@@ -819,10 +916,12 @@ pub fn extract_labs_with_unreadable(text: &str) -> (Vec<LabObservation>, Vec<Unr
                     && complete_wrapped_range(&mut o, lines[i], lines.get(i + 1).copied())
                 {
                     out.push(o);
+                    out.extend(extra);
                     i += 2;
                     continue;
                 }
                 out.push(o);
+                out.extend(extra);
             }
             LineOutcome::Unreadable(u) => unreadable.push(u),
             LineOutcome::Nothing => {}
@@ -950,7 +1049,13 @@ fn merged_wrap_row(name_line: &str, value_line: &str) -> Option<LabObservation> 
         return None;
     }
     let joined = format!("{}  {}", name_line.trim_end(), value_line.trim_start());
-    match parse_line(&joined) {
+    // Any FURTHER entries `parse_line` might recover from the joined line's own
+    // tail are dropped, not threaded through — `is_wrapped_value_line` already
+    // requires `value_line` to be nothing but one result cell's worth of
+    // material, so there is nothing left over for a genuine second entry to
+    // live in; keeping this function's existing `Option<LabObservation>`
+    // contract is simpler than a return type only one caller would ever use.
+    match parse_line(&joined).0 {
         LineOutcome::Row(o) if o.analyte_key.is_some() => Some(o),
         _ => None,
     }
@@ -1033,10 +1138,28 @@ fn is_lab_evidence_token(tok: &str) -> bool {
         .any(|c| c.is_ascii_alphabetic() || c == '%' || c == '/' || c == '°')
 }
 
-/// Parse ONE line into at most one lab row. Split out of
+/// How many lab entries `parse_line` will read off ONE physical line, entry 1
+/// included. Bounds `recover_second_entry`'s recursion (see that function's
+/// doc) -- real corpus tops out at two entries packed onto a line (a
+/// two-column table row PP-OCR flattened into one text line), so this never
+/// gets close to being the limiting factor there; it exists purely so a
+/// pathological line can't recurse without bound.
+const MAX_LINE_ENTRIES: u8 = 4;
+
+/// Parse ONE line into at most one lab row, PLUS any further entries packed
+/// onto the same physical line (see `recover_second_entry`). Split out of
 /// [`extract_labs_with_unreadable`] so a wrapped pair can be re-parsed as a
 /// single joined line through exactly the same rules.
-fn parse_line(raw_line: &str) -> LineOutcome {
+fn parse_line(raw_line: &str) -> (LineOutcome, Vec<LabObservation>) {
+    parse_line_budgeted(raw_line, MAX_LINE_ENTRIES)
+}
+
+/// `parse_line`'s actual implementation, plus the entry budget passed down
+/// through `recover_second_entry`'s recursion. `budget` is "how many entries,
+/// including this one, may still be read starting here" -- the second-entry
+/// recovery only fires while `budget > 1`, so it can never fire from a call
+/// that has none left to spend.
+fn parse_line_budgeted(raw_line: &str, budget: u8) -> (LineOutcome, Vec<LabObservation>) {
     // Un-glue a name directly fused to its value (`含量*26.3`) before
     // row_re ever sees the line — see fix_name_value_glue doc. An
     // ambiguous glue (can't tell where name ends) surfaces the row as
@@ -1049,26 +1172,29 @@ fn parse_line(raw_line: &str) -> LineOutcome {
             &owned_line
         }
         GlueFix::Ambiguous(reason) => {
-            return LineOutcome::Unreadable(UnreadableRow {
-                raw_line: raw_line.to_string(),
-                reason: reason.to_string(),
-            });
+            return (
+                LineOutcome::Unreadable(UnreadableRow {
+                    raw_line: raw_line.to_string(),
+                    reason: reason.to_string(),
+                }),
+                Vec::new(),
+            );
         }
     };
     let Some(caps) = row_re().captures(line) else {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     };
     let name_group = caps.name("name").expect("name group");
     let raw_name = name_group.as_str().trim();
     // Need a real name token — rejects date/number-only lines.
     if raw_name.is_empty() || !raw_name.chars().any(|c| c.is_alphabetic()) {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     }
     // The "value column" (everything from right after the name) is itself a
     // YYYY-MM-DD date — this is a 采集/送检/报告 timestamp row, not a result.
     // See date_value_column_re doc.
     if date_value_column_re().is_match(&line[name_group.end()..]) {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     }
     // A real analyte name has no *sentence* punctuation. This rejects narrative
     // fragments that a mis-routed prose/imaging line would otherwise smuggle in
@@ -1077,7 +1203,7 @@ fn parse_line(raw_line: &str) -> LineOutcome {
         .chars()
         .any(|c| matches!(c, '，' | ',' | '。' | '；' | ';' | '、'))
     {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     }
     // Demographics / specimen headers (`姓名：张建国  性别：男  年龄：58岁
     // 门诊号：20230615-1046`) parse as a lab row because the trailing field is
@@ -1096,14 +1222,14 @@ fn parse_line(raw_line: &str) -> LineOutcome {
     // The result table's own COLUMN LABELS fail the same way once a photo
     // splits the header band across detection boxes — see `TABLE_HEADER`.
     if is_page_furniture(raw_name) {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     }
     // Same number parser as the reference-range bounds — a comma-decimal
     // result (`0,08`) is read whole instead of truncated to its leading digit.
     // See `parse_decimal_token` / `row_re`.
     let Some(value_num) = parse_decimal_token(caps.name("value").expect("value group").as_str())
     else {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     };
     let rest = caps.name("rest").expect("rest group").as_str();
     // Value glued with zero separator straight into another number (its
@@ -1112,12 +1238,15 @@ fn parse_line(raw_line: &str) -> LineOutcome {
     // unreadable rather than report a value we can't actually justify.
     let sep2_is_empty = caps.name("sep2").expect("sep2 group").as_str().is_empty();
     if value_glued_to_next_number(sep2_is_empty, rest) {
-        return LineOutcome::Unreadable(UnreadableRow {
-            raw_line: raw_line.to_string(),
-            reason: REASON_VALUE_GLUED_TO_RANGE.to_string(),
-        });
+        return (
+            LineOutcome::Unreadable(UnreadableRow {
+                raw_line: raw_line.to_string(),
+                reason: REASON_VALUE_GLUED_TO_RANGE.to_string(),
+            }),
+            Vec::new(),
+        );
     }
-    let (unit_raw, ref_low, ref_high, explicit_flag) = parse_rest(rest);
+    let (unit_raw, ref_low, ref_high, explicit_flag, residual) = parse_rest_with_residual(rest);
     // Invariant fallback, NOT the fix itself: a genuine reference range
     // never inverts, so low>high can only mean the range was misread
     // somewhere upstream (range_is_bounded / parse_decimal_token above
@@ -1158,7 +1287,7 @@ fn parse_line(raw_line: &str) -> LineOutcome {
         || explicit_flag.is_some()
         || m.is_some();
     if !has_evidence {
-        return LineOutcome::Nothing;
+        return (LineOutcome::Nothing, Vec::new());
     }
     // The number taken as the result is bound into a reference range — this
     // line has a name and a range but no result of its own (see
@@ -1167,10 +1296,13 @@ fn parse_line(raw_line: &str) -> LineOutcome {
     // same shape and is already thrown away as a non-row, and promoting those
     // to reviewable rows would bury the real ones in noise.
     if value_is_range_low_bound(value_num, rest) {
-        return LineOutcome::Unreadable(UnreadableRow {
-            raw_line: raw_line.to_string(),
-            reason: REASON_NO_RESULT_ONLY_RANGE.to_string(),
-        });
+        return (
+            LineOutcome::Unreadable(UnreadableRow {
+                raw_line: raw_line.to_string(),
+                reason: REASON_NO_RESULT_ONLY_RANGE.to_string(),
+            }),
+            Vec::new(),
+        );
     }
 
     // Canonical conversion (only when matched AND the entry knows this unit).
@@ -1213,23 +1345,96 @@ fn parse_line(raw_line: &str) -> LineOutcome {
         }
     });
 
-    LineOutcome::Row(LabObservation {
-        raw_name: raw_name.to_string(),
-        analyte_key: m.as_ref().map(|m| m.key.clone()),
-        canonical_name: m.as_ref().map(|m| m.canonical_name.clone()),
-        loinc: m.as_ref().and_then(|m| m.codes.loinc.clone()),
-        value_num,
-        value_canonical,
-        unit_raw,
-        unit_canonical,
-        ref_low,
-        ref_high,
-        ref_low_canonical,
-        ref_high_canonical,
-        flag,
-        confidence: m.as_ref().map_or(0.0, |m| m.confidence),
-        self_measured: false,
-    })
+    // A second (or third...) lab entry packed onto this same physical line --
+    // see `recover_second_entry`'s doc. `residual` is `rest` with THIS entry's
+    // own range/unit/flag already blanked out, so it can only contain a
+    // genuine second entry's own material, never a re-read of this one's.
+    let extra = if budget > 1 {
+        recover_second_entry(&residual, budget - 1)
+    } else {
+        Vec::new()
+    };
+
+    (
+        LineOutcome::Row(LabObservation {
+            raw_name: raw_name.to_string(),
+            analyte_key: m.as_ref().map(|m| m.key.clone()),
+            canonical_name: m.as_ref().map(|m| m.canonical_name.clone()),
+            loinc: m.as_ref().and_then(|m| m.codes.loinc.clone()),
+            value_num,
+            value_canonical,
+            unit_raw,
+            unit_canonical,
+            ref_low,
+            ref_high,
+            ref_low_canonical,
+            ref_high_canonical,
+            flag,
+            confidence: m.as_ref().map_or(0.0, |m| m.confidence),
+            self_measured: false,
+        }),
+        extra,
+    )
+}
+
+/// Recover a SECOND (or further) lab entry packed onto the same physical line
+/// as the one `parse_line_budgeted` just read -- the shape a two-column report
+/// produces when PP-OCR's line reconstruction flattens a whole physical table
+/// row (both halves of a 双栏 layout side by side) into one text line:
+/// `entry1 的名/值/单位/参考范围   entry2 的名/值/单位/参考范围`, with nothing
+/// but whitespace between the two entries. Real corpus example (MedRepBench):
+///
+/// ```text
+/// BAS0%  嗜碱细胞比率        0.3   0.0-1.0       MPV  血小板体积分布宽度   15.4   11.00-45.00%
+/// ```
+///
+/// Before this existed, `row_re` matched only the FIRST name/value pair
+/// (`嗜碱细胞比率 0.3`); everything after entry 1's own range was inert text
+/// sitting in `rest`, parsed only for a stray unit/flag/range token and then
+/// discarded -- MPV's `15.4` never became a row at all. The recall diagnostic
+/// (`ocr/examples/medrep_recall_diag.rs`) found several percent of all recall
+/// misses on the real photographed-report corpus fit exactly this shape: name
+/// and value both present in the OCR text, on the SAME line as another entry
+/// that had already consumed the line.
+///
+/// `residual` -- see `parse_rest_with_residual` -- is `rest` with entry 1's OWN
+/// range/unit/flag tokens already blanked to spaces, so entry 1's own
+/// reference range can never masquerade as entry 2's name. Feeding the RAW
+/// (unblanked) `rest` back through the parser instead would glue entry 1's own
+/// range onto entry 2's name (`0.0-1.0    MPV  血小板体积分布宽度`) and, worse,
+/// misread entry 1's range as part of entry 2's own value/name split --
+/// fabricating exactly the kind of cross-entry contamination this module's
+/// module-doc "Wrapped rows" section already warns joins can cause. What's
+/// left in `residual`, if anything, is untouched original text.
+///
+/// Mandatory corroboration, same discipline as `merged_wrap_row`: recurses
+/// through `parse_line_budgeted` -- i.e. through every one of that function's
+/// existing gates (evidence, page-furniture, sentence punctuation, ...) -- and
+/// the result is only accepted when it ALSO resolves to a dictionary analyte.
+/// An unmatched residual is far more likely to be leftover footnote/column
+/// noise than a genuine second entry, and guessing there is exactly the kind
+/// of fabrication "宁可漏,不能编" exists to prevent -- so an unresolved
+/// residual is silently dropped, never surfaced as `Unreadable` (that channel
+/// is for a genuine OCR line a person can go check against the original
+/// document; a synthesized leftover fragment isn't one).
+fn recover_second_entry(residual: &str, budget: u8) -> Vec<LabObservation> {
+    let trimmed = residual.trim();
+    // Cheap pre-filter before running the full line parser: a genuine second
+    // entry needs at least a two-character name -- the same floor
+    // `strip_serial_prefix` uses, for the same reason (anything shorter
+    // resolves far too eagerly against the dictionary's short aliases).
+    if trimmed.chars().filter(|c| c.is_alphabetic()).count() < 2 {
+        return Vec::new();
+    }
+    let (outcome, mut more) = parse_line_budgeted(trimmed, budget);
+    match outcome {
+        LineOutcome::Row(o) if o.analyte_key.is_some() => {
+            let mut out = vec![o];
+            out.append(&mut more);
+            out
+        }
+        _ => Vec::new(),
+    }
 }
 
 #[cfg(test)]
@@ -2423,5 +2628,91 @@ NO             25      umol/L      10-40
                 );
             }
         }
+    }
+
+    /// Real repro (MedRepBench 683-photo corpus, 血常规 CBC panel): a
+    /// two-column table flattened onto one physical text line by PP-OCR's
+    /// layout reconstruction, entry 1's own reference range butting straight
+    /// up against entry 2's English abbreviation with only whitespace between
+    /// them. Before `recover_second_entry` existed, `row_re` matched only the
+    /// FIRST name/value pair; everything from `MPV` onward was inert text
+    /// parsed just for a stray unit/range/flag token and then discarded —
+    /// PDW's `15.4` never became a row at all.
+    #[test]
+    fn second_lab_entry_packed_onto_the_same_line_is_recovered() {
+        let text = "BAS0%  嗜碱细胞比率        0.3   0.0-1.0       MPV  血小板体积分布宽度   15.4   11.00-45.00%  30-90×10^9/\n";
+        let obs = extract_labs(text);
+        let pdw = find(&obs, "pdw");
+        // `raw_name` keeps the `MPV` abbreviation column verbatim (it's part
+        // of the line, not stripped) — the abbreviation-guard test below
+        // covers that it isn't mistaken for entry 1's own unit instead.
+        assert_eq!(pdw.raw_name, "MPV  血小板体积分布宽度");
+        assert_eq!(pdw.value_num, 15.4);
+        assert_eq!(pdw.ref_low, Some(11.0));
+        assert_eq!(pdw.ref_high, Some(45.0));
+        // Entry 1's own range (`0.0-1.0`, the ONLY range that's really its
+        // own) must not have been stolen or contaminated by entry 2's
+        // material — the residual handoff blanks exactly what entry 1
+        // consumed, nothing more.
+        assert!(
+            obs.iter().any(|o| o.raw_name.contains("嗜碱")
+                && o.ref_low == Some(0.0)
+                && o.ref_high == Some(1.0)),
+            "entry 1's own range got lost or corrupted: {obs:?}"
+        );
+    }
+
+    /// The `MPV` immediately ahead of entry 2's CJK name in the fixture above
+    /// must NOT be read as entry 1's own unit — it's the leftmost token of a
+    /// SECOND entry's abbreviation column, not this row's unit cell. Before
+    /// the uppercase-abbreviation guard, entry 1 (`嗜碱细胞比率`) came out
+    /// with `unit_raw = Some("MPV")`, a fabricated field that appears nowhere
+    /// as this row's actual unit in the source document.
+    #[test]
+    fn a_second_entrys_abbreviation_is_not_mistaken_for_this_entrys_unit() {
+        let text = "BAS0%  嗜碱细胞比率        0.3   0.0-1.0       MPV  血小板体积分布宽度   15.4   11.00-45.00%  30-90×10^9/\n";
+        let obs = extract_labs(text);
+        let entry1 = obs
+            .iter()
+            .find(|o| o.raw_name.contains("嗜碱"))
+            .expect("entry 1 must still parse");
+        assert_ne!(
+            entry1.unit_raw.as_deref(),
+            Some("MPV"),
+            "entry 2's abbreviation leaked into entry 1's unit: {entry1:?}"
+        );
+    }
+
+    /// Counter-example / safety net: a second entry is only ever recovered
+    /// when it resolves to a dictionary analyte (same discipline as
+    /// `merged_wrap_row`'s condition 4). An unmatched name in the leftover
+    /// text — indistinguishable, by shape alone, from a genuine second
+    /// entry — must stay dropped, not fabricated into an extra row.
+    #[test]
+    fn an_unresolved_second_entry_candidate_is_not_fabricated() {
+        let text =
+            "肌酐            88      μmol/L      59-104    神秘指标XYZ   12.3   mg/L   0-5\n";
+        let obs = extract_labs(text);
+        assert_eq!(
+            obs.len(),
+            1,
+            "an unmatched leftover was fabricated into a row: {obs:?}"
+        );
+        let cr = find(&obs, "creatinine");
+        assert_eq!(cr.value_num, 88.0);
+        assert_eq!(cr.ref_low, Some(59.0));
+        assert_eq!(cr.ref_high, Some(104.0));
+    }
+
+    /// Counter-example: an ordinary single-entry line with a perfectly normal
+    /// bare-uppercase unit (none in the dictionary, but still plausible raw
+    /// report text) and NOTHING CJK after it must keep reading that token as
+    /// the unit — the abbreviation guard only withholds a bare-uppercase
+    /// token when a CJK-led token follows it later on the line.
+    #[test]
+    fn a_trailing_bare_uppercase_unit_with_nothing_after_it_is_still_read_as_a_unit() {
+        let obs = extract_labs("神秘指标XYZ   12.3   IU   0-5");
+        assert_eq!(obs.len(), 1, "got {obs:?}");
+        assert_eq!(obs[0].unit_raw.as_deref(), Some("IU"));
     }
 }

--- a/packages/parser/src/labs.rs
+++ b/packages/parser/src/labs.rs
@@ -907,18 +907,31 @@ pub fn extract_labs_with_unreadable(text: &str) -> (Vec<LabObservation>, Vec<Unr
         match outcome {
             LineOutcome::Row(mut o) => {
                 // The row parsed cleanly but with NO reference range at all —
-                // try completing it from a range that wrapped onto the next
-                // line (see `complete_wrapped_range`). Only attempted when
-                // `parse_rest` found neither bound, so this can only ADD a
-                // range, never override one already read with confidence.
-                if o.ref_low.is_none()
-                    && o.ref_high.is_none()
-                    && complete_wrapped_range(&mut o, lines[i], lines.get(i + 1).copied())
-                {
-                    out.push(o);
-                    out.extend(extra);
-                    i += 2;
-                    continue;
+                // either try completing it from a range that wrapped onto the
+                // next line, or — if `value` itself turns out to BE that
+                // range's own low bound (see `value_is_range_low_bound_wrapped`)
+                // — refuse the row outright rather than fabricate a range from
+                // it. Only attempted when `parse_rest` found neither bound, so
+                // this can only ADD a range or retract the row, never override
+                // a range already read with confidence.
+                if o.ref_low.is_none() && o.ref_high.is_none() {
+                    if let Some(rest) = rest_after_value(lines[i], o.value_num) {
+                        let next_line = lines.get(i + 1).copied();
+                        if value_is_range_low_bound_wrapped(o.value_num, rest, next_line) {
+                            unreadable.push(UnreadableRow {
+                                raw_line: lines[i].to_string(),
+                                reason: REASON_NO_RESULT_ONLY_RANGE.to_string(),
+                            });
+                            i += 2;
+                            continue;
+                        }
+                        if complete_wrapped_range(&mut o, rest, next_line) {
+                            out.push(o);
+                            out.extend(extra);
+                            i += 2;
+                            continue;
+                        }
+                    }
                 }
                 out.push(o);
                 out.extend(extra);
@@ -934,17 +947,67 @@ pub fn extract_labs_with_unreadable(text: &str) -> (Vec<LabObservation>, Vec<Unr
 /// A reference range's low bound trails a line with a dangling separator
 /// (`0.85-`) and nothing after it — evidence the layout reconstruction wrapped
 /// the line before the high bound could print, not that the range is simply
-/// absent. Read straight off the RAW line (not `rest`): `rest` is just its
-/// trailing substring, so the text at the very end is identical either way.
+/// absent.
+///
+/// Takes `rest` — the text after THIS row's own value column (`row_re`'s
+/// `rest` group), never the full raw line. That distinction is not
+/// cosmetic: an earlier version of this function scanned the raw line on the
+/// reasoning that "`rest` is just its trailing substring, so the text at the
+/// very end is identical either way" — true when a genuinely SEPARATE low
+/// bound sits in `rest` (`血红蛋白浓度 HGB 112 g/L 112-` \n `149`: the second
+/// `112` is `rest`'s own token, distinct from `value`'s), but false the
+/// moment the result cell is blank and there IS no second occurrence: on
+/// `钙 HR/☆ Ca2.31 mmol/L 2.11-` \n `2.52` (real corpus), `row_re` already
+/// misreads the range's own low bound as `value` (`2.31` is glued to `Ca`
+/// with no separator for `row_re` to anchor on, so it's invisible to the
+/// name/value split — see module doc "Name↔value glue"), leaving `rest` as
+/// just `-`. Scanning the raw LINE at that point re-reads `value`'s own
+/// `2.11` a second time and reports it as the range's low bound too —
+/// `value == ref_low` not because a result happens to sit at the reference
+/// floor, but because they are, literally, the same digits read twice.
+/// Scanning `rest` instead can't do this: with nothing between `value` and
+/// the trailing dash, `rest` has no number left for this regex to find, so
+/// it correctly reports "no dangling low bound here" — see
+/// `value_is_range_low_bound_wrapped` for how THAT shape is instead refused
+/// outright rather than silently left un-ranged.
 fn dangling_range_low_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
     R.get_or_init(|| Regex::new(r"(\d+(?:[.,]\d+)?)\s*[-~]+\s*$").expect("dangling range re"))
 }
 
-fn dangling_range_low(line: &str) -> Option<f64> {
-    let folded = fold_range_punct(line.trim_end());
+fn dangling_range_low(rest: &str) -> Option<f64> {
+    let folded = fold_range_punct(rest.trim_end());
     let caps = dangling_range_low_re().captures(&folded)?;
     parse_decimal_token(caps.get(1)?.as_str())
+}
+
+/// `rest`'s wrap-across-lines twin of `value_is_range_low_bound`: the range
+/// operator directly abuts `value` exactly the same way, but the layout
+/// reconstruction wrapped the line before the high bound itself could
+/// print, so `rest` (after the operator) is empty instead of holding it —
+/// `葡萄糖 …  正常值范围：3.90-` \n `6.10` (real corpus: the label even says
+/// "reference range" outright) is `0.03~0.30` one line-break wider. `rest`
+/// reducing to NOTHING but the operator is what tells this apart from a
+/// genuine wrapped range (`complete_wrapped_range`'s shape, where `rest`
+/// still carries a unit or other text before its own dangling low bound):
+/// there, `value` and the low bound are two distinct tokens; here `value`
+/// IS the (misidentified) low bound, and the row has no result of its own
+/// to report. Same next-line safety net as `complete_wrapped_range` — see
+/// that function's doc for why the next line must be nothing but a bare
+/// number before it's trusted to belong to this row at all.
+fn value_is_range_low_bound_wrapped(value_num: f64, rest: &str, next_line: Option<&str>) -> bool {
+    let folded = fold_range_punct(rest.trim());
+    if folded.is_empty() || !folded.chars().all(|c| matches!(c, '-' | '~')) {
+        return false;
+    }
+    let Some(next) = next_line else {
+        return false;
+    };
+    let candidate = next.trim().trim_start_matches(['-', '~']);
+    if !bare_number_re().is_match(candidate) {
+        return false;
+    }
+    parse_decimal_token(candidate).is_some_and(|high| value_num <= high)
 }
 
 /// Complete a reference range whose high bound wrapped onto the next physical
@@ -958,8 +1021,9 @@ fn dangling_range_low(line: &str) -> Option<f64> {
 /// for the same reason (a wrong join fabricates a reference range that
 /// appears nowhere in the document, worse than leaving the row un-ranged):
 ///
-/// 1. **The current line ends in a dangling low bound** (`dangling_range_low`)
-///    — proof this line's range was cut off mid-print, not just absent.
+/// 1. **`rest` ends in a dangling low bound** (`dangling_range_low`) — proof
+///    THIS row's range was cut off mid-print, not just absent, and (see that
+///    function's doc) a bound distinct from `value` itself.
 /// 2. **The next line, trimmed, is nothing but a bare number** — after
 ///    stripping any LEADING `-`/`~` run first, since the doubled-separator
 ///    typo this module already folds elsewhere (`range_two_re`'s `[-~]+` —
@@ -982,8 +1046,8 @@ fn dangling_range_low(line: &str) -> Option<f64> {
 /// `low <= high` is required for the same reason `parse_line`'s own
 /// low>high check exists: a genuine reference range never inverts, so a pair
 /// that doesn't form one isn't a matching pair and the row is left alone.
-fn complete_wrapped_range(row: &mut LabObservation, line: &str, next_line: Option<&str>) -> bool {
-    let Some(low) = dangling_range_low(line) else {
+fn complete_wrapped_range(row: &mut LabObservation, rest: &str, next_line: Option<&str>) -> bool {
+    let Some(low) = dangling_range_low(rest) else {
         return false;
     };
     let Some(next) = next_line else {
@@ -1002,6 +1066,28 @@ fn complete_wrapped_range(row: &mut LabObservation, line: &str, next_line: Optio
     row.ref_low = Some(low);
     row.ref_high = Some(high);
     true
+}
+
+/// Re-locate the text after THIS row's own value column, straight off the
+/// RAW line — used by the outer loop's wrap-completion checks, which run
+/// after `parse_line` has already built (or refused) the row and no longer
+/// exposes `rest`. Mirrors, rather than reuses, `parse_line_budgeted`'s own
+/// `row_re` match: `fix_name_value_glue` (see module doc "Name↔value glue")
+/// only ever touches the name/value boundary near the FRONT of the line, so
+/// re-matching against the untouched raw line reproduces the identical tail
+/// every time. Guarded by comparing the recovered value against `o`'s own —
+/// on the rare line where the glue fix DID change what `row_re` sees, this
+/// returns `None` and the caller simply skips wrap-completion for that row
+/// (a small, deliberate recall cost, not a correctness risk: trusting a
+/// mismatched split back here is exactly how the raw-line scan this replaces
+/// re-read a value's own digits as its range's low bound).
+fn rest_after_value(raw_line: &str, value_num: f64) -> Option<&str> {
+    let caps = row_re().captures(raw_line)?;
+    let v = parse_decimal_token(caps.name("value")?.as_str())?;
+    if v != value_num {
+        return None;
+    }
+    Some(caps.name("rest")?.as_str())
 }
 
 /// What one line of the report turned into.
@@ -1304,6 +1390,47 @@ fn parse_line_budgeted(raw_line: &str, budget: u8) -> (LineOutcome, Vec<LabObser
             Vec::new(),
         );
     }
+    // KNOWN, DELIBERATE GAP — not an oversight, and not fixed here:
+    //
+    // The same fabrication as `value_is_range_low_bound` also happens when
+    // the range's OWN separator (`-`/`~`) is itself lost to OCR — misread as
+    // plain whitespace instead of a dash — rather than missing from the line
+    // entirely: `find_range` above never sees an operator, so `ref_low`/
+    // `ref_high` come back `None` even though the range is still right
+    // there. Real corpus, blanked result cell: `尿酸（急） 208  428 umol/L`
+    // prints the low and high bounds as two bare numbers with nothing but a
+    // gap between them where the dash should be — `value` (208) is really
+    // the range's own low bound, and 428 sits stranded in `residual`.
+    //
+    // A guard shaped like `value_is_range_low_bound` — reject whenever
+    // `residual` (rest with unit/flag/label-noise already blanked; see
+    // `parse_rest_with_residual`) trims down to exactly ONE bare number
+    // `>= value_num` — was tried and reverted: it cannot be told apart from
+    // an entirely different, and more common, corpus shape — a GENUINE
+    // result followed by a range whose separator was lost WITHIN the range
+    // itself, gluing the two bounds into one token instead of leaving a gap
+    // where `value` sits. Real counter-examples, all with `residual` also
+    // trimming to one bare number `>= value`, all with a real, independently
+    // plausible `value`:
+    //   碱性磷酸酶（急） 117  45125 U/L        — 117, ref "45-125" glued whole
+    //   腺苷脱氨酶       14.0  745  U/L        — 14.0, ref "7-45" glued whole
+    //   直接胆红素       12.3  V/L  040        — 12.3, ref "0-40" glued whole
+    //   (CEA)            4.84  5.2             — 4.84, ref "<5.2", `<` dropped
+    //   T4淋巴细胞数(CD4+/CD3+) 24.00 ↓ Cells/ul 40  — explicit ↓ flag already
+    //     proves 24.00 is a real (abnormal) reading, not a fabricated bound
+    // `residual`'s digit shape gives no reliable tell between "428" (a
+    // genuine second bound, 尿酸's case) and "45125"/"745"/"040" (two bounds
+    // already fused) — both are one ungapped run of digits either way. Per
+    // 宁可漏,不能编: shipping the guard traded one confirmed fabrication
+    // shape for a same-sized new one (rejecting genuine results, several
+    // already flagged abnormal), which is a worse outcome, not a better one.
+    // Left un-ranged, exactly as before this change — see the report/PR
+    // description for the full corpus audit. A real fix needs a signal this
+    // module doesn't have: either the OCR/layout stage preserving (or
+    // flagging) a blanked result-cell box, or a dictionary-informed
+    // plausibility check on the candidate bound pair — both out of scope
+    // here (the latter is `packages/terminology`, off limits per the task
+    // that produced this comment).
 
     // Canonical conversion (only when matched AND the entry knows this unit).
     // 值和参考区间的两个界值走**同一行** `UnitConversion`、**同一个**仿射映射:
@@ -2591,6 +2718,55 @@ NO             25      umol/L      10-40
         let t = find(&obs2, "tbil");
         assert_eq!(t.ref_low, Some(5.1));
         assert_eq!(t.ref_high, Some(28.0));
+    }
+
+    #[test]
+    fn wrapped_range_whose_low_bound_is_actually_the_row_s_own_value_is_refused() {
+        // Real MedRepBench corpus (`钙` row, blanked/unreadable result cell):
+        // `row_re` can't see the real result (`Ca2.31` — the digits are glued
+        // straight onto `Ca` with no separator, invisible to the name/value
+        // split; see module doc "Name↔value glue"), so it reads the FIRST
+        // number it CAN split on — the range's own low bound — as `value`.
+        // The high bound then wraps to the next line, and a naive
+        // `line`-based completion (the pre-fix behaviour) re-reads that same
+        // `2.11` a second time off the raw line and reports it as `ref_low`
+        // too: `value == ref_low` not because a result happens to sit at the
+        // reference floor (see `a_genuine_result_followed_by_its_range_is_untouched`
+        // for that legitimate shape), but because they are the same digits
+        // read twice. The row must be refused outright, not kept with a
+        // fabricated range.
+        let text = "\
+钙                        HR/☆ Ca2.31               mmol/L                    2.11-
+2.52
+";
+        let (obs, unreadable) = extract_labs_with_unreadable(text);
+        assert!(
+            !obs.iter()
+                .any(|o| o.analyte_key.as_deref() == Some("calcium")),
+            "value fabricated from the wrapped range's own low bound: {obs:?}"
+        );
+        assert_eq!(unreadable.len(), 1);
+        assert_eq!(unreadable[0].reason, REASON_NO_RESULT_ONLY_RANGE);
+    }
+
+    #[test]
+    fn a_genuine_result_followed_by_its_own_wrapped_range_is_untouched() {
+        // Counter-example for the guard above: a row whose OWN separate value
+        // token sits before a range that happens to wrap — `complete_wrapped_range`
+        // must still complete it, exactly as before this change, because
+        // there IS a second, distinct low-bound token in `rest` (not a reuse
+        // of `value`). Real corpus: `血红蛋白浓度 HGB 112 g/L 112-` \ `149` —
+        // both `112`s are printed separately; the result genuinely sits at
+        // the reference floor.
+        let text = "\
+血红蛋白浓度                              HGB         112         g/L                 112-
+149
+";
+        let obs = extract_labs(text);
+        let h = find(&obs, "hgb");
+        assert_eq!(h.value_num, 112.0);
+        assert_eq!(h.ref_low, Some(112.0));
+        assert_eq!(h.ref_high, Some(149.0));
     }
 
     #[test]


### PR DESCRIPTION
## 缺陷

`extract_labs` 在结果格为空/定性、且参考区间的高位跨行换行时,会把区间自己的
下界报成化验值。真实语料(`钙` 行,MedRepBench):

```
钙                        HR/☆ Ca2.31               mmol/L                    2.11-
2.52
```

真实结果 `2.31` 因为紧贴在 `Ca` 后面(OCR/重建没留分隔符,`row_re` 认不出这个
数字断点——见模块注释「Name↔value glue」)而无法被识别为 value;`row_re` 转而
把它能断开的第一个数字——区间自己的下界 `2.11`——读成了 `value`。换行补全区间
的既有逻辑(`complete_wrapped_range`,经 `dangling_range_low`)当时是在**整行
原文**上重新扫「数字+悬空破折号」,又把这同一个 `2.11` 读了第二遍,报成
`ref_low`。`value == ref_low` 不是"结果恰好压在下限上",是同一串数字被读了
两次。

## 根因

`dangling_range_low` / `complete_wrapped_range` 扫描的是整行原文 `line`,而不
是这一行里**这一条记录自己的** `rest`(`value` 之后的文本)。当 `rest` 里确
实还有第二个、独立的下界 token 时(如 `血红蛋白浓度 HGB 112 g/L 112-` \
`149`——两个 `112` 是分别印刷的,结果恰好压线是真的),扫 `line` 和扫 `rest`
结果一样;但当没有时(`钙` 的情况),`line` 只是因为往回吃到了 `value` 自己
的数字才"找到"一个。

## 修复

- `dangling_range_low` / `complete_wrapped_range` 改为接收 `rest`(经新增
  `rest_after_value` 从原始行重新定位;该函数用恢复出的 value 和行里已有的
  value 自检,不一致时退回"不补全",而不是退回旧的不安全行为)。
- 新增 `value_is_range_low_bound_wrapped`,是既有同行守卫
  `value_is_range_low_bound` 跨行版本:`rest` 里除了一个悬空的 `-`/`~` 什么都
  不剩、且下一行是能与 `value` 组成升序区间的裸数字时,整行拒收
  (`REASON_NO_RESULT_ONLY_RANGE`),不再接受并编出一个区间。

## 诊断过、但撤回的另一半(同行版本)

同一类缺陷还有一个**不跨行**的变体:区间自己的分隔符(`-`/`~`)被 OCR 直接
读丢、变成了纯空格(`尿酸（急） 208  428 umol/L`,没有换行)。写过一版同行守
卫(`rest` 掐头去尾后剩下恰好一个裸数字就拒收),但用真实语料反证后撤回了:

```
碱性磷酸酶（急） 117  45125 U/L        —— 117 是真值,"45-125" 整体粘成一串
腺苷脱氨酶       14.0  745  U/L        —— 14.0 是真值,"7-45" 整体粘成一串
直接/间接胆红素   12.3/8.7 ... 040     —— 真值,"0-40" 整体粘成一串
(CEA)            4.84  5.2             —— 真值,`<5.2` 的 `<` 被吃掉了
T4淋巴细胞数(CD4+/CD3+) 24.00 ↓ ... 40  —— 显式 ↓ 标记已经证明 24.00 是真读数
```

这些和 `尿酸`/`酮体` 的真实语料在文本层面**长得一模一样**("value,后面跟且仅
跟一个裸数字"),没有找到能在文本层面区分"结果为空、后面数字是区间下界"和
"结果真实存在、区间自己的分隔符另外被吃掉"的可靠信号。上线这条守卫会把一类
确诊的伪造换成同等规模的新伪造(拒收一批真实结果,其中几条还带着显式异常箭
头),不符合本模块「宁可漏,不能编」的准则,所以没有上——`尿酸`/`酮体` 这个
具体案例目前**仍未修复**,已经在 `parse_line_budgeted` 里写清楚是已知、刻意
留下的缺口,附带反证语料,供下一个人接着想。

## 判据

每一条被新守卫拒收的行,判据都是**位置性的、可证的**,不是启发式猜测:
`rest_after_value` 拿到的 `rest`(row_re 对这一行的真实切分结果)里,`value`
之后除了一个悬空操作符什么都不剩——即这一行**没有第二个独立的低界 token**,
下一行提供的高界与 `value` 拼出的"区间"因此只能是 `value` 自己被复用的产物。

## 规模审计

用一个临时诊断脚本(未纳入本次改动,已删除)在 683 份 `arm2_geo`(几何重建)
文本上跑了改前/改后逐行 diff:**整个语料库里,新守卫总共只改变了 2 行的判
定**——正是本 PR 描述、逐条核实过的 `钙` 和 `葡萄糖`(后者原文标注就是「正常
值范围：3.90-6.10」,不是结果)。除这 2 行外,输出与改前逐字节相同,包括所有
既有的换行区间补全(HGB、无机磷、总胆红素等)——`rest`/`line` 的切换是一次
纯粹的收窄,不影响任何已验证的既有行为。

## 五个数字(② 几何重建,683 份真实化验单)

| 指标 | 改前 | 改后 |
|---|---|---|
| 项目召回 | 60.4% (1341/2220) | 60.3% (1339/2220) |
| 值-名配对 | 53.5% (1187/2220) | 53.5% (1187/2220) |
| 参考区间归属 | 41.7% (782/1876) | 41.6% (780/1876) |
| **错配率** | **13.0% (177/1363)** | **12.9% (175/1361)** |
| **端到端** | **23.4% (1187/5068)** | **23.4% (1187/5068)** |

错配率按要求下降(177→175);端到端基本持平(实际未变,两个被拒收的行本来就
不是"正确"匹配,分子分母同时减 2 抵消)。规模很小——这条修复精确对应"换行补
全把 value 自己的数字当成区间下界重读一遍"这一个具体机制,不是"值等于下界就
拒收"式的一刀切。

## 还有多少同类假值没拦住

- **同行版本(尿酸/酮体这类)**:未拦,已在代码注释里说明原因和反证语料,见
  上文。这是本次审计确认的、真实存在、但没有安全修法的缺口。
- **`阴离子隙（急）= 51`(用户原始报告里第三个例子)**:核实后发现和"区间下
  界当值"是**不同机制**——原文结果是 `5 ↓`(区间 8—16),`51` 既不等于下界 8
  也不等于上界 16,像是 OCR/几何重建把 `5` 和某处一个 `1` 错误拼接到了一起
  (`packages/ocr` 的几何重建层,不是 `packages/parser` 的解析逻辑)。不在本
  次改动范围内(任务要求只改 `packages/parser`),已诊断但未处理,单独报告。
- 复核过原先"值等于参考下界"的全部 56 行统计样本(683 份语料里,带参考下界
  的 1638 行中):除本 PR 修的 `钙` 外,逐条核实下来**绝大多数都是真实的边界
  巧合**(如尿沉渣 0 计数、pH 5.0、比重 1.010、BUN 2.9 等),不是伪造——这也
  是没有做「值等于下界就拒收」这种一刀切的直接证据。

## 门禁

`cargo fmt --check` / `cargo test --workspace` / `cargo clippy --all-targets -- -D warnings`(根 workspace 与
`apps/mobile_flutter/rust` 两个 workspace 均通过)、`flutter analyze`(无问
题)、`flutter test`(301/301 通过)。新增 2 条回归测试
(`wrapped_range_whose_low_bound_is_actually_the_row_s_own_value_is_refused`
锁定修复,`a_genuine_result_followed_by_its_own_wrapped_range_is_untouched`
锁定 HGB 这类合法边界巧合不受影响)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)